### PR TITLE
fix: Supabase Functions の verify_jwt を false に設定

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -54,3 +54,21 @@ content_path = "./supabase/templates/recovery.html"
 [auth.email.template.email_change]
 subject = "みるカン - メールアドレス変更の確認"
 content_path = "./supabase/templates/email_change.html"
+
+[functions.search-tmdb-works]
+verify_jwt = false
+
+[functions.fetch-tmdb-trending]
+verify_jwt = false
+
+[functions.fetch-tmdb-similar]
+verify_jwt = false
+
+[functions.fetch-tmdb-season-options]
+verify_jwt = false
+
+[functions.fetch-tmdb-work-details]
+verify_jwt = false
+
+[functions.fetch-omdb-work-details]
+verify_jwt = false


### PR DESCRIPTION
## 関連 Issue

<!-- なし -->

## 変更内容

- `supabase/config.toml` に全 Edge Functions の `verify_jwt = false` を追加

### 背景

#93 の自動デプロイ整備（`supabase functions deploy`）により、以前は手動で `--no-verify-jwt` 付きでデプロイされていた関数が JWT 検証有効の状態で再デプロイされた。結果、本番環境でのみ `Invalid JWT` エラーが発生するようになった。

対象の全関数（`search-tmdb-works` / `fetch-tmdb-trending` / `fetch-tmdb-similar` / `fetch-tmdb-season-options` / `fetch-tmdb-work-details` / `fetch-omdb-work-details`）は TMDB/OMDb への API プロキシであり、ユーザーデータへのアクセスなし。`verify_jwt = false` が正しい設定。