### PR TITLE
feat: nuqs による視聴モード URL 同期の検証

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.97.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "nuqs": "^2.8.9",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "shadcn": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      nuqs:
+        specifier: ^2.8.9
+        version: 2.8.9(react@19.2.5)
       react:
         specifier: ^19.2.4
         version: 19.2.5
@@ -1043,6 +1046,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2417,6 +2423,27 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nuqs@2.8.9:
+    resolution: {integrity: sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3893,6 +3920,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.103.0':
@@ -5111,6 +5140,11 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  nuqs@2.8.9(react@19.2.5):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.5
 
   object-assign@4.1.1: {}
 

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import type { OnUrlUpdateFunction } from "nuqs/adapters/testing";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
 import type { ViewingMode } from "../types.ts";
@@ -92,7 +93,7 @@ function createItem(
 
 function renderKanbanBoard(
   overrides: Partial<React.ComponentProps<typeof KanbanBoard>> = {},
-  options?: { searchParams?: string; onUrlUpdate?: ReturnType<typeof vi.fn> },
+  options?: { searchParams?: string; onUrlUpdate?: OnUrlUpdateFunction },
 ) {
   return render(
     <KanbanBoard

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
+import type { ViewingMode } from "../types.ts";
 import { KanbanBoard } from "./KanbanBoard.tsx";
 
 vi.mock("./KanbanColumn.tsx", () => ({
@@ -9,13 +11,35 @@ vi.mock("./KanbanColumn.tsx", () => ({
     status,
     items,
     extra,
+    activeViewingMode,
+    onViewingModeToggle,
   }: {
     status: BacklogStatus;
     items: BacklogItem[];
     extra?: React.ReactNode;
+    activeViewingMode?: ViewingMode | null;
+    onViewingModeToggle?: (mode: ViewingMode) => void;
   }) => (
     <div>
       {extra}
+      {status === "stacked" && onViewingModeToggle ? (
+        <div>
+          <button
+            type="button"
+            aria-pressed={activeViewingMode === "focus"}
+            onClick={() => onViewingModeToggle("focus")}
+          >
+            ガッツリ
+          </button>
+          <button
+            type="button"
+            aria-pressed={activeViewingMode === "quick"}
+            onClick={() => onViewingModeToggle("quick")}
+          >
+            サクッと
+          </button>
+        </div>
+      ) : null}
       <div>
         {status}:{items.map((item) => item.id).join(",")}
       </div>
@@ -66,7 +90,10 @@ function createItem(
   };
 }
 
-function renderKanbanBoard(overrides: Partial<React.ComponentProps<typeof KanbanBoard>> = {}) {
+function renderKanbanBoard(
+  overrides: Partial<React.ComponentProps<typeof KanbanBoard>> = {},
+  options?: { searchParams?: string; onUrlUpdate?: ReturnType<typeof vi.fn> },
+) {
   return render(
     <KanbanBoard
       items={[createItem("item-1", "stacked", "作品1"), createItem("item-2", "watching", "作品2")]}
@@ -82,6 +109,12 @@ function renderKanbanBoard(overrides: Partial<React.ComponentProps<typeof Kanban
       columnRef={vi.fn()}
       {...overrides}
     />,
+    {
+      wrapper: withNuqsTestingAdapter({
+        searchParams: options?.searchParams,
+        onUrlUpdate: options?.onUrlUpdate,
+      }),
+    },
   );
 }
 
@@ -130,5 +163,36 @@ describe("KanbanBoard", () => {
     });
 
     expect(onTabChange).toHaveBeenCalledWith("want_to_watch");
+  });
+
+  test("URL の view クエリから絞り込み状態を復元する", () => {
+    renderKanbanBoard({}, { searchParams: "?view=quick" });
+
+    expect(screen.getByRole("button", { name: /サクッと/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  test("絞り込み切り替えで view クエリを更新する", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn();
+    renderKanbanBoard({}, { onUrlUpdate });
+
+    await user.click(screen.getByRole("button", { name: /ガッツリ/ }));
+    await user.click(screen.getByRole("button", { name: /ガッツリ/ }));
+
+    expect(onUrlUpdate).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        queryString: "?view=focus",
+      }),
+    );
+    expect(onUrlUpdate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        queryString: "",
+      }),
+    );
   });
 });

--- a/src/features/backlog/components/KanbanBoard.tsx
+++ b/src/features/backlog/components/KanbanBoard.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
+import { parseAsStringLiteral, useQueryState } from "nuqs";
 import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
-import { statusOrder } from "../constants.ts";
+import { statusOrder, viewingModeOrder } from "../constants.ts";
 import { sortStackedItemsByViewingMode } from "../viewing-mode.ts";
 import { DesktopKanbanBoard } from "./DesktopKanbanBoard.tsx";
 import { MobileKanbanBoard } from "./MobileKanbanBoard.tsx";
@@ -33,9 +34,14 @@ export function KanbanBoard({
   onMarkAsWatched,
   columnRef,
 }: Props) {
-  const [activeViewingMode, setActiveViewingMode] = useState<ViewingMode | null>(null);
+  const [activeViewingMode, setActiveViewingMode] = useQueryState(
+    "view",
+    parseAsStringLiteral(viewingModeOrder).withOptions({
+      history: "replace",
+    }),
+  );
   const handleViewingModeToggle = useCallback((mode: ViewingMode) => {
-    setActiveViewingMode((current) => (current === mode ? null : mode));
+    void setActiveViewingMode((current) => (current === mode ? null : mode));
   }, []);
 
   const grouped = useMemo(() => {

--- a/src/features/backlog/constants.ts
+++ b/src/features/backlog/constants.ts
@@ -69,7 +69,12 @@ export function isPrimaryPlatformValue(value: unknown): value is PlatformKey {
   return typeof value === "string" && platformKeys.some((platform) => platform === value);
 }
 
-export const viewingModeOrder: ViewingMode[] = ["focus", "thoughtful", "quick", "background"];
+export const viewingModeOrder = [
+  "focus",
+  "thoughtful",
+  "quick",
+  "background",
+] as const satisfies readonly ViewingMode[];
 
 export const viewingModeLabels: Record<ViewingMode, string> = {
   focus: "ガッツリ",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsAdapter } from "nuqs/adapters/react";
 import "@fontsource-variable/geist";
 import "./style.css";
 import { App } from "./App.tsx";
@@ -10,8 +11,10 @@ const queryClient = new QueryClient();
 
 createRoot(getAppRootElement()).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <NuqsAdapter>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </NuqsAdapter>
   </StrictMode>,
 );


### PR DESCRIPTION
## 関連 Issue

Refs #136

## 変更内容

- `nuqs` を導入し、アプリルートを `NuqsAdapter` でラップ
- backlog の `stacked` 列で使っている視聴モード絞り込みを `view` クエリと同期
- `?view=quick` のような URL から絞り込み状態を復元できるように変更
- 絞り込みの切り替え時に query が更新され、解除時は query を消す挙動をテスト追加

## 検証

- `vp test src/features/backlog/components/KanbanBoard.test.tsx src/features/backlog/components/BoardPage.test.tsx src/features/backlog/components/ViewingModeFilter.test.tsx src/features/backlog/hooks/useBoardPageController.test.tsx`
- `vp run knip`
  - 既存の `.claude/worktrees/...` 配下と `supabase/functions/_shared/*` の未使用警告で失敗
  - 今回差分由来の未使用警告はなし

## 補足

- 認証前提の画面なので主目的は外部共有ではなく、再読み込み時の復元性と URL ベースの状態再現性の確認
- 導入対象は `view` に限定し、検索条件やソートまで広げるかは別途判断する想定