### PR TITLE
fix: 再取得中の画面暗転解消

### DIFF
--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -53,8 +53,8 @@ describe("useBacklogItems", () => {
     expect(result.current.items).toEqual([]);
   });
 
-  test("loadItems の再呼び出しで isLoading が true に戻る", async () => {
-    mockFetchBacklogItems.mockResolvedValue({ data: [], error: null });
+  test("loadItems の再呼び出し中も isLoading は false のまま保たれる", async () => {
+    mockFetchBacklogItems.mockResolvedValue({ data: [stubItem], error: null });
 
     const { result } = renderHook(() => useBacklogItems());
 
@@ -69,10 +69,13 @@ describe("useBacklogItems", () => {
 
     void result.current.loadItems();
 
-    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    // 再取得中も isLoading は false のまま（画面が暗転しない）
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.items).toEqual([stubItem]);
 
     resolveNext();
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.items).toEqual([]));
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -8,7 +8,6 @@ export function useBacklogItems() {
   const [error, setError] = useState<string | null>(null);
 
   const loadItems = useCallback(async () => {
-    setIsLoading(true);
     try {
       const result = await fetchBacklogItems();
       setItems(result.data);


### PR DESCRIPTION
## 関連 Issue

Closes #128

## 変更内容

- `loadItems` 内の `setIsLoading(true)` を除去し、再取得中も `isLoading` が false のまま保たれるように修正
- 初回ロードは `useState(true)` の初期値で賄うため、挙動は変わらない
- DnD やアイテム操作後の再取得で `BoardPage` が `null` を返して画面が暗転する問題を解消