### PR TITLE
refactor: useBacklogItems の失敗耐性改善

### DIFF
--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import * as backlogRepository from "../backlog-repository.ts";
+import type { BacklogItem } from "../types.ts";
+import { useBacklogItems } from "./useBacklogItems.ts";
+
+vi.mock("../backlog-repository.ts");
+
+const mockFetchBacklogItems = vi.mocked(backlogRepository.fetchBacklogItems);
+
+const stubItem: BacklogItem = {
+  id: "item-1",
+  status: "stacked",
+  primary_platform: null,
+  note: null,
+  sort_order: 1000,
+  works: null,
+};
+
+describe("useBacklogItems", () => {
+  test("正常取得時はデータを返し isLoading が false になる", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
+
+    const { result } = renderHook(() => useBacklogItems());
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items).toEqual([stubItem]);
+    expect(result.current.error).toBeNull();
+  });
+
+  test("repository がエラーを返した場合は error がセットされ isLoading が false になる", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [], error: "fetch failed" });
+
+    const { result } = renderHook(() => useBacklogItems());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.error).toBe("fetch failed");
+  });
+
+  test("repository が throw した場合も isLoading が false になりエラーがセットされる", async () => {
+    mockFetchBacklogItems.mockRejectedValue(new Error("network error"));
+
+    const { result } = renderHook(() => useBacklogItems());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("network error");
+    expect(result.current.items).toEqual([]);
+  });
+
+  test("loadItems の再呼び出しで isLoading が true に戻る", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [], error: null });
+
+    const { result } = renderHook(() => useBacklogItems());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let resolveNext!: () => void;
+    mockFetchBacklogItems.mockReturnValue(
+      new Promise((resolve) => {
+        resolveNext = () => resolve({ data: [], error: null });
+      }),
+    );
+
+    void result.current.loadItems();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    resolveNext();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+});

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -8,10 +8,16 @@ export function useBacklogItems() {
   const [error, setError] = useState<string | null>(null);
 
   const loadItems = useCallback(async () => {
-    const result = await fetchBacklogItems();
-    setItems(result.data);
-    setError(result.error);
-    setIsLoading(false);
+    setIsLoading(true);
+    try {
+      const result = await fetchBacklogItems();
+      setItems(result.data);
+      setError(result.error);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "不明なエラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 関連 Issue

Closes #116

## 変更内容

- `loadItems` の先頭で `setIsLoading(true)` を呼ぶようにした
  - 再呼び出し時にローディング状態がリセットされない問題を修正
- `try/catch/finally` を導入し、`fetchBacklogItems` が throw した場合も `isLoading` を必ず `false` に戻してエラーをセット
  - 従来は `{ data, error }` を返す前提のみで組まれており、throw ベースの処理が混入した際に `isLoading` が `true` のまま残るリスクがあった
- 上記挙動を検証するテスト（4ケース）を新規追加