### PR TITLE
refactor: Supabase 直叩き箇所の repository 層への集約

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,16 +6,12 @@ const authState = vi.hoisted(() => ({
   callback: null as ((event: string, session: unknown) => void) | null,
 }));
 
-const supabaseMock = vi.hoisted(() => ({
-  auth: {
-    getSession: vi.fn(),
-    onAuthStateChange: vi.fn(),
-  },
+const authRepositoryMock = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  onAuthStateChange: vi.fn(),
 }));
 
-vi.mock("./lib/supabase.ts", () => ({
-  supabase: supabaseMock,
-}));
+vi.mock("./lib/auth-repository.ts", () => authRepositoryMock);
 
 vi.mock("./features/backlog/components/LoginPage.tsx", () => ({
   LoginPage: ({ isSessionLoading = false }: { isSessionLoading?: boolean }) => (
@@ -47,8 +43,8 @@ describe("App", () => {
     authState.callback = null;
     window.history.replaceState({}, "", "/");
 
-    supabaseMock.auth.getSession.mockResolvedValue({ data: { session: null } });
-    supabaseMock.auth.onAuthStateChange.mockImplementation(
+    authRepositoryMock.getSession.mockResolvedValue({ data: { session: null } });
+    authRepositoryMock.onAuthStateChange.mockImplementation(
       (callback: (event: string, session: unknown) => void) => {
         authState.callback = callback;
 
@@ -64,7 +60,7 @@ describe("App", () => {
   });
 
   test("recovery リンク経由でセッションが復元されたら再設定画面を優先する", async () => {
-    supabaseMock.auth.getSession.mockResolvedValue({
+    authRepositoryMock.getSession.mockResolvedValue({
       data: { session: { user: { id: "user-1" } } },
     });
     window.history.replaceState({}, "", "/#type=recovery&access_token=token");
@@ -98,7 +94,7 @@ describe("App", () => {
   });
 
   test("パスワード更新後は recovery パラメータを消して backlog 画面へ戻す", async () => {
-    supabaseMock.auth.getSession.mockResolvedValue({
+    authRepositoryMock.getSession.mockResolvedValue({
       data: { session: { user: { id: "user-1" } } },
     });
     window.history.replaceState({}, "", "/?type=recovery");
@@ -116,7 +112,7 @@ describe("App", () => {
 
   test("getSession が失敗してもローディング状態で止まらずログイン画面に戻る", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    supabaseMock.auth.getSession.mockRejectedValueOnce(new Error("network error"));
+    authRepositoryMock.getSession.mockRejectedValueOnce(new Error("network error"));
 
     render(<App />);
 
@@ -133,7 +129,7 @@ describe("App", () => {
     render(<App />);
 
     expect(screen.getByText("PRIVACY_POLICY_PAGE")).toBeInTheDocument();
-    expect(supabaseMock.auth.getSession).not.toHaveBeenCalled();
+    expect(authRepositoryMock.getSession).not.toHaveBeenCalled();
   });
 
   test("/terms では認証処理を通さず利用規約を表示する", () => {
@@ -142,6 +138,6 @@ describe("App", () => {
     render(<App />);
 
     expect(screen.getByText("TERMS_OF_SERVICE_PAGE")).toBeInTheDocument();
-    expect(supabaseMock.auth.getSession).not.toHaveBeenCalled();
+    expect(authRepositoryMock.getSession).not.toHaveBeenCalled();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
-import { supabase } from "./lib/supabase.ts";
+import { getSession, onAuthStateChange } from "./lib/auth-repository.ts";
 import { LoginPage } from "./features/backlog/components/LoginPage.tsx";
 import { BoardPage } from "./features/backlog/components/BoardPage.tsx";
 import { ResetPasswordPage } from "./features/backlog/components/ResetPasswordPage.tsx";
@@ -64,8 +64,7 @@ function AuthenticatedApp() {
   );
 
   useEffect(() => {
-    void supabase.auth
-      .getSession()
+    void getSession()
       .then(({ data }) => {
         setSession(data.session);
       })
@@ -76,7 +75,7 @@ function AuthenticatedApp() {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    } = onAuthStateChange((event, session) => {
       if (event === "PASSWORD_RECOVERY") {
         setIsPasswordRecovery(true);
       } else if (event === "USER_UPDATED") {

--- a/src/features/backlog/backlog-repository.ts
+++ b/src/features/backlog/backlog-repository.ts
@@ -30,6 +30,16 @@ export async function fetchBacklogItems(): Promise<{
   };
 }
 
+export async function deleteBacklogItem(itemId: string): Promise<{ error: string | null }> {
+  const { error } = await supabase.from("backlog_items").delete().eq("id", itemId);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { error: null };
+}
+
 export async function updateBacklogItem(
   itemId: string,
   update: BacklogItemUpdate,

--- a/src/features/backlog/components/BoardPage.test.tsx
+++ b/src/features/backlog/components/BoardPage.test.tsx
@@ -28,12 +28,8 @@ vi.mock("@dnd-kit/core", () => ({
   pointerWithin: () => [],
 }));
 
-vi.mock("../../../lib/supabase.ts", () => ({
-  supabase: {
-    auth: {
-      signOut: hookMocks.signOut,
-    },
-  },
+vi.mock("../../../lib/auth-repository.ts", () => ({
+  signOut: hookMocks.signOut,
 }));
 
 vi.mock("../hooks/useWindowSize.ts", () => ({

--- a/src/features/backlog/components/BoardPage.tsx
+++ b/src/features/backlog/components/BoardPage.tsx
@@ -1,7 +1,7 @@
 import type { Session } from "@supabase/supabase-js";
 import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
 import { Button } from "@/components/ui/button.tsx";
-import { supabase } from "../../../lib/supabase.ts";
+import { signOut } from "../../../lib/auth-repository.ts";
 import { useBoardPageController } from "../hooks/useBoardPageController.ts";
 import { Header } from "./Header.tsx";
 import { KanbanBoard } from "./KanbanBoard.tsx";
@@ -38,7 +38,7 @@ export function BoardPage({ session }: Props) {
             variant="outline"
             className="rounded-full"
             type="button"
-            onClick={() => void supabase.auth.signOut()}
+            onClick={() => void signOut()}
           >
             ログアウト
           </Button>

--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -3,18 +3,14 @@ import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import { getAuthRedirectUrl, LoginPage } from "./LoginPage.tsx";
 
-const supabaseMock = vi.hoisted(() => ({
-  auth: {
-    signInWithPassword: vi.fn(),
-    signUp: vi.fn(),
-    resetPasswordForEmail: vi.fn(),
-    signInWithOAuth: vi.fn(),
-  },
+const authRepositoryMock = vi.hoisted(() => ({
+  signInWithPassword: vi.fn(),
+  signUp: vi.fn(),
+  resetPasswordForEmail: vi.fn(),
+  signInWithOAuth: vi.fn(),
 }));
 
-vi.mock("../../../lib/supabase.ts", () => ({
-  supabase: supabaseMock,
-}));
+vi.mock("../../../lib/auth-repository.ts", () => authRepositoryMock);
 
 setupTestLifecycle();
 
@@ -22,13 +18,13 @@ describe("LoginPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.history.replaceState({}, "", "/");
-    supabaseMock.auth.signInWithPassword.mockResolvedValue({ error: null });
-    supabaseMock.auth.signUp.mockResolvedValue({
+    authRepositoryMock.signInWithPassword.mockResolvedValue({ error: null });
+    authRepositoryMock.signUp.mockResolvedValue({
       data: { session: null, user: { id: "user-1" } },
       error: null,
     });
-    supabaseMock.auth.resetPasswordForEmail.mockResolvedValue({ error: null });
-    supabaseMock.auth.signInWithOAuth.mockResolvedValue({ error: null });
+    authRepositoryMock.resetPasswordForEmail.mockResolvedValue({ error: null });
+    authRepositoryMock.signInWithOAuth.mockResolvedValue({ error: null });
   });
 
   test("ブランドロゴと説明を表示する", () => {
@@ -91,7 +87,7 @@ describe("LoginPage", () => {
     const user = userEvent.setup();
     let resolveSignIn: ((value: { error: null }) => void) | undefined;
 
-    supabaseMock.auth.signInWithPassword.mockImplementation(
+    authRepositoryMock.signInWithPassword.mockImplementation(
       () =>
         new Promise<{ error: null }>((resolve) => {
           resolveSignIn = resolve;
@@ -120,7 +116,7 @@ describe("LoginPage", () => {
   test("認証失敗時はエラーメッセージを表示して再入力できる", async () => {
     const user = userEvent.setup();
 
-    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+    authRepositoryMock.signInWithPassword.mockResolvedValue({
       error: { message: "Invalid login credentials" },
     });
 
@@ -141,7 +137,7 @@ describe("LoginPage", () => {
   test("確認メール未完了の認証失敗は案内付き文言を表示する", async () => {
     const user = userEvent.setup();
 
-    supabaseMock.auth.signInWithPassword.mockResolvedValue({
+    authRepositoryMock.signInWithPassword.mockResolvedValue({
       error: { message: "Email not confirmed" },
     });
 
@@ -169,12 +165,8 @@ describe("LoginPage", () => {
     await user.type(screen.getByLabelText("確認用パスワード"), "password456");
     await user.click(screen.getByRole("button", { name: "確認メールを送信して登録" }));
 
-    expect(supabaseMock.auth.signUp).toHaveBeenCalledWith({
-      email: "new-user@example.com",
-      password: "password456",
-      options: {
-        emailRedirectTo: window.location.origin,
-      },
+    expect(authRepositoryMock.signUp).toHaveBeenCalledWith("new-user@example.com", "password456", {
+      emailRedirectTo: window.location.origin,
     });
     expect(await screen.findByText("確認メールを送信しました")).toBeInTheDocument();
     expect(
@@ -216,7 +208,7 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: "確認メールを送信して登録" }));
 
     expect(await screen.findByText("確認用パスワードが一致しません。")).toBeInTheDocument();
-    expect(supabaseMock.auth.signUp).not.toHaveBeenCalled();
+    expect(authRepositoryMock.signUp).not.toHaveBeenCalled();
   });
 
   test("ログイン画面からパスワードを忘れた場合の画面に遷移できる", async () => {
@@ -240,7 +232,7 @@ describe("LoginPage", () => {
     await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
     await user.click(screen.getByRole("button", { name: "リセットメールを送信" }));
 
-    expect(supabaseMock.auth.resetPasswordForEmail).toHaveBeenCalledWith("akari@example.com", {
+    expect(authRepositoryMock.resetPasswordForEmail).toHaveBeenCalledWith("akari@example.com", {
       redirectTo: window.location.origin,
     });
     expect(await screen.findByText("リセットメールを送信しました")).toBeInTheDocument();
@@ -289,7 +281,7 @@ describe("LoginPage", () => {
   test("redirect URL 不一致の失敗は設定起因の文言を表示する", async () => {
     const user = userEvent.setup();
 
-    supabaseMock.auth.resetPasswordForEmail.mockResolvedValue({
+    authRepositoryMock.resetPasswordForEmail.mockResolvedValue({
       error: { message: "Redirect URL not allowed" },
     });
 
@@ -343,18 +335,15 @@ describe("LoginPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Googleでログイン" }));
 
-    expect(supabaseMock.auth.signInWithOAuth).toHaveBeenCalledWith({
-      provider: "google",
-      options: {
-        redirectTo: window.location.origin,
-      },
+    expect(authRepositoryMock.signInWithOAuth).toHaveBeenCalledWith({
+      redirectTo: window.location.origin,
     });
   });
 
   test("Google ログイン失敗時はエラーメッセージを表示する", async () => {
     const user = userEvent.setup();
 
-    supabaseMock.auth.signInWithOAuth.mockResolvedValue({
+    authRepositoryMock.signInWithOAuth.mockResolvedValue({
       error: { message: "OAuth error" },
     });
 

--- a/src/features/backlog/components/ResetPasswordPage.test.tsx
+++ b/src/features/backlog/components/ResetPasswordPage.test.tsx
@@ -3,22 +3,18 @@ import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import { ResetPasswordPage } from "./ResetPasswordPage.tsx";
 
-const supabaseMock = vi.hoisted(() => ({
-  auth: {
-    updateUser: vi.fn(),
-  },
+const authRepositoryMock = vi.hoisted(() => ({
+  updateUserPassword: vi.fn(),
 }));
 
-vi.mock("../../../lib/supabase.ts", () => ({
-  supabase: supabaseMock,
-}));
+vi.mock("../../../lib/auth-repository.ts", () => authRepositoryMock);
 
 setupTestLifecycle();
 
 describe("ResetPasswordPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    supabaseMock.auth.updateUser.mockResolvedValue({ error: null });
+    authRepositoryMock.updateUserPassword.mockResolvedValue({ error: null });
   });
 
   test("新しいパスワードと確認用パスワードのフォームを表示する", () => {
@@ -39,7 +35,7 @@ describe("ResetPasswordPage", () => {
     await user.type(screen.getByLabelText("確認用パスワード"), "newpassword123");
     await user.click(screen.getByRole("button", { name: "パスワードを更新する" }));
 
-    expect(supabaseMock.auth.updateUser).toHaveBeenCalledWith({ password: "newpassword123" });
+    expect(authRepositoryMock.updateUserPassword).toHaveBeenCalledWith("newpassword123");
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "パスワードを更新する" })).toBeEnabled(),
@@ -56,13 +52,13 @@ describe("ResetPasswordPage", () => {
     await user.click(screen.getByRole("button", { name: "パスワードを更新する" }));
 
     expect(await screen.findByText("確認用パスワードが一致しません。")).toBeInTheDocument();
-    expect(supabaseMock.auth.updateUser).not.toHaveBeenCalled();
+    expect(authRepositoryMock.updateUserPassword).not.toHaveBeenCalled();
   });
 
   test("更新失敗時はエラーメッセージを表示する", async () => {
     const user = userEvent.setup();
 
-    supabaseMock.auth.updateUser.mockResolvedValue({
+    authRepositoryMock.updateUserPassword.mockResolvedValue({
       error: { message: "Password should be at least 6 characters" },
     });
 
@@ -82,7 +78,7 @@ describe("ResetPasswordPage", () => {
     const user = userEvent.setup();
     let resolveUpdate: ((value: { error: null }) => void) | undefined;
 
-    supabaseMock.auth.updateUser.mockImplementation(
+    authRepositoryMock.updateUserPassword.mockImplementation(
       () =>
         new Promise<{ error: null }>((resolve) => {
           resolveUpdate = resolve;

--- a/src/features/backlog/components/ResetPasswordPage.tsx
+++ b/src/features/backlog/components/ResetPasswordPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
-import { supabase } from "../../../lib/supabase.ts";
+import { updateUserPassword } from "../../../lib/auth-repository.ts";
 import { AuthScreen } from "./AuthScreen.tsx";
 
 export function ResetPasswordPage() {
@@ -22,7 +22,7 @@ export function ResetPasswordPage() {
 
     setIsSubmitting(true);
 
-    const { error } = await supabase.auth.updateUser({ password });
+    const { error } = await updateUserPassword(password);
 
     if (error) {
       setErrorMessage("パスワードの更新に失敗しました。再度お試しください。");

--- a/src/features/backlog/components/UserMenu.test.tsx
+++ b/src/features/backlog/components/UserMenu.test.tsx
@@ -3,15 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import { UserMenu } from "./UserMenu.tsx";
 
-const supabaseMock = vi.hoisted(() => ({
-  auth: {
-    signOut: vi.fn(),
-  },
+const authRepositoryMock = vi.hoisted(() => ({
+  signOut: vi.fn(),
 }));
 
-vi.mock("../../../lib/supabase.ts", () => ({
-  supabase: supabaseMock,
-}));
+vi.mock("../../../lib/auth-repository.ts", () => authRepositoryMock);
 
 setupTestLifecycle();
 
@@ -20,7 +16,7 @@ describe("UserMenu", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    supabaseMock.auth.signOut.mockResolvedValue({ error: null });
+    authRepositoryMock.signOut.mockResolvedValue({ error: null });
     vi.stubGlobal("open", openMock);
   });
 

--- a/src/features/backlog/components/UserMenu.tsx
+++ b/src/features/backlog/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
-import { supabase } from "../../../lib/supabase.ts";
+import { signOut } from "../../../lib/auth-repository.ts";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -62,7 +62,7 @@ export function UserMenu({ email }: Props) {
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              void supabase.auth.signOut();
+              void signOut();
             }}
           >
             ログアウト

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -6,41 +6,22 @@ import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import type { BacklogItem } from "../types.ts";
 import { useBacklogActions } from "./useBacklogActions.ts";
 
-const supabaseMocks = vi.hoisted(() => {
-  const deleteEq = vi.fn();
-  const deleteMock = vi.fn(() => ({ eq: deleteEq }));
-  const updateEq = vi.fn();
-  const updateMock = vi.fn(() => ({ eq: updateEq }));
-
-  return {
-    deleteEq,
-    deleteMock,
-    updateEq,
-    updateMock,
-  };
-});
-
 const repositoryMocks = vi.hoisted(() => {
   return {
-    upsertTmdbWork: vi.fn(),
+    deleteBacklogItem: vi.fn(),
+    updateBacklogItem: vi.fn(),
     upsertBacklogItemsToStatus: vi.fn(),
+    upsertTmdbWork: vi.fn(),
   };
 });
-
-vi.mock("../../../lib/supabase.ts", () => ({
-  supabase: {
-    from: () => ({
-      delete: supabaseMocks.deleteMock,
-      update: supabaseMocks.updateMock,
-    }),
-  },
-}));
 
 vi.mock("../work-repository.ts", () => ({
   upsertTmdbWork: repositoryMocks.upsertTmdbWork,
 }));
 
 vi.mock("../backlog-repository.ts", () => ({
+  deleteBacklogItem: repositoryMocks.deleteBacklogItem,
+  updateBacklogItem: repositoryMocks.updateBacklogItem,
   upsertBacklogItemsToStatus: repositoryMocks.upsertBacklogItemsToStatus,
 }));
 
@@ -142,10 +123,8 @@ function HookHarness({
 
 describe("useBacklogActions", () => {
   beforeEach(() => {
-    supabaseMocks.deleteEq.mockResolvedValue({ error: null });
-    supabaseMocks.deleteMock.mockClear();
-    supabaseMocks.updateEq.mockResolvedValue({ error: null });
-    supabaseMocks.updateMock.mockClear();
+    repositoryMocks.deleteBacklogItem.mockResolvedValue({ error: null });
+    repositoryMocks.updateBacklogItem.mockResolvedValue({ error: null });
     repositoryMocks.upsertTmdbWork.mockResolvedValue({ data: { id: "work-1" }, error: null });
     repositoryMocks.upsertBacklogItemsToStatus.mockResolvedValue({ error: null });
   });
@@ -161,8 +140,8 @@ describe("useBacklogActions", () => {
     };
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onItemDeleted = vi.fn();
-    supabaseMocks.deleteEq.mockResolvedValueOnce({
-      error: { message: "row not found" },
+    repositoryMocks.deleteBacklogItem.mockResolvedValueOnce({
+      error: "row not found",
     });
 
     const user = userEvent.setup();

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -1,12 +1,15 @@
 import type { Session } from "@supabase/supabase-js";
-import { supabase } from "../../../lib/supabase.ts";
 import type { TmdbSearchResult } from "../../../lib/tmdb.ts";
 import {
   buildMoveToStatusConfirmMessage,
   getTopSortOrder,
   planBacklogItemUpserts,
 } from "../backlog-item-utils.ts";
-import { upsertBacklogItemsToStatus } from "../backlog-repository.ts";
+import {
+  deleteBacklogItem,
+  updateBacklogItem,
+  upsertBacklogItemsToStatus,
+} from "../backlog-repository.ts";
 import { upsertTmdbWork } from "../work-repository.ts";
 import type { BacklogItem } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
@@ -37,10 +40,10 @@ export function useBacklogActions({
   feedback = browserBacklogFeedback,
 }: Props) {
   const handleDeleteItem = async (itemId: string) => {
-    const { error: deleteError } = await supabase.from("backlog_items").delete().eq("id", itemId);
+    const { error: deleteError } = await deleteBacklogItem(itemId);
 
     if (deleteError) {
-      await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError.message}`));
+      await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError}`));
       return;
     }
 
@@ -51,13 +54,13 @@ export function useBacklogActions({
   const handleMarkAsWatched = async (itemId: string) => {
     const sortOrder = getTopSortOrder(items, "watched");
 
-    const { error: updateError } = await supabase
-      .from("backlog_items")
-      .update({ status: "watched", sort_order: sortOrder })
-      .eq("id", itemId);
+    const { error: updateError } = await updateBacklogItem(itemId, {
+      status: "watched",
+      sort_order: sortOrder,
+    });
 
     if (updateError) {
-      await Promise.resolve(feedback.alert(`変更に失敗しました: ${updateError.message}`));
+      await Promise.resolve(feedback.alert(`変更に失敗しました: ${updateError}`));
       return;
     }
 

--- a/src/features/backlog/hooks/useLoginPageAuth.ts
+++ b/src/features/backlog/hooks/useLoginPageAuth.ts
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { supabase } from "../../../lib/supabase.ts";
+import {
+  resetPasswordForEmail,
+  signInWithOAuth,
+  signInWithPassword,
+  signUp,
+} from "../../../lib/auth-repository.ts";
 
 type AuthMode = "login" | "signUp" | "forgotPassword";
 
@@ -120,12 +125,8 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
     }
 
     if (isSignUpMode) {
-      const { data, error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          emailRedirectTo: authRedirectUrl,
-        },
+      const { data, error } = await signUp(email, password, {
+        emailRedirectTo: authRedirectUrl,
       });
 
       if (error) {
@@ -139,7 +140,7 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
       return;
     }
 
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { error } = await signInWithPassword(email, password);
 
     if (error) {
       setErrorMessage(getLoginErrorMessage(error.message));
@@ -147,7 +148,7 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
   };
 
   const submitForgotPassword = async () => {
-    const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
+    const { error } = await resetPasswordForEmail(resetEmail, {
       redirectTo: authRedirectUrl,
     });
 
@@ -180,11 +181,8 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
     setIsSubmitting(true);
 
     try {
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: authRedirectUrl,
-        },
+      const { error } = await signInWithOAuth({
+        redirectTo: authRedirectUrl,
       });
 
       if (error) {

--- a/src/lib/auth-repository.ts
+++ b/src/lib/auth-repository.ts
@@ -1,0 +1,36 @@
+import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
+import { supabase } from "./supabase.ts";
+
+export function getSession() {
+  return supabase.auth.getSession();
+}
+
+export function onAuthStateChange(
+  callback: (event: AuthChangeEvent, session: Session | null) => void,
+) {
+  return supabase.auth.onAuthStateChange(callback);
+}
+
+export function signOut() {
+  return supabase.auth.signOut();
+}
+
+export function signInWithPassword(email: string, password: string) {
+  return supabase.auth.signInWithPassword({ email, password });
+}
+
+export function signUp(email: string, password: string, options: { emailRedirectTo?: string }) {
+  return supabase.auth.signUp({ email, password, options });
+}
+
+export function resetPasswordForEmail(email: string, options: { redirectTo?: string }) {
+  return supabase.auth.resetPasswordForEmail(email, options);
+}
+
+export function signInWithOAuth(options: { redirectTo?: string }) {
+  return supabase.auth.signInWithOAuth({ provider: "google", options });
+}
+
+export function updateUserPassword(password: string) {
+  return supabase.auth.updateUser({ password });
+}


### PR DESCRIPTION
## 関連 Issue

Closes #114

## 変更内容

- `src/lib/auth-repository.ts` を新設し、`supabase.auth.*` の全操作をラップ
  - `getSession` / `onAuthStateChange` / `signOut` / `signInWithPassword` / `signUp` / `resetPasswordForEmail` / `signInWithOAuth` / `updateUserPassword`
- `backlog-repository.ts` に `deleteBacklogItem` を追加
- `useBacklogActions.ts` の `backlog_items` 直叩き（`delete` / `update`）を `deleteBacklogItem` / `updateBacklogItem` 経由に変更し `supabase` import を削除
- `useLoginPageAuth.ts` / `ResetPasswordPage.tsx` / `UserMenu.tsx` / `BoardPage.tsx` / `App.tsx` の `supabase.auth.*` 呼び出しを `auth-repository` 経由に変更
- 各テストの mock 対象を `supabase` から `auth-repository` / `backlog-repository` へ移行