### PR TITLE
fix: バックログのメタ情報表記を整理

### DIFF
--- a/src/features/backlog/components/BacklogCard.tsx
+++ b/src/features/backlog/components/BacklogCard.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
-import { getWorkTypeLabel } from "../helpers.ts";
+import { getWorkMetadataLabels, getWorkTypeLabel } from "../helpers.ts";
 import { viewingModeLabels } from "../constants.ts";
 import type { DropIndicator } from "./kanban-board-shared.ts";
 
@@ -66,7 +66,7 @@ export function BacklogCard({
   const viewingMode = showModeBadge ? getViewingMode(work) : null;
   const WorkTypeIcon = work.work_type === "movie" ? FilmIcon : TvIcon;
   const workTypeLabel = getWorkTypeLabel(work.work_type);
-  const metadataRest = [work.release_date ? work.release_date.slice(0, 4) : null].filter(Boolean);
+  const metadataLabels = getWorkMetadataLabels(work, { includeReleaseYear: true });
 
   const cardDropIndicator =
     dropIndicator?.type === "card" && dropIndicator.itemId === item.id ? dropIndicator : null;
@@ -182,14 +182,23 @@ export function BacklogCard({
         </div>
         <div className="grid gap-2 min-w-0">
           <p className="text-[1rem] font-bold">{title}</p>
-          <p className="text-muted-foreground text-[0.9rem]">
-            <WorkTypeIcon
-              className="w-[14px] h-[14px] inline-block align-[-2px] mr-[3px] shrink-0"
-              aria-hidden="true"
-            />
-            {workTypeLabel}
-            {metadataRest.length > 0 && ` · ${metadataRest.join(" · ")}`}
-          </p>
+          <div className="flex flex-wrap items-center gap-1.5 text-muted-foreground text-[0.9rem]">
+            <span className="inline-flex items-center">
+              <WorkTypeIcon
+                className="w-[14px] h-[14px] inline-block align-[-2px] mr-[3px] shrink-0"
+                aria-hidden="true"
+              />
+              {workTypeLabel}
+            </span>
+            {metadataLabels.map((label) => (
+              <span
+                key={label}
+                className="inline-flex items-center rounded-full border border-[rgba(92,59,35,0.12)] bg-[rgba(92,59,35,0.05)] px-2 py-0.5 text-[0.76rem] leading-none"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
           {item.note && <p className="text-muted-foreground text-[0.9rem]">{item.note}</p>}
         </div>
       </div>

--- a/src/features/backlog/components/BacklogCard.tsx
+++ b/src/features/backlog/components/BacklogCard.tsx
@@ -182,7 +182,7 @@ export function BacklogCard({
         </div>
         <div className="grid gap-2 min-w-0">
           <p className="text-[1rem] font-bold">{title}</p>
-          <div className="flex flex-wrap items-center gap-1.5 text-muted-foreground text-[0.9rem]">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-[0.9rem]">
             <span className="inline-flex items-center">
               <WorkTypeIcon
                 className="w-[14px] h-[14px] inline-block align-[-2px] mr-[3px] shrink-0"
@@ -191,10 +191,7 @@ export function BacklogCard({
               {workTypeLabel}
             </span>
             {metadataLabels.map((label) => (
-              <span
-                key={label}
-                className="inline-flex items-center rounded-full border border-[rgba(92,59,35,0.12)] bg-[rgba(92,59,35,0.05)] px-2 py-0.5 text-[0.76rem] leading-none"
-              >
+              <span key={label} className="text-[0.82rem] leading-none text-muted-foreground/80">
                 {label}
               </span>
             ))}

--- a/src/features/backlog/components/DetailModal.test.tsx
+++ b/src/features/backlog/components/DetailModal.test.tsx
@@ -264,4 +264,24 @@ describe("DetailModal", () => {
 
     expect(screen.getByLabelText("Rotten Tomatoes Rotten 42%")).toBeInTheDocument();
   });
+
+  test("シリーズの runtime は約表記でメタ情報ラベルに出す", () => {
+    renderDetailModal({
+      item: createItem({
+        works: {
+          ...createItem().works!,
+          work_type: "series",
+          tmdb_media_type: "tv",
+          runtime_minutes: null,
+          typical_episode_runtime_minutes: 45,
+          season_count: 1,
+        },
+      }),
+    });
+
+    expect(screen.getByText("2024年")).toBeInTheDocument();
+    expect(screen.getByText("1話約45分")).toBeInTheDocument();
+    expect(screen.getByText("全1シーズン")).toBeInTheDocument();
+    expect(screen.queryByText(/ · /)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/backlog/components/DetailModal.tsx
+++ b/src/features/backlog/components/DetailModal.tsx
@@ -116,16 +116,13 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
                 />
               )}
             </div>
-            <div className="flex flex-wrap items-center gap-2 text-muted-foreground text-[0.95rem]">
+            <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 text-muted-foreground text-[0.95rem]">
               <span className="inline-flex items-center gap-1">
                 <WorkTypeIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
                 {workTypeLabel}
               </span>
               {metadataLabels.map((label) => (
-                <span
-                  key={label}
-                  className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[0.82rem] leading-none"
-                >
+                <span key={label} className="text-[0.84rem] leading-none text-muted-foreground/80">
                   {label}
                 </span>
               ))}

--- a/src/features/backlog/components/DetailModal.tsx
+++ b/src/features/backlog/components/DetailModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
 import { FilmIcon, TvIcon } from "@heroicons/react/24/outline";
-import { createDetailModalState, getWorkTypeLabel } from "../helpers.ts";
+import { createDetailModalState, getWorkMetadataLabels, getWorkTypeLabel } from "../helpers.ts";
 import { statusLabels, statusOrder } from "../constants.ts";
 import { PosterImage } from "./PosterImage.tsx";
 import { RottenTomatoesBadge } from "./RottenTomatoesBadge.tsx";
@@ -62,12 +62,11 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
   const title = work.title;
   const WorkTypeIcon = work.work_type === "movie" ? FilmIcon : TvIcon;
   const workTypeLabel = getWorkTypeLabel(work.work_type);
-  const metadataRest = [
-    work.release_date ? work.release_date.slice(0, 4) : null,
-    work.runtime_minutes ? `${work.runtime_minutes}分` : null,
-    work.typical_episode_runtime_minutes ? `1話 ${work.typical_episode_runtime_minutes}分` : null,
-    work.season_count ? `${work.season_count}シーズン` : null,
-  ].filter(Boolean);
+  const metadataLabels = getWorkMetadataLabels(work, {
+    includeReleaseYear: true,
+    includeRuntime: true,
+    includeSeasonCount: true,
+  });
 
   const rtScore = work.rotten_tomatoes_score;
 
@@ -117,11 +116,20 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
                 />
               )}
             </div>
-            <p className="flex items-center gap-1 text-muted-foreground text-[0.95rem]">
-              <WorkTypeIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
-              {workTypeLabel}
-              {metadataRest.length > 0 && ` · ${metadataRest.join(" · ")}`}
-            </p>
+            <div className="flex flex-wrap items-center gap-2 text-muted-foreground text-[0.95rem]">
+              <span className="inline-flex items-center gap-1">
+                <WorkTypeIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+                {workTypeLabel}
+              </span>
+              {metadataLabels.map((label) => (
+                <span
+                  key={label}
+                  className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-[0.82rem] leading-none"
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
             {rtScore !== null && (
               <p className="text-[0.85rem]">
                 <RottenTomatoesBadge score={rtScore} variant={rtScore >= 60 ? "fresh" : "rotten"} />

--- a/src/features/backlog/components/DetailModal.tsx
+++ b/src/features/backlog/components/DetailModal.tsx
@@ -129,7 +129,11 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
             </div>
             {rtScore !== null && (
               <p className="text-[0.85rem]">
-                <RottenTomatoesBadge score={rtScore} variant={rtScore >= 60 ? "fresh" : "rotten"} />
+                <RottenTomatoesBadge
+                  score={rtScore}
+                  variant={rtScore >= 60 ? "fresh" : "rotten"}
+                  appearance="plain"
+                />
               </p>
             )}
           </div>

--- a/src/features/backlog/components/RottenTomatoesBadge.tsx
+++ b/src/features/backlog/components/RottenTomatoesBadge.tsx
@@ -5,6 +5,7 @@ type RottenTomatoesBadgeVariant = "fresh" | "rotten";
 type Props = {
   score: number;
   variant: RottenTomatoesBadgeVariant;
+  appearance?: "pill" | "plain";
   className?: string;
 };
 
@@ -54,26 +55,31 @@ function getVariantCopy(variant: RottenTomatoesBadgeVariant) {
     case "fresh":
       return {
         label: "Fresh",
-        className: "bg-[rgba(239,68,68,0.14)] text-[#f87171] border-[rgba(239,68,68,0.24)]",
+        textClassName: "text-[#f87171]",
+        pillClassName: "bg-[rgba(239,68,68,0.14)] border-[rgba(239,68,68,0.24)]",
         Icon: FreshIcon,
       };
     case "rotten":
       return {
         label: "Rotten",
-        className: "bg-[rgba(132,204,22,0.14)] text-[#bef264] border-[rgba(132,204,22,0.24)]",
+        textClassName: "text-[#bef264]",
+        pillClassName: "bg-[rgba(132,204,22,0.14)] border-[rgba(132,204,22,0.24)]",
         Icon: RottenIcon,
       };
   }
 }
 
-export function RottenTomatoesBadge({ score, variant, className }: Props) {
-  const { label, className: variantClassName, Icon } = getVariantCopy(variant);
+export function RottenTomatoesBadge({ score, variant, appearance = "pill", className }: Props) {
+  const { label, textClassName, pillClassName, Icon } = getVariantCopy(variant);
 
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-medium",
-        variantClassName,
+        appearance === "pill"
+          ? "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 font-medium"
+          : "inline-flex items-center gap-1 text-[0.8rem] font-medium",
+        textClassName,
+        appearance === "pill" && pillClassName,
         className,
       )}
       title="Rotten Tomatoes"

--- a/src/features/backlog/components/TmdbWorkCard.test.tsx
+++ b/src/features/backlog/components/TmdbWorkCard.test.tsx
@@ -28,6 +28,7 @@ describe("TmdbWorkCard", () => {
 
     expect(screen.getByText("ゴジラ")).toBeInTheDocument();
     expect(screen.queryByText("Godzilla")).not.toBeInTheDocument();
+    expect(screen.getByText("2024年")).toBeInTheDocument();
   });
 
   test("概要がない場合は説明文を表示しない", () => {
@@ -45,6 +46,13 @@ describe("TmdbWorkCard", () => {
   test("Rotten Tomatoes スコアがある場合は年の横にバッジを表示する", () => {
     render(<TmdbWorkCard result={createResult({ rottenTomatoesScore: 93 })} />);
 
+    expect(screen.getByText("2024年")).toBeInTheDocument();
     expect(screen.getByLabelText("Rotten Tomatoes Fresh 93%")).toBeInTheDocument();
+  });
+
+  test("メタ情報に中黒を使わない", () => {
+    render(<TmdbWorkCard result={createResult()} />);
+
+    expect(screen.queryByText("·")).not.toBeInTheDocument();
   });
 });

--- a/src/features/backlog/components/TmdbWorkCard.tsx
+++ b/src/features/backlog/components/TmdbWorkCard.tsx
@@ -29,6 +29,9 @@ export function TmdbWorkCard({
     : null;
   const rtScore = result.rottenTomatoesScore ?? null;
   const rtVariant = rtScore === null ? null : rtScore >= 60 ? "fresh" : "rotten";
+  const metadataLabels = [result.releaseDate ? `${result.releaseDate.slice(0, 4)}年` : null].filter(
+    Boolean,
+  );
 
   const checkButton = onAddToStacked ? (
     <button
@@ -78,23 +81,26 @@ export function TmdbWorkCard({
       </div>
       <div className="grid gap-1 min-w-0 pr-8">
         <span className="font-bold">{result.title}</span>
-        <span className="flex items-center gap-1 text-muted-foreground text-[0.88rem]">
-          {result.workType === "movie" ? (
-            <FilmIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
-          ) : (
-            <TvIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
-          )}
-          {result.workType === "movie" ? "映画" : "シリーズ"}
-          {result.releaseDate && ` · ${result.releaseDate.slice(0, 4)}`}
+        <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-[0.88rem]">
+          <span className="inline-flex items-center gap-1">
+            {result.workType === "movie" ? (
+              <FilmIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+            ) : (
+              <TvIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+            )}
+            {result.workType === "movie" ? "映画" : "シリーズ"}
+          </span>
+          {metadataLabels.map((label) => (
+            <span key={label} className="text-[0.8rem] leading-none text-muted-foreground/80">
+              {label}
+            </span>
+          ))}
           {rtScore !== null && rtVariant && (
-            <>
-              <span aria-hidden="true">·</span>
-              <RottenTomatoesBadge
-                score={rtScore}
-                variant={rtVariant}
-                className="px-1.5 py-0 text-[0.74rem]"
-              />
-            </>
+            <RottenTomatoesBadge
+              score={rtScore}
+              variant={rtVariant}
+              className="px-1.5 py-0 text-[0.74rem]"
+            />
           )}
         </span>
         {result.jpWatchPlatforms.length > 0 && (

--- a/src/features/backlog/components/TmdbWorkCard.tsx
+++ b/src/features/backlog/components/TmdbWorkCard.tsx
@@ -2,6 +2,7 @@ import { FilmIcon, TvIcon, CheckIcon } from "@heroicons/react/24/outline";
 import type { ReactNode } from "react";
 import type { TmdbSearchResult } from "../../../lib/tmdb.ts";
 import { platformLabels } from "../constants.ts";
+import { getTmdbSearchResultMetadataLabels } from "../helpers.ts";
 import { RottenTomatoesBadge } from "./RottenTomatoesBadge.tsx";
 import { TmdbLink } from "./TmdbLink.tsx";
 
@@ -29,9 +30,7 @@ export function TmdbWorkCard({
     : null;
   const rtScore = result.rottenTomatoesScore ?? null;
   const rtVariant = rtScore === null ? null : rtScore >= 60 ? "fresh" : "rotten";
-  const metadataLabels = [result.releaseDate ? `${result.releaseDate.slice(0, 4)}年` : null].filter(
-    Boolean,
-  );
+  const metadataLabels = getTmdbSearchResultMetadataLabels(result);
 
   const checkButton = onAddToStacked ? (
     <button
@@ -99,7 +98,8 @@ export function TmdbWorkCard({
             <RottenTomatoesBadge
               score={rtScore}
               variant={rtVariant}
-              className="px-1.5 py-0 text-[0.74rem]"
+              appearance="plain"
+              className="text-[0.74rem]"
             />
           )}
         </span>

--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   getClientYFromPointerEvent,
   getDropIndicator,
   getDropSideFromRect,
+  getWorkMetadataLabels,
   getWorkTypeLabel,
   resolveDropTarget,
 } from "./helpers.ts";
@@ -286,5 +287,62 @@ describe("getWorkTypeLabel", () => {
 
   test("returns series for season works", () => {
     expect(getWorkTypeLabel("season")).toBe("シリーズ");
+  });
+});
+
+describe("getWorkMetadataLabels", () => {
+  const baseWork: BacklogItem["works"] = {
+    id: "work-1",
+    title: "テスト作品",
+    work_type: "movie",
+    source_type: "tmdb",
+    tmdb_id: 1,
+    tmdb_media_type: "movie",
+    original_title: null,
+    overview: null,
+    poster_path: null,
+    release_date: "2024-01-01",
+    runtime_minutes: 120,
+    typical_episode_runtime_minutes: null,
+    duration_bucket: null,
+    genres: [],
+    season_count: null,
+    season_number: null,
+    focus_required_score: null,
+    background_fit_score: null,
+    completion_load_score: null,
+    rotten_tomatoes_score: null,
+    imdb_rating: null,
+    imdb_votes: null,
+    metacritic_score: null,
+  };
+
+  test("映画は公開年と上映時間をそのまま表示する", () => {
+    expect(
+      getWorkMetadataLabels(baseWork!, {
+        includeReleaseYear: true,
+        includeRuntime: true,
+      }),
+    ).toEqual(["2024年", "120分"]);
+  });
+
+  test("シリーズは平均 runtime を約表記にする", () => {
+    expect(
+      getWorkMetadataLabels(
+        {
+          ...baseWork!,
+          work_type: "series",
+          tmdb_media_type: "tv",
+          runtime_minutes: null,
+          typical_episode_runtime_minutes: 45,
+          season_count: 1,
+        },
+        {
+          includeReleaseYear: true,
+          includeRuntime: true,
+          includeSeasonCount: true,
+        },
+      ),
+    ).toEqual(["2024年", "1話約45分", "全1シーズン"]);
   });
 });

--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -9,10 +9,12 @@ import {
   getClientYFromPointerEvent,
   getDropIndicator,
   getDropSideFromRect,
+  getTmdbSearchResultMetadataLabels,
   getWorkMetadataLabels,
   getWorkTypeLabel,
   resolveDropTarget,
 } from "./helpers.ts";
+import type { TmdbSearchResult } from "../../lib/tmdb.ts";
 import type { BacklogItem } from "./types.ts";
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
 
@@ -344,5 +346,25 @@ describe("getWorkMetadataLabels", () => {
         },
       ),
     ).toEqual(["2024年", "1話約45分", "全1シーズン"]);
+  });
+});
+
+describe("getTmdbSearchResultMetadataLabels", () => {
+  test("検索結果の公開年ラベルを返す", () => {
+    const result: TmdbSearchResult = {
+      tmdbId: 1,
+      tmdbMediaType: "movie",
+      workType: "movie",
+      title: "テスト作品",
+      originalTitle: null,
+      overview: null,
+      posterPath: null,
+      releaseDate: "2024-01-01",
+      jpWatchPlatforms: [],
+      hasJapaneseRelease: true,
+      rottenTomatoesScore: null,
+    };
+
+    expect(getTmdbSearchResultMetadataLabels(result)).toEqual(["2024年"]);
   });
 });

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -6,6 +6,7 @@ import type {
   DropIndicator,
   PrimaryPlatform,
   ResolvedDropTarget,
+  WorkSummary,
   WorkType,
 } from "./types.ts";
 import { isPrimaryPlatformValue } from "./constants.ts";
@@ -161,4 +162,41 @@ export function resolveDropTarget(
 
 export function getWorkTypeLabel(workType: WorkType) {
   return workType === "movie" ? "映画" : "シリーズ";
+}
+
+type WorkMetadataLabelOptions = {
+  includeReleaseYear?: boolean;
+  includeRuntime?: boolean;
+  includeSeasonCount?: boolean;
+};
+
+export function getWorkMetadataLabels(
+  work: WorkSummary,
+  {
+    includeReleaseYear = false,
+    includeRuntime = false,
+    includeSeasonCount = false,
+  }: WorkMetadataLabelOptions = {},
+) {
+  const labels: string[] = [];
+
+  if (includeReleaseYear && work.release_date) {
+    labels.push(`${work.release_date.slice(0, 4)}年`);
+  }
+
+  if (includeRuntime) {
+    if (work.work_type === "movie" && work.runtime_minutes) {
+      labels.push(`${work.runtime_minutes}分`);
+    }
+
+    if (work.work_type !== "movie" && work.typical_episode_runtime_minutes) {
+      labels.push(`1話約${work.typical_episode_runtime_minutes}分`);
+    }
+  }
+
+  if (includeSeasonCount && work.season_count) {
+    labels.push(`全${work.season_count}シーズン`);
+  }
+
+  return labels;
 }

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -9,6 +9,7 @@ import type {
   WorkSummary,
   WorkType,
 } from "./types.ts";
+import type { TmdbSearchResult } from "../../lib/tmdb.ts";
 import { isPrimaryPlatformValue } from "./constants.ts";
 
 type RectLike = Pick<DOMRect, "top" | "height">;
@@ -199,4 +200,8 @@ export function getWorkMetadataLabels(
   }
 
   return labels;
+}
+
+export function getTmdbSearchResultMetadataLabels(result: TmdbSearchResult) {
+  return [result.releaseDate ? `${result.releaseDate.slice(0, 4)}年` : null].filter(Boolean);
 }


### PR DESCRIPTION
## 関連 Issue

<!-- 関連 Issue があれば Refs #123 または Closes #123 の形式で記載 -->

## 変更内容

- バックログカード、詳細モーダル、検索結果カードのメタ情報表示から中黒区切りを廃止し、gap ベースの非インタラクティブなテキスト表示に統一
- シリーズ系の runtime を `1話約45分` のような近似表記に変更し、シーズン数も `全1シーズン` の形式で表示
- メタ情報整形を helper に集約し、Rotten Tomatoes 表示にプレーン表示を追加して過剰なピル表現を抑制
- 関連テストを追加・更新
