### PR TITLE
fix: background_fit_score に高評価判定を組み込み（のんびりモードの精度改善）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@
 - 未実施の検証や確認できていないリスクがあれば、明示したうえでコミットする。
 - 重大な懸念が見つかった場合は、修正してからコミットまたは追加コミットする。
 
+Claude Code で作業している場合、self-review の代わりに `/codex:adversarial-review` を使ってもよい。これは Claude Code 専用のプラグイン機能であり、Codex エージェントによる批判的なレビューを実施できる。このリポジトリの開発には Codex も使用しているため、Claude Code 以外の環境では self-review を用いること。
+
 ## PR 追従修正
 
 既存 PR のレビュー指摘対応や CI 修正は `.agents/skills/pr-followup/SKILL.md` を参照する。

--- a/src/features/backlog/work-metadata.test.ts
+++ b/src/features/backlog/work-metadata.test.ts
@@ -95,6 +95,42 @@ describe("genre score helpers", () => {
   });
 });
 
+describe("calcBackgroundFitScore: 評価による補正", () => {
+  test("高評価（RT≥80）はジャンルスコア≥50を25に抑える", () => {
+    expect(
+      calcBackgroundFitScore(["コメディ"], { imdbRating: null, rottenTomatoesScore: 80 }),
+    ).toBe(25);
+  });
+
+  test("高評価（IMDb≥8.0）はジャンルスコア≥50を25に抑える", () => {
+    expect(
+      calcBackgroundFitScore(["アクション"], { imdbRating: 8.0, rottenTomatoesScore: null }),
+    ).toBe(25);
+  });
+
+  test("高評価でもジャンルスコアが0（low genre）なら0のまま", () => {
+    expect(calcBackgroundFitScore(["ホラー"], { imdbRating: 9.0, rottenTomatoesScore: 95 })).toBe(
+      0,
+    );
+  });
+
+  test("ジャンルスコアが25（low-mid）なら高評価でも25のまま", () => {
+    expect(calcBackgroundFitScore([], { imdbRating: 9.0, rottenTomatoesScore: 95 })).toBe(25);
+  });
+
+  test("評価がそこそこ（RT<80かつIMDb<8.0）はジャンルスコアをそのまま返す", () => {
+    expect(calcBackgroundFitScore(["コメディ"], { imdbRating: 7.9, rottenTomatoesScore: 79 })).toBe(
+      75,
+    );
+  });
+
+  test("評価 null は補正なし", () => {
+    expect(
+      calcBackgroundFitScore(["コメディ"], { imdbRating: null, rottenTomatoesScore: null }),
+    ).toBe(75);
+  });
+});
+
 describe("getDurationBucket", () => {
   test("各バケット境界を判定する", () => {
     expect(getDurationBucket(null)).toBeNull();

--- a/src/features/backlog/work-metadata.ts
+++ b/src/features/backlog/work-metadata.ts
@@ -67,11 +67,30 @@ export function calcFocusRequiredScore(genres: string[]): number {
   return 50;
 }
 
-export function calcBackgroundFitScore(genres: string[]): number {
+export type RatingInfo = {
+  imdbRating: number | null;
+  rottenTomatoesScore: number | null;
+};
+
+function isHighlyRated({ imdbRating, rottenTomatoesScore }: RatingInfo): boolean {
+  return (
+    (rottenTomatoesScore !== null && rottenTomatoesScore >= 80) ||
+    (imdbRating !== null && imdbRating >= 8.0)
+  );
+}
+
+export function calcBackgroundFitScore(
+  genres: string[],
+  ratings: RatingInfo = { imdbRating: null, rottenTomatoesScore: null },
+): number {
   if (genres.some((genre) => BG_LOW_GENRES.has(genre))) return 0;
-  if (genres.some((genre) => BG_HIGH_GENRES.has(genre))) return 75;
-  if (genres.some((genre) => BG_MED_GENRES.has(genre))) return 50;
-  return 25;
+  const genreScore = genres.some((genre) => BG_HIGH_GENRES.has(genre))
+    ? 75
+    : genres.some((genre) => BG_MED_GENRES.has(genre))
+      ? 50
+      : 25;
+  if (genreScore >= 50 && isHighlyRated(ratings)) return 25;
+  return genreScore;
 }
 
 export function getDurationBucket(minutes: number | null) {

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -10,7 +10,7 @@ import {
 import { fetchOmdbWorkDetails } from "../../lib/omdb.ts";
 import { buildSearchText } from "./helpers.ts";
 import type { WorkType } from "./types.ts";
-import { buildTmdbWorkUpdate } from "./work-metadata.ts";
+import { buildTmdbWorkUpdate, calcBackgroundFitScore, type RatingInfo } from "./work-metadata.ts";
 
 const TMDB_WORK_REFRESH_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
 const OMDB_WORK_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -20,6 +20,7 @@ type ExistingTmdbWorkRow = {
   last_tmdb_synced_at: string | null;
   omdb_fetched_at: string | null;
   imdb_id: string | null;
+  genres: string[];
 };
 type TmdbWorkLookup = {
   tmdbMediaType: "movie" | "tv";
@@ -259,7 +260,7 @@ async function findExistingTmdbWork({
 }: TmdbWorkLookup): Promise<{ data: ExistingTmdbWorkRow | null; error: PostgrestError | null }> {
   let query = supabase
     .from("works")
-    .select("id, last_tmdb_synced_at, omdb_fetched_at, imdb_id")
+    .select("id, last_tmdb_synced_at, omdb_fetched_at, imdb_id, genres")
     .eq("source_type", "tmdb")
     .eq("tmdb_media_type", tmdbMediaType)
     .eq("tmdb_id", tmdbId)
@@ -299,6 +300,10 @@ async function upsertFetchedTmdbWork(
     if (existing.imdb_id && shouldRefreshOmdb) {
       try {
         const omdb = await fetchOmdbWorkDetails(existing.imdb_id);
+        const omdbRatings: RatingInfo = {
+          imdbRating: omdb.imdbRating,
+          rottenTomatoesScore: omdb.rottenTomatoesScore,
+        };
         await supabase
           .from("works")
           .update({
@@ -306,6 +311,7 @@ async function upsertFetchedTmdbWork(
             imdb_rating: omdb.imdbRating,
             imdb_votes: omdb.imdbVotes,
             metacritic_score: omdb.metacriticScore,
+            background_fit_score: calcBackgroundFitScore(existing.genres, omdbRatings),
             omdb_fetched_at: new Date().toISOString(),
           })
           .eq("id", existing.id);
@@ -361,12 +367,22 @@ async function upsertFetchedTmdbWork(
     }
   })();
 
+  const omdbRatings: RatingInfo = {
+    imdbRating: "imdb_rating" in omdbFields ? (omdbFields.imdb_rating ?? null) : null,
+    rottenTomatoesScore:
+      "rotten_tomatoes_score" in omdbFields ? (omdbFields.rotten_tomatoes_score ?? null) : null,
+  };
   const updatePayload =
     options.parentWorkId === undefined
-      ? { ...buildTmdbWorkUpdate(details), ...omdbFields }
+      ? {
+          ...buildTmdbWorkUpdate(details),
+          ...omdbFields,
+          background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
+        }
       : {
           ...buildTmdbWorkUpdate(details),
           ...omdbFields,
+          background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
           parent_work_id: options.parentWorkId,
         };
 

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -404,6 +404,7 @@ async function upsertFetchedTmdbWork(
     .insert({
       ...buildTmdbWorkInsert(details, userId, workType, options.parentWorkId ?? null),
       ...omdbFields,
+      background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
     })
     .select("id")
     .single();


### PR DESCRIPTION
## 関連 Issue

Closes #5

## 変更内容

- `calcBackgroundFitScore` に `RatingInfo`（IMDb評価・RT スコア）引数を追加
  - RT≥80 または IMDb≥8.0 のいずれかを満たす場合を「高評価」とみなす
  - ジャンルスコアが 50 以上（のんびり候補）でも高評価作品は 25 に抑え、のんびり判定から除外
  - ジャンルスコアが 0（スリラー・ホラー等）の場合は評価によらず 0 のまま（既存挙動を維持）
  - 引数省略時は評価 null 扱いで補正なし（後方互換）
- `work-repository.ts`：TMDB+OMDb 同時取得パスで評価込みの `background_fit_score` を保存
- `work-repository.ts`：OMDb のみ再同期するパスでも `background_fit_score` を再計算
- `findExistingTmdbWork` の select に `genres` を追加（OMDb 再同期時の再計算に必要）

### 背景

The Bear（コメディジャンル）が「のんびり」として表示されていたが、高評価作品をながら見とするのは体感とずれがある。一方、長大シリーズでも評価がそこそこの作品はのんびり視聴に適している場合があるため、評価スコアを判定に組み込むことで精度を改善する。

### 残リスク

TMDB のみ再同期される際（OMDb が 7 日以内で新鮮な場合）、`omdbFields` が空になるため `background_fit_score` が一時的にジャンルのみの値に戻るケースがある。次の OMDb 再同期（最長 7 日）で修正されるため、許容範囲と判断。