### PR TITLE
chore: Renovateパッチ更新の自動マージ設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "runtime dependencies"
@@ -52,18 +57,6 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["@types/**"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
-      "matchManagers": ["npm"],
-      "matchPackageNames": [
-        "@playwright/test",
-        "@testing-library/**",
-        "@vitest/coverage-v8",
-        "jsdom",
-        "msw"
-      ],
-      "matchUpdateTypes": ["patch"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## 関連 Issue


## 変更内容

- Renovate の `npm` 管理対象について、`patch` 更新を自動マージする共通ルールを追加
- 既存のテスト依存向け `patch` 自動マージルールを削除し、重複を解消
- `@types/**` の `minor` / `patch` 自動マージ設定は維持
