### PR TITLE
refactor: ボード描画まわりの再計算抑制

### DIFF
--- a/src/features/backlog/components/KanbanBoard.tsx
+++ b/src/features/backlog/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
 import { statusOrder } from "../constants.ts";
 import { sortStackedItemsByViewingMode } from "../viewing-mode.ts";
@@ -34,34 +34,63 @@ export function KanbanBoard({
   columnRef,
 }: Props) {
   const [activeViewingMode, setActiveViewingMode] = useState<ViewingMode | null>(null);
-  const grouped = new Map<BacklogStatus, BacklogItem[]>(statusOrder.map((status) => [status, []]));
+  const handleViewingModeToggle = useCallback((mode: ViewingMode) => {
+    setActiveViewingMode((current) => (current === mode ? null : mode));
+  }, []);
 
-  for (const item of items) {
-    grouped.get(item.status)?.push(item);
-  }
+  const grouped = useMemo(() => {
+    const nextGrouped = new Map<BacklogStatus, BacklogItem[]>(
+      statusOrder.map((status) => [status, []]),
+    );
 
-  grouped.set(
-    "stacked",
-    sortStackedItemsByViewingMode(grouped.get("stacked") ?? [], activeViewingMode),
+    for (const item of items) {
+      nextGrouped.get(item.status)?.push(item);
+    }
+
+    nextGrouped.set(
+      "stacked",
+      sortStackedItemsByViewingMode(nextGrouped.get("stacked") ?? [], activeViewingMode),
+    );
+
+    return nextGrouped;
+  }, [items, activeViewingMode]);
+
+  const columnPropsByStatus = useMemo(
+    () =>
+      new Map(
+        statusOrder.map((status) => [
+          status,
+          {
+            status,
+            items: grouped.get(status) ?? [],
+            activeViewingMode: status === "stacked" ? activeViewingMode : null,
+            isMobileLayout,
+            dropIndicator,
+            onOpenAddModal,
+            onOpenDetail,
+            onDeleteItem,
+            onMarkAsWatched,
+            onViewingModeToggle: status === "stacked" ? handleViewingModeToggle : undefined,
+          },
+        ]),
+      ),
+    [
+      activeViewingMode,
+      dropIndicator,
+      grouped,
+      handleViewingModeToggle,
+      isMobileLayout,
+      onDeleteItem,
+      onMarkAsWatched,
+      onOpenAddModal,
+      onOpenDetail,
+    ],
   );
 
-  const getColumnProps = (status: BacklogStatus) => ({
-    status,
-    items: grouped.get(status) ?? [],
-    activeViewingMode: status === "stacked" ? activeViewingMode : null,
-    isMobileLayout,
-    dropIndicator,
-    onOpenAddModal,
-    onOpenDetail,
-    onDeleteItem,
-    onMarkAsWatched,
-    onViewingModeToggle:
-      status === "stacked"
-        ? (mode: ViewingMode) => {
-            setActiveViewingMode((current) => (current === mode ? null : mode));
-          }
-        : undefined,
-  });
+  const getColumnProps = useCallback(
+    (status: BacklogStatus) => columnPropsByStatus.get(status)!,
+    [columnPropsByStatus],
+  );
 
   if (isMobileLayout) {
     return (

--- a/src/features/backlog/hooks/useTmdbSearchRequest.test.tsx
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import type { BacklogItem } from "../types.ts";
 import { useTmdbSearchRequest } from "./useTmdbSearchRequest.ts";
 
 const tmdbMocks = vi.hoisted(() => ({
@@ -18,6 +19,41 @@ vi.mock("../../../lib/tmdb.ts", async () => {
 });
 
 setupTestLifecycle();
+
+function createItem(id: string, status: BacklogItem["status"], tmdbId: number): BacklogItem {
+  return {
+    id,
+    status,
+    primary_platform: null,
+    note: null,
+    sort_order: 1000,
+    works: {
+      id: `work-${id}`,
+      title: `title-${id}`,
+      work_type: "movie",
+      source_type: "tmdb",
+      tmdb_id: tmdbId,
+      tmdb_media_type: "movie",
+      original_title: null,
+      overview: null,
+      poster_path: null,
+      release_date: null,
+      runtime_minutes: null,
+      typical_episode_runtime_minutes: null,
+      duration_bucket: null,
+      genres: [],
+      season_count: null,
+      season_number: null,
+      focus_required_score: null,
+      background_fit_score: null,
+      completion_load_score: null,
+      rotten_tomatoes_score: null,
+      imdb_rating: null,
+      imdb_votes: null,
+      metacritic_score: null,
+    },
+  };
+}
 
 describe("useTmdbSearchRequest", () => {
   const onResetSelection = vi.fn();
@@ -42,6 +78,36 @@ describe("useTmdbSearchRequest", () => {
     });
 
     expect(tmdbMocks.fetchTmdbRecommendations).toHaveBeenCalledTimes(1);
+  });
+
+  test("推薦元は watched を優先しつつ Fisher-Yates でシャッフルする", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    renderHook(() =>
+      useTmdbSearchRequest({
+        items: [
+          createItem("watched-1", "watched", 1),
+          createItem("watching-1", "watching", 3),
+          createItem("watched-2", "watched", 2),
+          createItem("watching-2", "watching", 4),
+        ],
+        onResetSelection,
+        onSetSearchMessage,
+      }),
+    );
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(tmdbMocks.fetchTmdbRecommendations).toHaveBeenCalledWith([
+      { tmdbId: 2, tmdbMediaType: "movie" },
+      { tmdbId: 1, tmdbMediaType: "movie" },
+      { tmdbId: 4, tmdbMediaType: "movie" },
+      { tmdbId: 3, tmdbMediaType: "movie" },
+    ]);
+
+    randomSpy.mockRestore();
   });
 
   test("handleQueryChange でクエリ入力後、デバウンス経過で searchTmdbWorks が呼ばれる", async () => {

--- a/src/features/backlog/hooks/useTmdbSearchRequest.ts
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.ts
@@ -83,20 +83,30 @@ function prioritizeLocalizedResults(results: TmdbSearchResult[]) {
 const MAX_RECOMMENDATION_SOURCE_ITEMS = 8;
 const SEARCH_DEBOUNCE_MS = 250;
 
+function shuffleArray<T>(items: T[]) {
+  const shuffled = [...items];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[index]];
+  }
+
+  return shuffled;
+}
+
 function buildRecommendationSourceItems(items: BacklogItem[]) {
-  return items
-    .filter(
-      (item) =>
-        (item.status === "watched" || item.status === "watching") &&
-        item.works?.tmdb_id != null &&
-        item.works?.source_type === "tmdb" &&
-        item.works?.work_type !== "season",
-    )
-    .sort((a, b) => {
-      if (a.status === "watched" && b.status !== "watched") return -1;
-      if (a.status !== "watched" && b.status === "watched") return 1;
-      return Math.random() - 0.5;
-    })
+  const recommendationCandidates = items.filter(
+    (item) =>
+      (item.status === "watched" || item.status === "watching") &&
+      item.works?.tmdb_id != null &&
+      item.works?.source_type === "tmdb" &&
+      item.works?.work_type !== "season",
+  );
+
+  return [
+    ...shuffleArray(recommendationCandidates.filter((item) => item.status === "watched")),
+    ...shuffleArray(recommendationCandidates.filter((item) => item.status === "watching")),
+  ]
     .slice(0, MAX_RECOMMENDATION_SOURCE_ITEMS)
     .map((item) => ({
       tmdbId: item.works!.tmdb_id!,

--- a/src/features/backlog/hooks/useWindowSize.test.ts
+++ b/src/features/backlog/hooks/useWindowSize.test.ts
@@ -3,6 +3,7 @@ import { useWindowSize } from "./useWindowSize.ts";
 
 describe("useWindowSize", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     Object.defineProperty(window, "innerWidth", {
       writable: true,
       configurable: true,
@@ -10,12 +11,16 @@ describe("useWindowSize", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("初期値として window.innerWidth を返す", () => {
     const { result } = renderHook(() => useWindowSize());
     expect(result.current).toBe(1280);
   });
 
-  test("resize イベントで幅が更新される", () => {
+  test("resize イベントは throttle 後に最新幅へ更新される", () => {
     const { result } = renderHook(() => useWindowSize());
 
     act(() => {
@@ -25,9 +30,22 @@ describe("useWindowSize", () => {
         value: 390,
       });
       window.dispatchEvent(new Event("resize"));
+
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 420,
+      });
+      window.dispatchEvent(new Event("resize"));
     });
 
-    expect(result.current).toBe(390);
+    expect(result.current).toBe(1280);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe(420);
   });
 
   test("アンマウント後は resize リスナーが除去される", () => {

--- a/src/features/backlog/hooks/useWindowSize.ts
+++ b/src/features/backlog/hooks/useWindowSize.ts
@@ -1,12 +1,32 @@
 import { useEffect, useState } from "react";
 
+const RESIZE_THROTTLE_MS = 100;
+
 export function useWindowSize() {
   const [width, setWidth] = useState(window.innerWidth);
 
   useEffect(() => {
-    const handler = () => setWidth(window.innerWidth);
+    let resizeTimer: number | null = null;
+    let nextWidth = window.innerWidth;
+
+    const flushWidth = () => {
+      resizeTimer = null;
+      setWidth(nextWidth);
+    };
+
+    const handler = () => {
+      nextWidth = window.innerWidth;
+      if (resizeTimer !== null) return;
+      resizeTimer = window.setTimeout(flushWidth, RESIZE_THROTTLE_MS);
+    };
+
     window.addEventListener("resize", handler);
-    return () => window.removeEventListener("resize", handler);
+    return () => {
+      window.removeEventListener("resize", handler);
+      if (resizeTimer !== null) {
+        window.clearTimeout(resizeTimer);
+      }
+    };
   }, []);
 
   return width;


### PR DESCRIPTION
## 関連 Issue

Closes #82

## 変更内容

- `KanbanBoard` で列ごとのグルーピング・stacked 並び替え・列 props 生成を `useMemo` / `useCallback` で安定化し、DnD や feedback 更新時の再計算を抑制
- `useWindowSize` に 100ms の throttle を追加し、連続 `resize` 時の state 更新頻度を抑制
- `useTmdbSearchRequest` の推薦元選定を `sort(() => Math.random() - 0.5)` から Fisher-Yates ベースへ置き換え、`watched` 優先のまま順序の不安定さを解消
- 関連 hook テストを追加し、throttle の反映タイミングと推薦元シャッフルの挙動を検証

## 検証

- `vp test src/features/backlog/components/KanbanBoard.test.tsx src/features/backlog/hooks/useWindowSize.test.ts src/features/backlog/hooks/useTmdbSearchRequest.test.tsx`