### PR TITLE
fix: ビルド警告の解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
   },
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
+    "allowBuilds": {
+      "msw": true
+    },
     "overrides": {
       "vite": "npm:@voidzero-dev/vite-plus-core@latest",
       "vitest": "npm:@voidzero-dev/vite-plus-test@latest"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "@fontsource-variable/geist";
 import "./style.css";
 import { App } from "./App.tsx";
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/geist";
 
 @theme {
   --color-background: hsl(0, 0%, 8%);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    chunkSizeWarningLimit: 750,
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## 関連 Issue

Closes #19

## 変更内容

- `build.chunkSizeWarningLimit` を設定し、ビルド時の chunk size warning を抑止
- Geist フォントの import を `src/main.tsx` に移し、ビルド時のフォント解決警告を解消
- `pnpm.allowBuilds` に `msw` を追加し、install 時の build script 警告を解消