### PR TITLE
fix: useBacklogActionsテストのWorkSummary型不整合の修正

### DIFF
--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -264,10 +264,6 @@ describe("useBacklogActions", () => {
         items={[
           createItem({
             status: "watching",
-            works: {
-              ...createItem().works!,
-              id: "work-1",
-            },
           }),
         ]}
         results={[createSearchResult(), createSearchResult({ tmdbId: 2, title: "作品2" })]}

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -265,7 +265,7 @@ describe("useBacklogActions", () => {
           createItem({
             status: "watching",
             works: {
-              ...createItem().works,
+              ...createItem().works!,
               id: "work-1",
             },
           }),


### PR DESCRIPTION
## 関連 Issue

Refs #87

## 変更内容

- `useBacklogActions.test.tsx` で `works: { ...createItem().works, id: "work-1" }` のスプレッドが TypeScript に `title?: string | undefined` と推論され、`WorkSummary.title: string` と型不整合になっていた
- `createItem()` のデフォルト `works.id` はすでに `"work-1"` のため、冗長なスプレッドを削除して修正
- デプロイ時の `pnpm run build` (型チェック込み) が通るようになる