### PR TITLE
fix: DnD の操作性改善（先頭・末尾への配置、インジケーター刷新）

### DIFF
--- a/src/features/backlog/components/BacklogCard.tsx
+++ b/src/features/backlog/components/BacklogCard.tsx
@@ -71,19 +71,6 @@ export function BacklogCard({
   const cardDropIndicator =
     dropIndicator?.type === "card" && dropIndicator.itemId === item.id ? dropIndicator : null;
 
-  const dropStyle: React.CSSProperties | undefined =
-    cardDropIndicator?.side === "before"
-      ? {
-          borderTop: "3px solid var(--primary)",
-          boxShadow: "inset 0 8px 0 -5px rgba(191,90,54,0.18)",
-        }
-      : cardDropIndicator?.side === "after"
-        ? {
-            borderBottom: "3px solid var(--primary)",
-            boxShadow: "inset 0 -8px 0 -5px rgba(191,90,54,0.18)",
-          }
-        : undefined;
-
   return (
     <article
       ref={(node) => {
@@ -91,10 +78,7 @@ export function BacklogCard({
         setDropRef(node);
       }}
       className="relative grid w-full min-w-0 cursor-grab gap-[10px] rounded-[18px] border border-[rgba(92,59,35,0.08)] bg-[var(--surface-strong)] pt-[18px] pr-11 pb-4 pl-4 transition-[opacity,box-shadow,border-color] duration-[140ms] ease-[ease] active:cursor-grabbing hover:border-primary/[0.18] hover:shadow-[0_14px_32px_rgba(75,48,30,0.08)] focus-visible:outline-2 focus-visible:outline-primary/45 focus-visible:border-primary/[0.18] focus-visible:shadow-[0_14px_32px_rgba(75,48,30,0.08)]"
-      style={{
-        ...dropStyle,
-        opacity: isDragging ? 0.4 : 1,
-      }}
+      style={{ opacity: isDragging ? 0.4 : 1 }}
       data-card-id={item.id}
       data-card-status={item.status}
       onClick={onOpenDetail}
@@ -107,6 +91,26 @@ export function BacklogCard({
       {...listeners}
       {...attributes}
     >
+      {cardDropIndicator?.side === "before" && (
+        <div
+          aria-hidden
+          className="animate-in fade-in duration-100 pointer-events-none absolute inset-x-0 flex items-center gap-1.5 px-1"
+          style={{ top: "-5px" }}
+        >
+          <div className="h-[6px] w-[6px] shrink-0 rounded-full bg-primary" />
+          <div className="h-[2px] flex-1 rounded-full bg-primary" />
+        </div>
+      )}
+      {cardDropIndicator?.side === "after" && (
+        <div
+          aria-hidden
+          className="animate-in fade-in duration-100 pointer-events-none absolute inset-x-0 flex items-center gap-1.5 px-1"
+          style={{ bottom: "-5px" }}
+        >
+          <div className="h-[6px] w-[6px] shrink-0 rounded-full bg-primary" />
+          <div className="h-[2px] flex-1 rounded-full bg-primary" />
+        </div>
+      )}
       <div className="absolute top-[10px] right-[10px]">
         <DropdownMenu>
           <DropdownMenuTrigger

--- a/src/features/backlog/components/BoardPage.test.tsx
+++ b/src/features/backlog/components/BoardPage.test.tsx
@@ -25,6 +25,7 @@ setupTestLifecycle();
 vi.mock("@dnd-kit/core", () => ({
   DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DragOverlay: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  pointerWithin: () => [],
 }));
 
 vi.mock("../../../lib/supabase.ts", () => ({

--- a/src/features/backlog/components/BoardPage.tsx
+++ b/src/features/backlog/components/BoardPage.tsx
@@ -1,5 +1,5 @@
 import type { Session } from "@supabase/supabase-js";
-import { DndContext, DragOverlay } from "@dnd-kit/core";
+import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
 import { Button } from "@/components/ui/button.tsx";
 import { supabase } from "../../../lib/supabase.ts";
 import { useBoardPageController } from "../hooks/useBoardPageController.ts";
@@ -53,6 +53,7 @@ export function BoardPage({ session }: Props) {
 
       <DndContext
         sensors={dnd.sensors}
+        collisionDetection={pointerWithin}
         onDragStart={dnd.handleDragStart}
         onDragOver={dnd.handleDragOver}
         onDragEnd={(e) => void dnd.handleDragEnd(e)}

--- a/src/features/backlog/components/DraggedBacklogCardOverlay.tsx
+++ b/src/features/backlog/components/DraggedBacklogCardOverlay.tsx
@@ -10,8 +10,8 @@ export function DraggedBacklogCardOverlay({ item }: Props) {
   }
 
   return (
-    <div className="opacity-60">
-      <div className="grid gap-[10px] pt-[18px] pr-11 pb-4 pl-4 rounded-[18px] bg-[var(--surface-strong)] border border-[rgba(92,59,35,0.08)] cursor-grabbing pointer-events-none">
+    <div className="rotate-[1.5deg] scale-[1.04] opacity-90 shadow-[0_24px_48px_rgba(0,0,0,0.28)] rounded-[18px]">
+      <div className="grid gap-[10px] pt-[18px] pr-11 pb-4 pl-4 rounded-[18px] bg-[var(--surface-strong)] border border-primary/20 cursor-grabbing pointer-events-none">
         <div className="grid grid-cols-[64px_minmax(0,1fr)] gap-3 items-start">
           <div className="relative aspect-[2/3] overflow-hidden rounded-[14px] border border-[rgba(92,59,35,0.08)]">
             {item.works.poster_path && (

--- a/src/features/backlog/components/KanbanColumn.tsx
+++ b/src/features/backlog/components/KanbanColumn.tsx
@@ -1,9 +1,17 @@
 import type { ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
+import type { BacklogStatus } from "../types.ts";
 import type { KanbanColumnProps } from "./kanban-board-shared.ts";
+import type { DropIndicator } from "./kanban-board-shared.ts";
 import { BacklogCard } from "./BacklogCard.tsx";
 import { KanbanColumnHeader } from "./KanbanColumnHeader.tsx";
 import { ViewingModeFilter } from "./ViewingModeFilter.tsx";
+
+function TopSlot({ status }: { status: BacklogStatus }) {
+  const { setNodeRef } = useDroppable({ id: `top-slot:${status}` });
+  return <div ref={setNodeRef} className="h-2" />;
+}
+
 type Props = KanbanColumnProps & {
   extra?: ReactNode;
 };
@@ -33,6 +41,12 @@ export function KanbanColumn({
       }
     : undefined;
 
+  const firstItemId = items[0]?.id;
+  const effectiveDropIndicator: DropIndicator | null =
+    dropIndicator?.type === "top-slot" && dropIndicator.status === status && firstItemId
+      ? { type: "card", itemId: firstItemId, side: "before" }
+      : dropIndicator;
+
   return (
     <section
       className="flex h-full min-h-0 w-full min-w-0 flex-col rounded-[24px] border border-[var(--border)] bg-[var(--surface)] py-[14px] shadow-[var(--shadow)] backdrop-blur-[20px] max-[500px]:rounded-[18px] max-[500px]:py-3 max-[400px]:rounded-[14px] max-[400px]:py-2"
@@ -58,13 +72,14 @@ export function KanbanColumn({
               onViewingModeToggle={onViewingModeToggle}
             />
           ) : null}
+          <TopSlot status={status} />
           {items.length > 0 ? (
             items.map((item) => (
               <BacklogCard
                 key={item.id}
                 item={item}
                 showModeBadge={status === "stacked"}
-                dropIndicator={dropIndicator}
+                dropIndicator={effectiveDropIndicator}
                 onOpenDetail={() => onOpenDetail(item.id)}
                 onDeleteItem={onDeleteItem}
                 onMarkAsWatched={onMarkAsWatched}

--- a/src/features/backlog/components/KanbanColumn.tsx
+++ b/src/features/backlog/components/KanbanColumn.tsx
@@ -9,7 +9,7 @@ import { ViewingModeFilter } from "./ViewingModeFilter.tsx";
 
 function TopSlot({ status }: { status: BacklogStatus }) {
   const { setNodeRef } = useDroppable({ id: `top-slot:${status}` });
-  return <div ref={setNodeRef} className="h-2" />;
+  return <div ref={setNodeRef} className="h-6" />;
 }
 
 type Props = KanbanColumnProps & {
@@ -30,7 +30,8 @@ export function KanbanColumn({
   onViewingModeToggle,
 }: Props) {
   const { setNodeRef } = useDroppable({ id: `column:${status}` });
-  const isColumnActive = dropIndicator?.type === "column" && dropIndicator.status === status;
+  const isColumnActive =
+    dropIndicator?.type === "column" && dropIndicator.status === status && items.length === 0;
 
   const dropzoneStyle: React.CSSProperties | undefined = isColumnActive
     ? {

--- a/src/features/backlog/components/KanbanColumn.tsx
+++ b/src/features/backlog/components/KanbanColumn.tsx
@@ -12,6 +12,11 @@ function TopSlot({ status }: { status: BacklogStatus }) {
   return <div ref={setNodeRef} className="h-6" />;
 }
 
+function BottomSlot({ status }: { status: BacklogStatus }) {
+  const { setNodeRef } = useDroppable({ id: `bottom-slot:${status}` });
+  return <div ref={setNodeRef} className="h-6" />;
+}
+
 type Props = KanbanColumnProps & {
   extra?: ReactNode;
 };
@@ -43,10 +48,13 @@ export function KanbanColumn({
     : undefined;
 
   const firstItemId = items[0]?.id;
+  const lastItemId = items.at(-1)?.id;
   const effectiveDropIndicator: DropIndicator | null =
     dropIndicator?.type === "top-slot" && dropIndicator.status === status && firstItemId
       ? { type: "card", itemId: firstItemId, side: "before" }
-      : dropIndicator;
+      : dropIndicator?.type === "bottom-slot" && dropIndicator.status === status && lastItemId
+        ? { type: "card", itemId: lastItemId, side: "after" }
+        : dropIndicator;
 
   return (
     <section
@@ -75,17 +83,20 @@ export function KanbanColumn({
           ) : null}
           <TopSlot status={status} />
           {items.length > 0 ? (
-            items.map((item) => (
-              <BacklogCard
-                key={item.id}
-                item={item}
-                showModeBadge={status === "stacked"}
-                dropIndicator={effectiveDropIndicator}
-                onOpenDetail={() => onOpenDetail(item.id)}
-                onDeleteItem={onDeleteItem}
-                onMarkAsWatched={onMarkAsWatched}
-              />
-            ))
+            <>
+              {items.map((item) => (
+                <BacklogCard
+                  key={item.id}
+                  item={item}
+                  showModeBadge={status === "stacked"}
+                  dropIndicator={effectiveDropIndicator}
+                  onOpenDetail={() => onOpenDetail(item.id)}
+                  onDeleteItem={onDeleteItem}
+                  onMarkAsWatched={onMarkAsWatched}
+                />
+              ))}
+              <BottomSlot status={status} />
+            </>
           ) : (
             <p className="text-[var(--text-muted)] pt-[18px] text-[0.92rem]">
               この列にはまだカードがありません。

--- a/src/features/backlog/components/kanban-board-shared.ts
+++ b/src/features/backlog/components/kanban-board-shared.ts
@@ -3,7 +3,8 @@ import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
 
 export type DropIndicator =
   | { type: "card"; itemId: string; side: "before" | "after" }
-  | { type: "column"; status: BacklogStatus };
+  | { type: "column"; status: BacklogStatus }
+  | { type: "top-slot"; status: BacklogStatus };
 
 export type KanbanColumnProps = {
   status: BacklogStatus;

--- a/src/features/backlog/components/kanban-board-shared.ts
+++ b/src/features/backlog/components/kanban-board-shared.ts
@@ -4,7 +4,8 @@ import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
 export type DropIndicator =
   | { type: "card"; itemId: string; side: "before" | "after" }
   | { type: "column"; status: BacklogStatus }
-  | { type: "top-slot"; status: BacklogStatus };
+  | { type: "top-slot"; status: BacklogStatus }
+  | { type: "bottom-slot"; status: BacklogStatus };
 
 export type KanbanColumnProps = {
   status: BacklogStatus;

--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -178,6 +178,13 @@ describe("getDropIndicator", () => {
       side: "before",
     });
   });
+
+  test("top-slot ターゲットには top-slot インジケーターを返す", () => {
+    expect(getDropIndicator("top-slot:stacked", { top: 100, height: 80 }, 140)).toEqual({
+      type: "top-slot",
+      status: "stacked",
+    });
+  });
 });
 
 describe("resolveDropTarget", () => {
@@ -210,6 +217,46 @@ describe("resolveDropTarget", () => {
 
   test("returns null when the over item does not exist", () => {
     expect(resolveDropTarget(items, "missing", { top: 0, height: 100 }, 20)).toBeNull();
+  });
+
+  test("アイテムのある列への column ドロップは null を返す", () => {
+    const watchingItems: BacklogItem[] = [
+      {
+        id: "item-2",
+        status: "watching",
+        primary_platform: null,
+        note: null,
+        sort_order: 100,
+        works: null,
+      },
+    ];
+    expect(
+      resolveDropTarget(watchingItems, "column:watching", { top: 0, height: 100 }, 50),
+    ).toBeNull();
+  });
+
+  test("空列への column ドロップは先頭挿入を返す", () => {
+    expect(resolveDropTarget(items, "column:stacked", { top: 0, height: 100 }, 50)).toEqual({
+      status: "stacked",
+      targetItemId: null,
+      side: "after",
+    });
+  });
+
+  test("top-slot ドロップは先頭アイテムの before を返す", () => {
+    expect(resolveDropTarget(items, "top-slot:watching", { top: 0, height: 100 }, 50)).toEqual({
+      status: "watching",
+      targetItemId: "item-1",
+      side: "before",
+    });
+  });
+
+  test("空列への top-slot ドロップは先頭挿入を返す", () => {
+    expect(resolveDropTarget(items, "top-slot:stacked", { top: 0, height: 100 }, 50)).toEqual({
+      status: "stacked",
+      targetItemId: null,
+      side: "after",
+    });
   });
 });
 

--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -185,6 +185,13 @@ describe("getDropIndicator", () => {
       status: "stacked",
     });
   });
+
+  test("bottom-slot ターゲットには bottom-slot インジケーターを返す", () => {
+    expect(getDropIndicator("bottom-slot:stacked", { top: 100, height: 80 }, 140)).toEqual({
+      type: "bottom-slot",
+      status: "stacked",
+    });
+  });
 });
 
 describe("resolveDropTarget", () => {
@@ -254,6 +261,14 @@ describe("resolveDropTarget", () => {
   test("空列への top-slot ドロップは先頭挿入を返す", () => {
     expect(resolveDropTarget(items, "top-slot:stacked", { top: 0, height: 100 }, 50)).toEqual({
       status: "stacked",
+      targetItemId: null,
+      side: "after",
+    });
+  });
+
+  test("bottom-slot ドロップは末尾挿入を返す", () => {
+    expect(resolveDropTarget(items, "bottom-slot:watching", { top: 0, height: 100 }, 50)).toEqual({
+      status: "watching",
       targetItemId: null,
       side: "after",
     });

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -97,6 +97,13 @@ export function getDropIndicator(overId: string, rect: RectLike, clientY: number
     };
   }
 
+  if (overId.startsWith("top-slot:")) {
+    return {
+      type: "top-slot",
+      status: overId.replace("top-slot:", "") as BacklogStatus,
+    };
+  }
+
   return {
     type: "card",
     itemId: overId,
@@ -110,12 +117,22 @@ export function resolveDropTarget(
   rect: RectLike,
   clientY: number,
 ): ResolvedDropTarget | null {
+  if (overId.startsWith("top-slot:")) {
+    const status = overId.replace("top-slot:", "") as BacklogStatus;
+    const columnItems = items
+      .filter((item) => item.status === status)
+      .sort((a, b) => a.sort_order - b.sort_order);
+    if (columnItems.length > 0) {
+      return { status, targetItemId: columnItems[0].id, side: "before" };
+    }
+    return { status, targetItemId: null, side: "after" };
+  }
+
   if (overId.startsWith("column:")) {
-    return {
-      status: overId.replace("column:", "") as BacklogStatus,
-      targetItemId: null,
-      side: "after",
-    };
+    const status = overId.replace("column:", "") as BacklogStatus;
+    const hasItems = items.some((item) => item.status === status);
+    if (hasItems) return null;
+    return { status, targetItemId: null, side: "after" };
   }
 
   const targetItem = items.find((item) => item.id === overId);

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -104,6 +104,13 @@ export function getDropIndicator(overId: string, rect: RectLike, clientY: number
     };
   }
 
+  if (overId.startsWith("bottom-slot:")) {
+    return {
+      type: "bottom-slot",
+      status: overId.replace("bottom-slot:", "") as BacklogStatus,
+    };
+  }
+
   return {
     type: "card",
     itemId: overId,
@@ -125,6 +132,11 @@ export function resolveDropTarget(
     if (columnItems.length > 0) {
       return { status, targetItemId: columnItems[0].id, side: "before" };
     }
+    return { status, targetItemId: null, side: "after" };
+  }
+
+  if (overId.startsWith("bottom-slot:")) {
+    const status = overId.replace("bottom-slot:", "") as BacklogStatus;
     return { status, targetItemId: null, side: "after" };
   }
 

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -135,6 +135,44 @@ describe("useBacklogDnd", () => {
     expect(onAfterDrop).not.toHaveBeenCalled();
   });
 
+  test("非空列の column エリアへのドロップは supabase を呼ばない", async () => {
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+    const rect = makeRect(100, 200);
+
+    await act(async () => {
+      await result.current.handleDragEnd({
+        active: { id: "item-1" },
+        over: { id: "column:stacked", rect },
+        activatorEvent: null,
+      } as unknown as DragEndEvent);
+    });
+
+    expect(supabaseMocks.update).not.toHaveBeenCalled();
+    expect(onAfterDrop).not.toHaveBeenCalled();
+  });
+
+  test("top-slot へのドロップは先頭アイテムの前に挿入する", async () => {
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+    const rect = makeRect(100, 8);
+
+    await act(async () => {
+      await result.current.handleDragEnd({
+        active: { id: "item-2" },
+        over: { id: "top-slot:stacked", rect },
+        activatorEvent: null,
+      } as unknown as DragEndEvent);
+    });
+
+    expect(supabaseMocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "stacked" }),
+    );
+    expect(onAfterDrop).toHaveBeenCalledTimes(1);
+  });
+
   test("モバイルレイアウトでは列間ドラッグをブロックする", async () => {
     const crossColumnItems = [
       createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -60,7 +60,8 @@ export type DetailModalState = {
 export type DropIndicator =
   | { type: "card"; itemId: string; side: "before" | "after" }
   | { type: "column"; status: BacklogStatus }
-  | { type: "top-slot"; status: BacklogStatus };
+  | { type: "top-slot"; status: BacklogStatus }
+  | { type: "bottom-slot"; status: BacklogStatus };
 
 export type ResolvedDropTarget = {
   status: BacklogStatus;

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -59,7 +59,8 @@ export type DetailModalState = {
 
 export type DropIndicator =
   | { type: "card"; itemId: string; side: "before" | "after" }
-  | { type: "column"; status: BacklogStatus };
+  | { type: "column"; status: BacklogStatus }
+  | { type: "top-slot"; status: BacklogStatus };
 
 export type ResolvedDropTarget = {
   status: BacklogStatus;


### PR DESCRIPTION
## 関連 Issue

Closes #100

## 変更内容

- ドロップ失敗時（カード・スロット以外の場所に離した場合）に元の位置へ戻るよう修正
- `pointerWithin` collision detection に切り替え（小さい droppable が優先される）
- 各列の先頭に `TopSlot`（24px）を追加し、先頭への配置を可能に
- 各列の末尾に `BottomSlot`（24px）を追加し、末尾への配置を可能に
- ドロップインジケーターをカードの border 強調から、カード間に出る挿入ライン（●───）に変更（`animate-in fade-in`）
- 非空列での column 背景ドロップは無効化（空列のみ dashed outline 表示）
- `DraggedBacklogCardOverlay` を傾き・スケール・影付きの浮いた見た目に変更