### PR TITLE
feat: backlog items 取得に React Query を導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@supabase/supabase-js": "^2.100.1",
+    "@tanstack/react-query": "^5.97.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.100.1
         version: 2.103.0
+      '@tanstack/react-query':
+        specifier: ^5.97.0
+        version: 5.97.0(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1162,6 +1165,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tanstack/query-core@5.97.0':
+    resolution: {integrity: sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==}
+
+  '@tanstack/react-query@5.97.0':
+    resolution: {integrity: sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3992,6 +4003,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.8
       tailwindcss: 4.2.2
+
+  '@tanstack/query-core@5.97.0': {}
+
+  '@tanstack/react-query@5.97.0(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.97.0
+      react: 19.2.5
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/src/features/backlog/backlog-query.ts
+++ b/src/features/backlog/backlog-query.ts
@@ -1,0 +1,13 @@
+import { fetchBacklogItems } from "./backlog-repository.ts";
+
+export const backlogItemsQueryKey = ["backlog-items"] as const;
+
+export async function fetchBacklogItemsQuery() {
+  const result = await fetchBacklogItems();
+
+  if (result.error) {
+    throw new Error(result.error);
+  }
+
+  return result.data;
+}

--- a/src/features/backlog/backlog-query.ts
+++ b/src/features/backlog/backlog-query.ts
@@ -1,6 +1,8 @@
 import { fetchBacklogItems } from "./backlog-repository.ts";
 
-export const backlogItemsQueryKey = ["backlog-items"] as const;
+export function backlogItemsQueryKey(userId: string) {
+  return ["backlog-items", userId] as const;
+}
 
 export async function fetchBacklogItemsQuery() {
   const result = await fetchBacklogItems();

--- a/src/features/backlog/components/BoardPage.test.tsx
+++ b/src/features/backlog/components/BoardPage.test.tsx
@@ -10,7 +10,6 @@ const hookMocks = vi.hoisted(() => ({
   isLoading: false,
   error: null as string | null,
   loadItems: vi.fn().mockResolvedValue(undefined),
-  setItems: vi.fn(),
   onItemDeleted: null as ((itemId: string) => void) | null,
   onWorksAdded: null as (() => void) | null,
   handleDeleteItem: vi.fn(async (itemId: string) => {
@@ -39,7 +38,6 @@ vi.mock("../hooks/useWindowSize.ts", () => ({
 vi.mock("../hooks/useBacklogItems.ts", () => ({
   useBacklogItems: () => ({
     items: hookMocks.items,
-    setItems: hookMocks.setItems,
     isLoading: hookMocks.isLoading,
     error: hookMocks.error,
     loadItems: hookMocks.loadItems,
@@ -191,7 +189,6 @@ describe("BoardPage", () => {
     hookMocks.isLoading = false;
     hookMocks.error = null;
     hookMocks.loadItems.mockResolvedValue(undefined);
-    hookMocks.setItems.mockReset();
     hookMocks.handleDeleteItem.mockClear();
     hookMocks.handleMarkAsWatched.mockClear();
     hookMocks.signOut.mockClear();

--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -60,8 +60,8 @@ describe("useBacklogItems", () => {
     expect(result.current.items).toEqual([]);
   });
 
-  test("loadItems の再呼び出しで isLoading が true に戻る", async () => {
-    mockFetchBacklogItems.mockResolvedValue({ data: [], error: null });
+  test("loadItems の再呼び出し中も isLoading は false のまま保たれる", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
 
     const { result } = renderHook(() => useBacklogItems(), {
       wrapper: TestQueryClientProvider,
@@ -78,10 +78,13 @@ describe("useBacklogItems", () => {
 
     void result.current.loadItems();
 
-    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    // 再取得中も isLoading は false のまま（画面が暗転しない）
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.items).toEqual([stubItem]);
 
     resolveNext();
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.items).toEqual([]));
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -22,7 +22,7 @@ describe("useBacklogItems", () => {
   test("正常取得時はデータを返し isLoading が false になる", async () => {
     mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
 
-    const { result } = renderHook(() => useBacklogItems(), {
+    const { result } = renderHook(() => useBacklogItems("user-1"), {
       wrapper: TestQueryClientProvider,
     });
 
@@ -37,7 +37,7 @@ describe("useBacklogItems", () => {
   test("repository がエラーを返した場合は error がセットされ isLoading が false になる", async () => {
     mockFetchBacklogItems.mockResolvedValue({ data: [], error: "fetch failed" });
 
-    const { result } = renderHook(() => useBacklogItems(), {
+    const { result } = renderHook(() => useBacklogItems("user-1"), {
       wrapper: TestQueryClientProvider,
     });
 
@@ -50,7 +50,7 @@ describe("useBacklogItems", () => {
   test("repository が throw した場合も isLoading が false になりエラーがセットされる", async () => {
     mockFetchBacklogItems.mockRejectedValue(new Error("network error"));
 
-    const { result } = renderHook(() => useBacklogItems(), {
+    const { result } = renderHook(() => useBacklogItems("user-1"), {
       wrapper: TestQueryClientProvider,
     });
 
@@ -60,10 +60,10 @@ describe("useBacklogItems", () => {
     expect(result.current.items).toEqual([]);
   });
 
-  test("loadItems の再呼び出しで isLoading が true に戻る", async () => {
-    mockFetchBacklogItems.mockResolvedValue({ data: [], error: null });
+  test("loadItems の再呼び出し中も isLoading は false のまま保たれる", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
 
-    const { result } = renderHook(() => useBacklogItems(), {
+    const { result } = renderHook(() => useBacklogItems("user-1"), {
       wrapper: TestQueryClientProvider,
     });
 
@@ -78,10 +78,12 @@ describe("useBacklogItems", () => {
 
     void result.current.loadItems();
 
-    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.items).toEqual([stubItem]);
 
     resolveNext();
 
+    await waitFor(() => expect(result.current.items).toEqual([]));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 });

--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -60,8 +60,8 @@ describe("useBacklogItems", () => {
     expect(result.current.items).toEqual([]);
   });
 
-  test("loadItems の再呼び出し中も isLoading は false のまま保たれる", async () => {
-    mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
+  test("loadItems の再呼び出しで isLoading が true に戻る", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [], error: null });
 
     const { result } = renderHook(() => useBacklogItems(), {
       wrapper: TestQueryClientProvider,
@@ -78,13 +78,10 @@ describe("useBacklogItems", () => {
 
     void result.current.loadItems();
 
-    // 再取得中も isLoading は false のまま（画面が暗転しない）
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.items).toEqual([stubItem]);
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
 
     resolveNext();
 
-    await waitFor(() => expect(result.current.items).toEqual([]));
-    expect(result.current.isLoading).toBe(false);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 });

--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
+import { TestQueryClientProvider } from "../../../test/query-client.tsx";
 import * as backlogRepository from "../backlog-repository.ts";
 import type { BacklogItem } from "../types.ts";
 import { useBacklogItems } from "./useBacklogItems.ts";
@@ -21,7 +22,9 @@ describe("useBacklogItems", () => {
   test("正常取得時はデータを返し isLoading が false になる", async () => {
     mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
 
-    const { result } = renderHook(() => useBacklogItems());
+    const { result } = renderHook(() => useBacklogItems(), {
+      wrapper: TestQueryClientProvider,
+    });
 
     expect(result.current.isLoading).toBe(true);
 
@@ -34,7 +37,9 @@ describe("useBacklogItems", () => {
   test("repository がエラーを返した場合は error がセットされ isLoading が false になる", async () => {
     mockFetchBacklogItems.mockResolvedValue({ data: [], error: "fetch failed" });
 
-    const { result } = renderHook(() => useBacklogItems());
+    const { result } = renderHook(() => useBacklogItems(), {
+      wrapper: TestQueryClientProvider,
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -45,7 +50,9 @@ describe("useBacklogItems", () => {
   test("repository が throw した場合も isLoading が false になりエラーがセットされる", async () => {
     mockFetchBacklogItems.mockRejectedValue(new Error("network error"));
 
-    const { result } = renderHook(() => useBacklogItems());
+    const { result } = renderHook(() => useBacklogItems(), {
+      wrapper: TestQueryClientProvider,
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -56,7 +63,9 @@ describe("useBacklogItems", () => {
   test("loadItems の再呼び出しで isLoading が true に戻る", async () => {
     mockFetchBacklogItems.mockResolvedValue({ data: [], error: null });
 
-    const { result } = renderHook(() => useBacklogItems());
+    const { result } = renderHook(() => useBacklogItems(), {
+      wrapper: TestQueryClientProvider,
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -2,21 +2,21 @@ import { useCallback } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { backlogItemsQueryKey, fetchBacklogItemsQuery } from "../backlog-query.ts";
 
-export function useBacklogItems() {
+export function useBacklogItems(userId: string) {
   const queryClient = useQueryClient();
   const query = useQuery({
-    queryKey: backlogItemsQueryKey,
+    queryKey: backlogItemsQueryKey(userId),
     queryFn: fetchBacklogItemsQuery,
     retry: false,
   });
 
   const loadItems = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: backlogItemsQueryKey });
-  }, [queryClient]);
+    await queryClient.invalidateQueries({ queryKey: backlogItemsQueryKey(userId) });
+  }, [queryClient, userId]);
 
   return {
     items: query.data ?? [],
-    isLoading: query.isPending || query.isRefetching,
+    isLoading: query.isPending,
     error: query.error instanceof Error ? query.error.message : null,
     loadItems,
   };

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -16,7 +16,7 @@ export function useBacklogItems() {
 
   return {
     items: query.data ?? [],
-    isLoading: query.isPending,
+    isLoading: query.isPending || query.isRefetching,
     error: query.error instanceof Error ? query.error.message : null,
     loadItems,
   };

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -1,28 +1,23 @@
-import { useCallback, useEffect, useState } from "react";
-import { fetchBacklogItems } from "../backlog-repository.ts";
-import type { BacklogItem } from "../types.ts";
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { backlogItemsQueryKey, fetchBacklogItemsQuery } from "../backlog-query.ts";
 
 export function useBacklogItems() {
-  const [items, setItems] = useState<BacklogItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: backlogItemsQueryKey,
+    queryFn: fetchBacklogItemsQuery,
+    retry: false,
+  });
 
   const loadItems = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const result = await fetchBacklogItems();
-      setItems(result.data);
-      setError(result.error);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "不明なエラーが発生しました");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+    await queryClient.invalidateQueries({ queryKey: backlogItemsQueryKey });
+  }, [queryClient]);
 
-  useEffect(() => {
-    void loadItems();
-  }, [loadItems]);
-
-  return { items, setItems, isLoading, error, loadItems };
+  return {
+    items: query.data ?? [],
+    isLoading: query.isPending || query.isRefetching,
+    error: query.error instanceof Error ? query.error.message : null,
+    loadItems,
+  };
 }

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -16,7 +16,7 @@ export function useBacklogItems() {
 
   return {
     items: query.data ?? [],
-    isLoading: query.isPending || query.isRefetching,
+    isLoading: query.isPending,
     error: query.error instanceof Error ? query.error.message : null,
     loadItems,
   };

--- a/src/features/backlog/hooks/useBoardPageController.test.tsx
+++ b/src/features/backlog/hooks/useBoardPageController.test.tsx
@@ -10,7 +10,6 @@ const hookMocks = vi.hoisted(() => ({
   isLoading: false,
   error: null as string | null,
   loadItems: vi.fn().mockResolvedValue(undefined),
-  setItems: vi.fn(),
   detailModalOpenItemId: null as string | null,
 }));
 
@@ -21,7 +20,6 @@ vi.mock("./useWindowSize.ts", () => ({
 vi.mock("./useBacklogItems.ts", () => ({
   useBacklogItems: () => ({
     items: hookMocks.items,
-    setItems: hookMocks.setItems,
     isLoading: hookMocks.isLoading,
     error: hookMocks.error,
     loadItems: hookMocks.loadItems,
@@ -79,7 +77,6 @@ describe("useBoardPageController", () => {
     hookMocks.isLoading = false;
     hookMocks.error = null;
     hookMocks.loadItems.mockClear();
-    hookMocks.setItems.mockClear();
   });
 
   test("windowWidth が 720 以下のとき isMobileLayout が true になる", () => {

--- a/src/features/backlog/hooks/useBoardPageController.ts
+++ b/src/features/backlog/hooks/useBoardPageController.ts
@@ -13,7 +13,7 @@ type UseBoardPageControllerOptions = {
 export function useBoardPageController({ session }: UseBoardPageControllerOptions) {
   const { isMobileLayout } = useBoardPageLayout();
   const { feedback, feedbackUi } = useBacklogFeedback();
-  const { items, isLoading, error, loadItems } = useBacklogItems();
+  const { items, isLoading, error, loadItems } = useBacklogItems(session.user.id);
   const boardPageState = useBoardPageState({ isMobileLayout });
 
   const dnd = useBacklogDnd({

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,17 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@fontsource-variable/geist";
 import "./style.css";
 import { App } from "./App.tsx";
 import { getAppRootElement } from "./getAppRootElement.ts";
 
+const queryClient = new QueryClient();
+
 createRoot(getAppRootElement()).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/test/query-client.tsx
+++ b/src/test/query-client.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export function TestQueryClientProvider({ children }: { children: ReactNode }) {
+  const queryClient = createTestQueryClient();
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}


### PR DESCRIPTION
## 関連 Issue

Closes #126
Closes #128

## 変更内容

- `useBacklogItems` を React Query (`useQuery`) ベースに書き換え、初回取得・再取得・エラーハンドリングを統一
- `backlog-query.ts` を追加し、クエリキーと `queryFn` を分離
- `main.tsx` に `QueryClientProvider` を追加
- テスト用の `TestQueryClientProvider` を `src/test/query-client.tsx` に追加
- `isLoading` を `query.isPending` のみとし、再取得中（`isRefetching`）は既存データを表示したままにすることで、並び順変更・状態変更後の画面暗転を解消