### PR TITLE
fix: キャッシュがある場合はバックグラウンド refetch エラーを無視

### DIFF
--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -17,7 +17,13 @@ export function useBacklogItems(userId: string) {
   return {
     items: query.data ?? [],
     isLoading: query.isPending,
-    error: query.error instanceof Error ? query.error.message : null,
+    // キャッシュデータがない場合のみエラーを表示（バックグラウンド refetch エラーはキャッシュがあれば無視）
+    error:
+      !query.data && query.error
+        ? query.error instanceof Error
+          ? query.error.message
+          : null
+        : null,
     loadItems,
   };
 }


### PR DESCRIPTION
## 関連 Issue

Refs #129

## 変更内容

- useBacklogItems の error ハンドリングを改善
- キャッシュデータがない場合のみエラーを表示し、キャッシュがある場合はバックグラウンド refetch エラーを無視
- これにより、並び順変更・状態変更後の再取得時にネットワーク一時的エラーで画面がエラー状態に遷移することを防止