### PR TITLE
fix: シリーズ複数シーズン追加時の sort_order 衝突修正

### DIFF
--- a/src/features/backlog/backlog-item-utils.test.ts
+++ b/src/features/backlog/backlog-item-utils.test.ts
@@ -4,6 +4,7 @@ import {
   buildDetailFieldUpdate,
   buildMoveToStatusConfirmMessage,
   getNextSortOrder,
+  getTopSortOrder,
   getSortOrderForDrop,
   getSortOrderForStatusChange,
   normalizeBacklogItems,
@@ -84,6 +85,25 @@ describe("getNextSortOrder", () => {
 
     expect(getNextSortOrder(items, "stacked")).toBe(3000);
     expect(getNextSortOrder(items, "watching")).toBe(1000);
+  });
+});
+
+describe("getTopSortOrder", () => {
+  test("空列なら 1000 を返す", () => {
+    expect(getTopSortOrder([], "stacked")).toBe(1000);
+    expect(getTopSortOrder([], "stacked", 3)).toBe(1000);
+  });
+
+  test("1件挿入では最小 sort_order の 1000 前を返す", () => {
+    const items = [createItem("a", "stacked", 1000), createItem("b", "stacked", 2000)];
+    expect(getTopSortOrder(items, "stacked")).toBe(0);
+  });
+
+  test("複数件挿入では count 分手前から開始することで衝突を防ぐ", () => {
+    const items = [createItem("a", "stacked", 1000), createItem("b", "stacked", 2000)];
+    // 3件追加: 開始 sort_order は 1000 - 3*1000 = -2000
+    // → -2000, -1000, 0 が割り当てられ、既存の 1000, 2000 と衝突しない
+    expect(getTopSortOrder(items, "stacked", 3)).toBe(-2000);
   });
 });
 

--- a/src/features/backlog/backlog-item-utils.ts
+++ b/src/features/backlog/backlog-item-utils.ts
@@ -28,10 +28,10 @@ export function getNextSortOrder(items: BacklogItem[], status: BacklogStatus) {
   return currentMax + 1000;
 }
 
-export function getTopSortOrder(items: BacklogItem[], status: BacklogStatus): number {
+export function getTopSortOrder(items: BacklogItem[], status: BacklogStatus, count = 1): number {
   const statusItems = items.filter((item) => item.status === status);
   if (statusItems.length === 0) return 1000;
-  return Math.min(...statusItems.map((item) => item.sort_order)) - 1000;
+  return Math.min(...statusItems.map((item) => item.sort_order)) - count * 1000;
 }
 
 type BacklogUpsertAction = { type: "insert"; workId: string } | { type: "move"; item: BacklogItem };

--- a/src/features/backlog/backlog-repository.test.ts
+++ b/src/features/backlog/backlog-repository.test.ts
@@ -216,18 +216,18 @@ describe("upsertBacklogItemsToStatus", () => {
         work_id: "work-move",
         primary_platform: null,
         note: null,
+        sort_order: 1000,
+      },
+      {
+        work_id: "work-new",
+        primary_platform: "netflix",
+        note: "新規メモ",
         sort_order: 2000,
       },
       {
         work_id: "work-top",
         primary_platform: null,
         note: null,
-        sort_order: 3000,
-      },
-      {
-        work_id: "work-new",
-        primary_platform: "netflix",
-        note: "新規メモ",
         sort_order: 3000,
       },
     ]);

--- a/src/features/backlog/backlog-repository.ts
+++ b/src/features/backlog/backlog-repository.ts
@@ -60,7 +60,7 @@ export async function upsertBacklogItemsToStatus(
     return { error: null };
   }
 
-  let sortOrder = getTopSortOrder(items, targetStatus);
+  let sortOrder = getTopSortOrder(items, targetStatus, plan.actions.length);
   const rows = plan.actions.map((action) => {
     const row =
       action.type === "move"


### PR DESCRIPTION
## 関連 Issue

Closes #56

## 変更内容

- `getTopSortOrder` に `count` パラメータを追加し、複数アイテムを追加する際に追加件数分のスロットを事前確保するよう変更
- `upsertBacklogItemsToStatus` で `plan.actions.length` を渡し、全アイテムの sort_order が既存最小値より前に収まることを保証
- `getTopSortOrder` のユニットテストを追加（空列・1件・複数件の各ケース）
- `backlog-repository.test.ts` の期待値を修正後の正しい順序に更新（バグのある挙動を期待していた箇所）