### PR TITLE
ci: deploy-functions の Node.js 24 へのオプトイン

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
 


### PR DESCRIPTION
## 関連 Issue

<!-- 関連 Issue があれば Refs #123 または Closes #123 の形式で記載 -->

## 変更内容

- `deploy-functions.yml` の `deploy` ジョブに `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を追加
- `supabase/setup-cli@v1.6.0` が Node.js 20 で動作しており、2026-06-02 以降に強制移行される前に Node.js 24 へオプトイン
- `ci.yml` にはすでに同変数が設定されており、`deploy-functions.yml` のみ未設定だったため追加