### PR TITLE
feat: backlog の並び替えに @dnd-kit/sortable を適用

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@supabase/supabase-js": "^2.100.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@fontsource-variable/geist": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@supabase/supabase-js": "^2.100.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@dnd-kit/sortable':
         specifier: ^10.0.0
         version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
@@ -343,6 +346,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
 
   '@dnd-kit/utilities@3.2.2':
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
@@ -3455,6 +3464,13 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
       tslib: 2.8.1
 
   '@dnd-kit/utilities@3.2.2(react@19.2.5)':

--- a/src/features/backlog/components/BacklogCard.test.tsx
+++ b/src/features/backlog/components/BacklogCard.test.tsx
@@ -4,16 +4,19 @@ import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import type { BacklogItem } from "../types.ts";
 import { BacklogCard } from "./BacklogCard.tsx";
 
-vi.mock("@dnd-kit/core", () => ({
-  useDraggable: () => ({
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
     attributes: {},
     listeners: {},
     setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
     isDragging: false,
   }),
-  useDroppable: () => ({
-    setNodeRef: () => {},
-  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => undefined } },
 }));
 
 setupTestLifecycle();
@@ -69,7 +72,6 @@ async function renderCard(): Promise<RenderResult> {
   render(
     <BacklogCard
       item={createItem()}
-      dropIndicator={null}
       onOpenDetail={onOpenDetail}
       onDeleteItem={onDeleteItem}
       onMarkAsWatched={onMarkAsWatched}

--- a/src/features/backlog/components/BacklogCard.tsx
+++ b/src/features/backlog/components/BacklogCard.tsx
@@ -1,4 +1,5 @@
-import { useDraggable, useDroppable } from "@dnd-kit/core";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import {
   BoltIcon,
   ClockIcon,
@@ -19,7 +20,6 @@ import {
 } from "@/components/ui/dropdown-menu.tsx";
 import { getWorkMetadataLabels, getWorkTypeLabel } from "../helpers.ts";
 import { viewingModeLabels } from "../constants.ts";
-import type { DropIndicator } from "./kanban-board-shared.ts";
 
 const ModeIcon: Record<
   ViewingMode,
@@ -34,7 +34,6 @@ const ModeIcon: Record<
 type Props = {
   item: BacklogItem;
   showModeBadge?: boolean;
-  dropIndicator: DropIndicator | null;
   onOpenDetail: () => void;
   onDeleteItem: (itemId: string) => void;
   onMarkAsWatched: (itemId: string) => void;
@@ -43,18 +42,13 @@ type Props = {
 export function BacklogCard({
   item,
   showModeBadge = false,
-  dropIndicator,
   onOpenDetail,
   onDeleteItem,
   onMarkAsWatched,
 }: Props) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef: setDragRef,
-    isDragging,
-  } = useDraggable({ id: item.id });
-  const { setNodeRef: setDropRef } = useDroppable({ id: item.id });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.id,
+  });
 
   const work = item.works;
 
@@ -68,17 +62,15 @@ export function BacklogCard({
   const workTypeLabel = getWorkTypeLabel(work.work_type);
   const metadataLabels = getWorkMetadataLabels(work, { includeReleaseYear: true });
 
-  const cardDropIndicator =
-    dropIndicator?.type === "card" && dropIndicator.itemId === item.id ? dropIndicator : null;
-
   return (
     <article
-      ref={(node) => {
-        setDragRef(node);
-        setDropRef(node);
+      ref={setNodeRef}
+      className="relative grid w-full min-w-0 cursor-grab gap-[10px] rounded-[18px] border border-[rgba(92,59,35,0.08)] bg-[var(--surface-strong)] pt-[18px] pr-11 pb-4 pl-4 transition-[box-shadow,border-color] duration-[140ms] ease-[ease] active:cursor-grabbing hover:border-primary/[0.18] hover:shadow-[0_14px_32px_rgba(75,48,30,0.08)] focus-visible:outline-2 focus-visible:outline-primary/45 focus-visible:border-primary/[0.18] focus-visible:shadow-[0_14px_32px_rgba(75,48,30,0.08)]"
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
       }}
-      className="relative grid w-full min-w-0 cursor-grab gap-[10px] rounded-[18px] border border-[rgba(92,59,35,0.08)] bg-[var(--surface-strong)] pt-[18px] pr-11 pb-4 pl-4 transition-[opacity,box-shadow,border-color] duration-[140ms] ease-[ease] active:cursor-grabbing hover:border-primary/[0.18] hover:shadow-[0_14px_32px_rgba(75,48,30,0.08)] focus-visible:outline-2 focus-visible:outline-primary/45 focus-visible:border-primary/[0.18] focus-visible:shadow-[0_14px_32px_rgba(75,48,30,0.08)]"
-      style={{ opacity: isDragging ? 0.4 : 1 }}
       data-card-id={item.id}
       data-card-status={item.status}
       onClick={onOpenDetail}
@@ -91,26 +83,6 @@ export function BacklogCard({
       {...listeners}
       {...attributes}
     >
-      {cardDropIndicator?.side === "before" && (
-        <div
-          aria-hidden
-          className="animate-in fade-in duration-100 pointer-events-none absolute inset-x-0 flex items-center gap-1.5 px-1"
-          style={{ top: "-5px" }}
-        >
-          <div className="h-[6px] w-[6px] shrink-0 rounded-full bg-primary" />
-          <div className="h-[2px] flex-1 rounded-full bg-primary" />
-        </div>
-      )}
-      {cardDropIndicator?.side === "after" && (
-        <div
-          aria-hidden
-          className="animate-in fade-in duration-100 pointer-events-none absolute inset-x-0 flex items-center gap-1.5 px-1"
-          style={{ bottom: "-5px" }}
-        >
-          <div className="h-[6px] w-[6px] shrink-0 rounded-full bg-primary" />
-          <div className="h-[2px] flex-1 rounded-full bg-primary" />
-        </div>
-      )}
       <div className="absolute top-[10px] right-[10px]">
         <DropdownMenu>
           <DropdownMenuTrigger

--- a/src/features/backlog/components/BoardPage.test.tsx
+++ b/src/features/backlog/components/BoardPage.test.tsx
@@ -47,10 +47,11 @@ vi.mock("../hooks/useBacklogItems.ts", () => ({
 vi.mock("../hooks/useBacklogDnd.ts", () => ({
   useBacklogDnd: () => ({
     dragItemId: null,
-    dropIndicator: null,
+    localItems: hookMocks.items,
     sensors: [],
     handleDragStart: vi.fn(),
     handleDragOver: vi.fn(),
+    handleDragCancel: vi.fn(),
     handleDragEnd: vi.fn(),
   }),
 }));

--- a/src/features/backlog/components/BoardPage.tsx
+++ b/src/features/backlog/components/BoardPage.tsx
@@ -56,13 +56,14 @@ export function BoardPage({ session }: Props) {
         collisionDetection={pointerWithin}
         onDragStart={dnd.handleDragStart}
         onDragOver={dnd.handleDragOver}
+        onDragCancel={dnd.handleDragCancel}
         onDragEnd={(e) => void dnd.handleDragEnd(e)}
       >
         <KanbanBoard {...board} />
         <DragOverlay dropAnimation={null}>
           {dnd.dragItemId ? (
             <DraggedBacklogCardOverlay
-              item={board.items.find((candidate) => candidate.id === dnd.dragItemId) ?? null}
+              item={dnd.localItems.find((candidate) => candidate.id === dnd.dragItemId) ?? null}
             />
           ) : null}
         </DragOverlay>

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import type { OnUrlUpdateFunction } from "nuqs/adapters/testing";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
-import type { BacklogItem, BacklogStatus } from "../types.ts";
+import type { BacklogItem, BacklogStatus, WorkSummary } from "../types.ts";
 import type { ViewingMode } from "../types.ts";
 import { KanbanBoard } from "./KanbanBoard.tsx";
 
@@ -88,6 +88,34 @@ function createItem(
       metacritic_score: null,
     },
     ...overrides,
+  };
+}
+
+function createWorkSummary(id: string, title: string, runtimeMinutes: number): WorkSummary {
+  return {
+    id: `work-${id}`,
+    title,
+    work_type: "movie",
+    source_type: "tmdb",
+    tmdb_id: Number(id.replace(/\D/g, "")) || 1,
+    tmdb_media_type: "movie",
+    original_title: null,
+    overview: null,
+    poster_path: null,
+    release_date: null,
+    runtime_minutes: runtimeMinutes,
+    typical_episode_runtime_minutes: null,
+    duration_bucket: null,
+    genres: [],
+    season_count: null,
+    season_number: null,
+    focus_required_score: null,
+    background_fit_score: null,
+    completion_load_score: null,
+    rotten_tomatoes_score: null,
+    imdb_rating: null,
+    imdb_votes: null,
+    metacritic_score: null,
   };
 }
 
@@ -200,16 +228,10 @@ describe("KanbanBoard", () => {
   test("view 絞り込み中にドラッグ開始しても stacked 列の表示順を維持する", () => {
     const items = [
       createItem("item-1", "stacked", "長編", {
-        works: {
-          ...createItem("item-1", "stacked", "長編").works,
-          runtime_minutes: 120,
-        },
+        works: createWorkSummary("item-1", "長編", 120),
       }),
       createItem("item-2", "stacked", "短編", {
-        works: {
-          ...createItem("item-2", "stacked", "短編").works,
-          runtime_minutes: 20,
-        },
+        works: createWorkSummary("item-2", "短編", 20),
       }),
     ];
 

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -98,7 +98,7 @@ function renderKanbanBoard(
   return render(
     <KanbanBoard
       items={[createItem("item-1", "stacked", "作品1"), createItem("item-2", "watching", "作品2")]}
-      dropIndicator={null}
+      isDragging={false}
       isMobileLayout={false}
       isMobileDragging={false}
       selectedTabStatus="stacked"

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -196,4 +196,48 @@ describe("KanbanBoard", () => {
       }),
     );
   });
+
+  test("view 絞り込み中にドラッグ開始しても stacked 列の表示順を維持する", () => {
+    const items = [
+      createItem("item-1", "stacked", "長編", {
+        works: {
+          ...createItem("item-1", "stacked", "長編").works,
+          runtime_minutes: 120,
+        },
+      }),
+      createItem("item-2", "stacked", "短編", {
+        works: {
+          ...createItem("item-2", "stacked", "短編").works,
+          runtime_minutes: 20,
+        },
+      }),
+    ];
+
+    const { rerender } = renderKanbanBoard(
+      {
+        items,
+      },
+      { searchParams: "?view=quick" },
+    );
+
+    expect(screen.getByText("stacked:item-2,item-1")).toBeInTheDocument();
+
+    rerender(
+      <KanbanBoard
+        items={items}
+        isDragging
+        isMobileLayout={false}
+        isMobileDragging={false}
+        selectedTabStatus="stacked"
+        onTabChange={vi.fn()}
+        onOpenAddModal={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onDeleteItem={vi.fn()}
+        onMarkAsWatched={vi.fn()}
+        columnRef={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("stacked:item-2,item-1")).toBeInTheDocument();
+  });
 });

--- a/src/features/backlog/components/KanbanBoard.tsx
+++ b/src/features/backlog/components/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
 import { statusOrder, viewingModeOrder } from "../constants.ts";
@@ -42,6 +42,8 @@ export function KanbanBoard({
   const handleViewingModeToggle = useCallback((mode: ViewingMode) => {
     void setActiveViewingMode((current) => (current === mode ? null : mode));
   }, []);
+  const lastStableItemsRef = useRef<BacklogItem[] | null>(null);
+  const lastStableStackedItemsRef = useRef<BacklogItem[] | null>(null);
 
   const grouped = useMemo(() => {
     const nextGrouped = new Map<BacklogStatus, BacklogItem[]>(
@@ -52,12 +54,18 @@ export function KanbanBoard({
       nextGrouped.get(item.status)?.push(item);
     }
 
-    // ドラッグ中は視聴モードによる再ソートをスキップ（localItems の順序を保持）
+    const sortedStackedItems = sortStackedItemsByViewingMode(
+      nextGrouped.get("stacked") ?? [],
+      activeViewingMode,
+    );
+
     if (!isDragging) {
-      nextGrouped.set(
-        "stacked",
-        sortStackedItemsByViewingMode(nextGrouped.get("stacked") ?? [], activeViewingMode),
-      );
+      lastStableItemsRef.current = items;
+      lastStableStackedItemsRef.current = sortedStackedItems;
+      nextGrouped.set("stacked", sortedStackedItems);
+    } else if (lastStableItemsRef.current === items && lastStableStackedItemsRef.current) {
+      // ドラッグ開始直後は、直前の filtered 表示順を維持してカードが跳ねないようにする
+      nextGrouped.set("stacked", lastStableStackedItemsRef.current);
     }
 
     return nextGrouped;

--- a/src/features/backlog/components/KanbanBoard.tsx
+++ b/src/features/backlog/components/KanbanBoard.tsx
@@ -5,11 +5,10 @@ import { statusOrder, viewingModeOrder } from "../constants.ts";
 import { sortStackedItemsByViewingMode } from "../viewing-mode.ts";
 import { DesktopKanbanBoard } from "./DesktopKanbanBoard.tsx";
 import { MobileKanbanBoard } from "./MobileKanbanBoard.tsx";
-import type { DropIndicator } from "./kanban-board-shared.ts";
 
 type Props = {
   items: BacklogItem[];
-  dropIndicator: DropIndicator | null;
+  isDragging: boolean;
   isMobileLayout: boolean;
   isMobileDragging: boolean;
   selectedTabStatus: BacklogStatus;
@@ -23,7 +22,7 @@ type Props = {
 
 export function KanbanBoard({
   items,
-  dropIndicator,
+  isDragging,
   isMobileLayout,
   isMobileDragging,
   selectedTabStatus,
@@ -53,13 +52,16 @@ export function KanbanBoard({
       nextGrouped.get(item.status)?.push(item);
     }
 
-    nextGrouped.set(
-      "stacked",
-      sortStackedItemsByViewingMode(nextGrouped.get("stacked") ?? [], activeViewingMode),
-    );
+    // ドラッグ中は視聴モードによる再ソートをスキップ（localItems の順序を保持）
+    if (!isDragging) {
+      nextGrouped.set(
+        "stacked",
+        sortStackedItemsByViewingMode(nextGrouped.get("stacked") ?? [], activeViewingMode),
+      );
+    }
 
     return nextGrouped;
-  }, [items, activeViewingMode]);
+  }, [items, activeViewingMode, isDragging]);
 
   const columnPropsByStatus = useMemo(
     () =>
@@ -71,7 +73,6 @@ export function KanbanBoard({
             items: grouped.get(status) ?? [],
             activeViewingMode: status === "stacked" ? activeViewingMode : null,
             isMobileLayout,
-            dropIndicator,
             onOpenAddModal,
             onOpenDetail,
             onDeleteItem,
@@ -82,7 +83,6 @@ export function KanbanBoard({
       ),
     [
       activeViewingMode,
-      dropIndicator,
       grouped,
       handleViewingModeToggle,
       isMobileLayout,

--- a/src/features/backlog/components/KanbanColumn.test.tsx
+++ b/src/features/backlog/components/KanbanColumn.test.tsx
@@ -6,7 +6,13 @@ import { KanbanColumn } from "./KanbanColumn.tsx";
 vi.mock("@dnd-kit/core", () => ({
   useDroppable: () => ({
     setNodeRef: vi.fn(),
+    isOver: false,
   }),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: {},
 }));
 
 vi.mock("./BacklogCard.tsx", () => ({
@@ -59,7 +65,6 @@ describe("KanbanColumn", () => {
         items={[createItem()]}
         activeViewingMode="thoughtful"
         isMobileLayout={false}
-        dropIndicator={null}
         onOpenAddModal={vi.fn()}
         onOpenDetail={vi.fn()}
         onDeleteItem={vi.fn()}
@@ -78,7 +83,6 @@ describe("KanbanColumn", () => {
         items={[createItem({ status: "watching" })]}
         activeViewingMode={null}
         isMobileLayout={false}
-        dropIndicator={null}
         onOpenAddModal={vi.fn()}
         onOpenDetail={vi.fn()}
         onDeleteItem={vi.fn()}
@@ -99,7 +103,6 @@ describe("KanbanColumn", () => {
         ]}
         activeViewingMode={null}
         isMobileLayout={false}
-        dropIndicator={null}
         onOpenAddModal={vi.fn()}
         onOpenDetail={vi.fn()}
         onDeleteItem={vi.fn()}

--- a/src/features/backlog/components/KanbanColumn.tsx
+++ b/src/features/backlog/components/KanbanColumn.tsx
@@ -1,21 +1,11 @@
 import type { ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { BacklogStatus } from "../types.ts";
 import type { KanbanColumnProps } from "./kanban-board-shared.ts";
-import type { DropIndicator } from "./kanban-board-shared.ts";
 import { BacklogCard } from "./BacklogCard.tsx";
 import { KanbanColumnHeader } from "./KanbanColumnHeader.tsx";
 import { ViewingModeFilter } from "./ViewingModeFilter.tsx";
-
-function TopSlot({ status }: { status: BacklogStatus }) {
-  const { setNodeRef } = useDroppable({ id: `top-slot:${status}` });
-  return <div ref={setNodeRef} className="h-6" />;
-}
-
-function BottomSlot({ status }: { status: BacklogStatus }) {
-  const { setNodeRef } = useDroppable({ id: `bottom-slot:${status}` });
-  return <div ref={setNodeRef} className="h-6" />;
-}
 
 type Props = KanbanColumnProps & {
   extra?: ReactNode;
@@ -27,18 +17,16 @@ export function KanbanColumn({
   extra,
   activeViewingMode = null,
   isMobileLayout = false,
-  dropIndicator,
   onOpenAddModal,
   onOpenDetail,
   onDeleteItem,
   onMarkAsWatched,
   onViewingModeToggle,
 }: Props) {
-  const { setNodeRef } = useDroppable({ id: `column:${status}` });
-  const isColumnActive =
-    dropIndicator?.type === "column" && dropIndicator.status === status && items.length === 0;
+  const { setNodeRef, isOver } = useDroppable({ id: `column:${status}` });
+  const isEmptyColumnActive = isOver && items.length === 0;
 
-  const dropzoneStyle: React.CSSProperties | undefined = isColumnActive
+  const dropzoneStyle: React.CSSProperties | undefined = isEmptyColumnActive
     ? {
         minHeight: "120px",
         borderRadius: "20px",
@@ -47,14 +35,7 @@ export function KanbanColumn({
       }
     : undefined;
 
-  const firstItemId = items[0]?.id;
-  const lastItemId = items.at(-1)?.id;
-  const effectiveDropIndicator: DropIndicator | null =
-    dropIndicator?.type === "top-slot" && dropIndicator.status === status && firstItemId
-      ? { type: "card", itemId: firstItemId, side: "before" }
-      : dropIndicator?.type === "bottom-slot" && dropIndicator.status === status && lastItemId
-        ? { type: "card", itemId: lastItemId, side: "after" }
-        : dropIndicator;
+  const itemIds = items.map((item) => item.id);
 
   return (
     <section
@@ -81,27 +62,24 @@ export function KanbanColumn({
               onViewingModeToggle={onViewingModeToggle}
             />
           ) : null}
-          <TopSlot status={status} />
-          {items.length > 0 ? (
-            <>
-              {items.map((item) => (
+          <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+            {items.length > 0 ? (
+              items.map((item) => (
                 <BacklogCard
                   key={item.id}
                   item={item}
                   showModeBadge={status === "stacked"}
-                  dropIndicator={effectiveDropIndicator}
                   onOpenDetail={() => onOpenDetail(item.id)}
                   onDeleteItem={onDeleteItem}
                   onMarkAsWatched={onMarkAsWatched}
                 />
-              ))}
-              <BottomSlot status={status} />
-            </>
-          ) : (
-            <p className="text-[var(--text-muted)] pt-[18px] text-[0.92rem]">
-              この列にはまだカードがありません。
-            </p>
-          )}
+              ))
+            ) : (
+              <p className="text-[var(--text-muted)] pt-[18px] text-[0.92rem]">
+                この列にはまだカードがありません。
+              </p>
+            )}
+          </SortableContext>
         </div>
       </div>
     </section>

--- a/src/features/backlog/components/KanbanColumn.tsx
+++ b/src/features/backlog/components/KanbanColumn.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import type { BacklogStatus } from "../types.ts";
 import type { KanbanColumnProps } from "./kanban-board-shared.ts";
 import { BacklogCard } from "./BacklogCard.tsx";
 import { KanbanColumnHeader } from "./KanbanColumnHeader.tsx";

--- a/src/features/backlog/components/kanban-board-shared.ts
+++ b/src/features/backlog/components/kanban-board-shared.ts
@@ -1,19 +1,12 @@
 import type { ReactNode } from "react";
 import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
 
-export type DropIndicator =
-  | { type: "card"; itemId: string; side: "before" | "after" }
-  | { type: "column"; status: BacklogStatus }
-  | { type: "top-slot"; status: BacklogStatus }
-  | { type: "bottom-slot"; status: BacklogStatus };
-
 export type KanbanColumnProps = {
   status: BacklogStatus;
   items: BacklogItem[];
   extra?: ReactNode;
   activeViewingMode: ViewingMode | null;
   isMobileLayout: boolean;
-  dropIndicator: DropIndicator | null;
   onOpenAddModal: () => void;
   onOpenDetail: (itemId: string) => void;
   onDeleteItem: (itemId: string) => void;

--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -6,13 +6,9 @@ import {
   normalizePrimaryPlatform,
   buildSearchText,
   escapeHtml,
-  getClientYFromPointerEvent,
-  getDropIndicator,
-  getDropSideFromRect,
   getTmdbSearchResultMetadataLabels,
   getWorkMetadataLabels,
   getWorkTypeLabel,
-  resolveDropTarget,
 } from "./helpers.ts";
 import type { TmdbSearchResult } from "../../lib/tmdb.ts";
 import type { BacklogItem } from "./types.ts";
@@ -126,155 +122,6 @@ describe("escapeHtml", () => {
 
   test("returns unchanged string when no special characters", () => {
     expect(escapeHtml("hello")).toBe("hello");
-  });
-});
-
-describe("getDropSideFromRect", () => {
-  test("returns the same side judgment without DOM access", () => {
-    expect(getDropSideFromRect({ top: 100, height: 80 }, 130)).toBe("before");
-    expect(getDropSideFromRect({ top: 100, height: 80 }, 150)).toBe("after");
-    expect(getDropSideFromRect({ top: 100, height: 80 }, 140)).toBe("after");
-  });
-});
-
-describe("getClientYFromPointerEvent", () => {
-  test("returns mouse clientY", () => {
-    const event = { type: "mousemove", clientY: 180 } as MouseEvent;
-    expect(getClientYFromPointerEvent(event, { top: 100, height: 80 })).toBe(180);
-  });
-
-  test("returns touches clientY for touchmove", () => {
-    const event = {
-      type: "touchmove",
-      touches: [{ clientY: 170 }],
-      changedTouches: [],
-    } as unknown as TouchEvent;
-    expect(getClientYFromPointerEvent(event, { top: 100, height: 80 })).toBe(170);
-  });
-
-  test("returns changedTouches clientY for touchend when requested", () => {
-    const event = {
-      type: "touchend",
-      touches: [],
-      changedTouches: [{ clientY: 190 }],
-    } as unknown as TouchEvent;
-    expect(getClientYFromPointerEvent(event, { top: 100, height: 80 }, "changedTouches")).toBe(190);
-  });
-
-  test("falls back to midpoint when event is missing", () => {
-    expect(getClientYFromPointerEvent(null, { top: 100, height: 80 })).toBe(140);
-  });
-});
-
-describe("getDropIndicator", () => {
-  test("returns column indicator for column targets", () => {
-    expect(getDropIndicator("column:watched", { top: 100, height: 80 }, 140)).toEqual({
-      type: "column",
-      status: "watched",
-    });
-  });
-
-  test("returns card indicator with before/after side", () => {
-    expect(getDropIndicator("item-1", { top: 100, height: 80 }, 120)).toEqual({
-      type: "card",
-      itemId: "item-1",
-      side: "before",
-    });
-  });
-
-  test("top-slot ターゲットには top-slot インジケーターを返す", () => {
-    expect(getDropIndicator("top-slot:stacked", { top: 100, height: 80 }, 140)).toEqual({
-      type: "top-slot",
-      status: "stacked",
-    });
-  });
-
-  test("bottom-slot ターゲットには bottom-slot インジケーターを返す", () => {
-    expect(getDropIndicator("bottom-slot:stacked", { top: 100, height: 80 }, 140)).toEqual({
-      type: "bottom-slot",
-      status: "stacked",
-    });
-  });
-});
-
-describe("resolveDropTarget", () => {
-  const items: BacklogItem[] = [
-    {
-      id: "item-1",
-      status: "watching",
-      primary_platform: null,
-      note: null,
-      sort_order: 100,
-      works: null,
-    },
-  ];
-
-  test("resolves column drops without target item", () => {
-    expect(resolveDropTarget(items, "column:stacked", { top: 0, height: 100 }, 50)).toEqual({
-      status: "stacked",
-      targetItemId: null,
-      side: "after",
-    });
-  });
-
-  test("resolves card drops using the target item status", () => {
-    expect(resolveDropTarget(items, "item-1", { top: 0, height: 100 }, 20)).toEqual({
-      status: "watching",
-      targetItemId: "item-1",
-      side: "before",
-    });
-  });
-
-  test("returns null when the over item does not exist", () => {
-    expect(resolveDropTarget(items, "missing", { top: 0, height: 100 }, 20)).toBeNull();
-  });
-
-  test("アイテムのある列への column ドロップは null を返す", () => {
-    const watchingItems: BacklogItem[] = [
-      {
-        id: "item-2",
-        status: "watching",
-        primary_platform: null,
-        note: null,
-        sort_order: 100,
-        works: null,
-      },
-    ];
-    expect(
-      resolveDropTarget(watchingItems, "column:watching", { top: 0, height: 100 }, 50),
-    ).toBeNull();
-  });
-
-  test("空列への column ドロップは先頭挿入を返す", () => {
-    expect(resolveDropTarget(items, "column:stacked", { top: 0, height: 100 }, 50)).toEqual({
-      status: "stacked",
-      targetItemId: null,
-      side: "after",
-    });
-  });
-
-  test("top-slot ドロップは先頭アイテムの before を返す", () => {
-    expect(resolveDropTarget(items, "top-slot:watching", { top: 0, height: 100 }, 50)).toEqual({
-      status: "watching",
-      targetItemId: "item-1",
-      side: "before",
-    });
-  });
-
-  test("空列への top-slot ドロップは先頭挿入を返す", () => {
-    expect(resolveDropTarget(items, "top-slot:stacked", { top: 0, height: 100 }, 50)).toEqual({
-      status: "stacked",
-      targetItemId: null,
-      side: "after",
-    });
-  });
-
-  test("bottom-slot ドロップは末尾挿入を返す", () => {
-    expect(resolveDropTarget(items, "bottom-slot:watching", { top: 0, height: 100 }, 50)).toEqual({
-      status: "watching",
-      targetItemId: null,
-      side: "after",
-    });
   });
 });
 

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -1,18 +1,13 @@
 import type {
   BacklogItem,
-  BacklogStatus,
   DetailModalEditableField,
   DetailModalState,
-  DropIndicator,
   PrimaryPlatform,
-  ResolvedDropTarget,
   WorkSummary,
   WorkType,
 } from "./types.ts";
 import type { TmdbSearchResult } from "../../lib/tmdb.ts";
 import { isPrimaryPlatformValue } from "./constants.ts";
-
-type RectLike = Pick<DOMRect, "top" | "height">;
 
 export function getStringField(formData: FormData, key: string) {
   const value = formData.get(key);
@@ -66,99 +61,6 @@ export function escapeHtml(value: string) {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
-}
-
-export function getDropSideFromRect(rect: RectLike, clientY: number) {
-  return clientY < rect.top + rect.height / 2 ? "before" : "after";
-}
-
-export function getClientYFromPointerEvent(
-  event: MouseEvent | TouchEvent | null | undefined,
-  rect: RectLike,
-  touchListKey: "touches" | "changedTouches" = "touches",
-) {
-  const fallbackY = rect.top + rect.height / 2;
-
-  if (!event) {
-    return fallbackY;
-  }
-
-  if ("touches" in event && event.type.includes("touch")) {
-    const touchList = touchListKey === "changedTouches" ? event.changedTouches : event.touches;
-    return touchList?.[0]?.clientY ?? fallbackY;
-  }
-
-  return "clientY" in event ? (event.clientY ?? fallbackY) : fallbackY;
-}
-
-export function getDropIndicator(overId: string, rect: RectLike, clientY: number): DropIndicator {
-  if (overId.startsWith("column:")) {
-    return {
-      type: "column",
-      status: overId.replace("column:", "") as BacklogStatus,
-    };
-  }
-
-  if (overId.startsWith("top-slot:")) {
-    return {
-      type: "top-slot",
-      status: overId.replace("top-slot:", "") as BacklogStatus,
-    };
-  }
-
-  if (overId.startsWith("bottom-slot:")) {
-    return {
-      type: "bottom-slot",
-      status: overId.replace("bottom-slot:", "") as BacklogStatus,
-    };
-  }
-
-  return {
-    type: "card",
-    itemId: overId,
-    side: getDropSideFromRect(rect, clientY),
-  };
-}
-
-export function resolveDropTarget(
-  items: BacklogItem[],
-  overId: string,
-  rect: RectLike,
-  clientY: number,
-): ResolvedDropTarget | null {
-  if (overId.startsWith("top-slot:")) {
-    const status = overId.replace("top-slot:", "") as BacklogStatus;
-    const columnItems = items
-      .filter((item) => item.status === status)
-      .sort((a, b) => a.sort_order - b.sort_order);
-    if (columnItems.length > 0) {
-      return { status, targetItemId: columnItems[0].id, side: "before" };
-    }
-    return { status, targetItemId: null, side: "after" };
-  }
-
-  if (overId.startsWith("bottom-slot:")) {
-    const status = overId.replace("bottom-slot:", "") as BacklogStatus;
-    return { status, targetItemId: null, side: "after" };
-  }
-
-  if (overId.startsWith("column:")) {
-    const status = overId.replace("column:", "") as BacklogStatus;
-    const hasItems = items.some((item) => item.status === status);
-    if (hasItems) return null;
-    return { status, targetItemId: null, side: "after" };
-  }
-
-  const targetItem = items.find((item) => item.id === overId);
-  if (!targetItem) {
-    return null;
-  }
-
-  return {
-    status: targetItem.status,
-    targetItemId: overId,
-    side: getDropSideFromRect(rect, clientY),
-  };
 }
 
 export function getWorkTypeLabel(workType: WorkType) {

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -18,15 +18,6 @@ vi.mock("../../../lib/supabase.ts", () => ({
   },
 }));
 
-vi.mock("@dnd-kit/sortable", () => ({
-  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
-    const result = [...arr];
-    const [item] = result.splice(from, 1);
-    result.splice(to, 0, item);
-    return result;
-  },
-}));
-
 setupTestLifecycle();
 
 function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
@@ -170,7 +161,8 @@ describe("useBacklogDnd", () => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-2" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 220 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 
@@ -212,7 +204,8 @@ describe("useBacklogDnd", () => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-2" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 220 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 
@@ -243,7 +236,8 @@ describe("useBacklogDnd", () => {
     act(() => {
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-2" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 220 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 
@@ -251,6 +245,56 @@ describe("useBacklogDnd", () => {
       .filter((i) => i.status === "stacked")
       .map((i) => i.id);
     expect(stackedOrder).toEqual(["item-2", "item-1"]);
+  });
+
+  test("handleDragOver で列またぎ時は pointer が over の上半分なら手前に挿入する", () => {
+    const crossColumnItems = [
+      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-3", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 120 } as MouseEvent,
+      } as unknown as DragOverEvent);
+    });
+
+    const watchingOrder = result.current.localItems
+      .filter((i) => i.status === "watching")
+      .map((i) => i.id);
+    expect(watchingOrder).toEqual(["item-2", "item-1", "item-3"]);
+  });
+
+  test("handleDragOver で列またぎ時は pointer が over の下半分なら後ろに挿入する", () => {
+    const crossColumnItems = [
+      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 260 } as MouseEvent,
+      } as unknown as DragOverEvent);
+    });
+
+    const watchingOrder = result.current.localItems
+      .filter((i) => i.status === "watching")
+      .map((i) => i.id);
+    expect(watchingOrder).toEqual(["item-2", "item-1", "item-3"]);
   });
 
   test("モバイルレイアウトでは handleDragOver が列間移動をブロックする", () => {
@@ -269,7 +313,8 @@ describe("useBacklogDnd", () => {
     act(() => {
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-2" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 220 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 
@@ -287,7 +332,8 @@ describe("useBacklogDnd", () => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-2" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 220 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -62,6 +62,14 @@ function createWatchingItems(): BacklogItem[] {
   ];
 }
 
+function createMixedColumnItems(): BacklogItem[] {
+  return [
+    createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+    createItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
+    createItem({ id: "item-3", status: "watching", sort_order: 1000 }),
+  ];
+}
+
 const onAfterDrop = vi.fn().mockResolvedValue(undefined);
 const feedback = {
   alert: vi.fn().mockResolvedValue(undefined),
@@ -263,6 +271,27 @@ describe("useBacklogDnd", () => {
     const { result } = renderDnd(createWatchingItems());
     dragOver(result, "item-2", 260);
     expect(getOrderByStatus(result, "watching")).toEqual(["item-2", "item-1", "item-3"]);
+  });
+
+  test("連続した handleDragOver でも updater の状態から列判定して status を取りこぼさない", () => {
+    const { result } = renderDnd(createMixedColumnItems());
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-3", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 120 } as MouseEvent,
+      } as unknown as DragOverEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 120 } as MouseEvent,
+      } as unknown as DragOverEvent);
+    });
+
+    expect(getOrderByStatus(result, "stacked")).toEqual(["item-1", "item-2"]);
+    expect(result.current.localItems.find((item) => item.id === "item-1")?.status).toBe("stacked");
   });
 
   test("handleDragOver で非空列の背景に落としたら列末尾に移動する", () => {

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -54,13 +54,61 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
-describe("useBacklogDnd", () => {
-  const onAfterDrop = vi.fn().mockResolvedValue(undefined);
-  const feedback = {
-    alert: vi.fn().mockResolvedValue(undefined),
-    confirm: vi.fn().mockResolvedValue(true),
-  };
+function createWatchingItems(): BacklogItem[] {
+  return [
+    createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+    createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+    createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+  ];
+}
 
+const onAfterDrop = vi.fn().mockResolvedValue(undefined);
+const feedback = {
+  alert: vi.fn().mockResolvedValue(undefined),
+  confirm: vi.fn().mockResolvedValue(true),
+};
+
+function renderDnd(
+  items: BacklogItem[],
+  options?: {
+    isMobileLayout?: boolean;
+    onAfterDropOverride?: () => Promise<void>;
+  },
+) {
+  return renderHook(() =>
+    useBacklogDnd({
+      items,
+      isMobileLayout: options?.isMobileLayout ?? false,
+      onAfterDrop: options?.onAfterDropOverride ?? onAfterDrop,
+      feedback,
+    }),
+  );
+}
+
+function dragOver(
+  result: ReturnType<typeof renderDnd>["result"],
+  overId: string,
+  clientY: number,
+  activeId = "item-1",
+) {
+  act(() => {
+    result.current.handleDragStart({ active: { id: activeId } } as DragStartEvent);
+    result.current.handleDragOver({
+      active: { id: activeId },
+      over: { id: overId, rect: makeRect(100, 200) },
+      activatorEvent: { clientY } as MouseEvent,
+    } as unknown as DragOverEvent);
+  });
+}
+
+function getOrderByStatus(
+  result: ReturnType<typeof renderDnd>["result"],
+  status: BacklogItem["status"],
+) {
+  return result.current.localItems.filter((i) => i.status === status).map((i) => i.id);
+}
+
+describe("useBacklogDnd", () => {
   const stackedItems = [
     createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
     createItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
@@ -74,9 +122,7 @@ describe("useBacklogDnd", () => {
   });
 
   test("handleDragStart で dragItemId がセットされる", () => {
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
+    const { result } = renderDnd(stackedItems);
 
     act(() => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
@@ -86,9 +132,7 @@ describe("useBacklogDnd", () => {
   });
 
   test("handleDragEnd で over が null なら supabase を呼ばない", async () => {
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
+    const { result } = renderDnd(stackedItems);
 
     await act(async () => {
       await result.current.handleDragEnd({
@@ -104,9 +148,7 @@ describe("useBacklogDnd", () => {
   });
 
   test("handleDragEnd 成功時に supabase を更新して onAfterDrop を呼び dragItemId をクリアする", async () => {
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
+    const { result } = renderDnd(stackedItems);
     const rect = makeRect(100, 200);
 
     await act(async () => {
@@ -126,9 +168,7 @@ describe("useBacklogDnd", () => {
 
   test("handleDragEnd で supabase がエラーを返したら alert を出して onAfterDrop を呼ばない", async () => {
     supabaseMocks.eq.mockResolvedValueOnce({ error: { message: "DB エラー" } });
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
+    const { result } = renderDnd(stackedItems);
     const rect = makeRect(100, 200);
 
     await act(async () => {
@@ -147,27 +187,15 @@ describe("useBacklogDnd", () => {
     const deferred = createDeferred<{ error: null }>();
     supabaseMocks.eq.mockReturnValueOnce(deferred.promise);
     const { result, rerender } = renderHook(
-      ({ items }) =>
-        useBacklogDnd({
-          items,
-          isMobileLayout: false,
-          onAfterDrop,
-          feedback,
-        }),
+      ({ items }) => useBacklogDnd({ items, isMobileLayout: false, onAfterDrop, feedback }),
       { initialProps: { items: stackedItems } },
     );
 
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 220 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
+    dragOver(result, "item-2", 220);
 
+    let dragEndPromise!: Promise<void>;
     act(() => {
-      void result.current.handleDragEnd({
+      dragEndPromise = result.current.handleDragEnd({
         active: { id: "item-1" },
         over: { id: "item-2", rect: makeRect(100, 200) },
         activatorEvent: null,
@@ -180,7 +208,9 @@ describe("useBacklogDnd", () => {
     expect(result.current.localItems.map((item) => item.id)).toEqual(["item-2", "item-1"]);
 
     deferred.resolve({ error: null });
-    await act(async () => {});
+    await act(async () => {
+      await dragEndPromise;
+    });
   });
 
   test("handleDragEnd 後に onAfterDrop が失敗しても次回同期をブロックし続けない", async () => {
@@ -200,14 +230,7 @@ describe("useBacklogDnd", () => {
       { initialProps: { items: stackedItems } },
     );
 
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 220 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
+    dragOver(result, "item-2", 220);
 
     await expect(
       act(async () => {
@@ -225,121 +248,32 @@ describe("useBacklogDnd", () => {
   });
 
   test("handleDragOver で同列内の並び替えで localItems が更新される", async () => {
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-    });
-
-    act(() => {
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 220 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
-
-    const stackedOrder = result.current.localItems
-      .filter((i) => i.status === "stacked")
-      .map((i) => i.id);
-    expect(stackedOrder).toEqual(["item-2", "item-1"]);
+    const { result } = renderDnd(stackedItems);
+    dragOver(result, "item-2", 220);
+    expect(getOrderByStatus(result, "stacked")).toEqual(["item-2", "item-1"]);
   });
 
   test("handleDragOver で列またぎ時は pointer が over の上半分なら手前に挿入する", () => {
-    const crossColumnItems = [
-      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-    ];
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-3", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 120 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
-
-    const watchingOrder = result.current.localItems
-      .filter((i) => i.status === "watching")
-      .map((i) => i.id);
-    expect(watchingOrder).toEqual(["item-2", "item-1", "item-3"]);
+    const { result } = renderDnd(createWatchingItems());
+    dragOver(result, "item-3", 120);
+    expect(getOrderByStatus(result, "watching")).toEqual(["item-2", "item-1", "item-3"]);
   });
 
   test("handleDragOver で列またぎ時は pointer が over の下半分なら後ろに挿入する", () => {
-    const crossColumnItems = [
-      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-    ];
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 260 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
-
-    const watchingOrder = result.current.localItems
-      .filter((i) => i.status === "watching")
-      .map((i) => i.id);
-    expect(watchingOrder).toEqual(["item-2", "item-1", "item-3"]);
+    const { result } = renderDnd(createWatchingItems());
+    dragOver(result, "item-2", 260);
+    expect(getOrderByStatus(result, "watching")).toEqual(["item-2", "item-1", "item-3"]);
   });
 
   test("handleDragOver で非空列の背景に落としたら列末尾に移動する", () => {
-    const crossColumnItems = [
-      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-    ];
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "column:watching", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 260 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
-
-    const watchingOrder = result.current.localItems
-      .filter((i) => i.status === "watching")
-      .map((i) => i.id);
-    expect(watchingOrder).toEqual(["item-2", "item-3", "item-1"]);
+    const { result } = renderDnd(createWatchingItems());
+    dragOver(result, "column:watching", 260);
+    expect(getOrderByStatus(result, "watching")).toEqual(["item-2", "item-3", "item-1"]);
   });
 
   test("handleDragEnd で非空列の背景ドロップは列末尾の sort_order を保存する", async () => {
-    const crossColumnItems = [
-      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-    ];
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "column:watching", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 260 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
+    const { result } = renderDnd(createWatchingItems());
+    dragOver(result, "column:watching", 260);
 
     await act(async () => {
       await result.current.handleDragEnd({
@@ -356,25 +290,14 @@ describe("useBacklogDnd", () => {
   });
 
   test("モバイルレイアウトでは handleDragOver が列間移動をブロックする", () => {
-    const crossColumnItems = [
-      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-    ];
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: crossColumnItems, isMobileLayout: true, onAfterDrop, feedback }),
+    const { result } = renderDnd(
+      [
+        createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+        createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      ],
+      { isMobileLayout: true },
     );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-    });
-
-    act(() => {
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 220 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
+    dragOver(result, "item-2", 220);
 
     // モバイルでは列またぎをブロックするので localItems は変わらない
     const item1 = result.current.localItems.find((i) => i.id === "item-1");
@@ -382,18 +305,8 @@ describe("useBacklogDnd", () => {
   });
 
   test("handleDragCancel で localItems がサーバー状態に戻る", () => {
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
-    );
-
-    act(() => {
-      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
-      result.current.handleDragOver({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
-        activatorEvent: { clientY: 220 } as MouseEvent,
-      } as unknown as DragOverEvent);
-    });
+    const { result } = renderDnd(stackedItems);
+    dragOver(result, "item-2", 220);
 
     act(() => {
       result.current.handleDragCancel();

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -297,6 +297,64 @@ describe("useBacklogDnd", () => {
     expect(watchingOrder).toEqual(["item-2", "item-1", "item-3"]);
   });
 
+  test("handleDragOver で非空列の背景に落としたら列末尾に移動する", () => {
+    const crossColumnItems = [
+      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "column:watching", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 260 } as MouseEvent,
+      } as unknown as DragOverEvent);
+    });
+
+    const watchingOrder = result.current.localItems
+      .filter((i) => i.status === "watching")
+      .map((i) => i.id);
+    expect(watchingOrder).toEqual(["item-2", "item-3", "item-1"]);
+  });
+
+  test("handleDragEnd で非空列の背景ドロップは列末尾の sort_order を保存する", async () => {
+    const crossColumnItems = [
+      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: crossColumnItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "column:watching", rect: makeRect(100, 200) },
+        activatorEvent: { clientY: 260 } as MouseEvent,
+      } as unknown as DragOverEvent);
+    });
+
+    await act(async () => {
+      await result.current.handleDragEnd({
+        active: { id: "item-1" },
+        over: { id: "column:watching", rect: makeRect(100, 200) },
+        activatorEvent: null,
+      } as unknown as DragEndEvent);
+    });
+
+    expect(supabaseMocks.update).toHaveBeenCalledWith({
+      status: "watching",
+      sort_order: 3000,
+    });
+  });
+
   test("モバイルレイアウトでは handleDragOver が列間移動をブロックする", () => {
     const crossColumnItems = [
       createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import type { DragEndEvent, DragOverEvent, DragStartEvent } from "@dnd-kit/core";
 import { useBacklogDnd } from "./useBacklogDnd.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import type { BacklogItem } from "../types.ts";
@@ -15,6 +15,15 @@ vi.mock("../../../lib/supabase.ts", () => ({
     from: () => ({
       update: supabaseMocks.update,
     }),
+  },
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  arrayMove: <T,>(arr: T[], from: number, to: number): T[] => {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item);
+    return result;
   },
 }));
 
@@ -44,6 +53,14 @@ function makeRect(top = 100, height = 200): DOMRect {
     y: top,
     toJSON: () => ({}),
   } as DOMRect;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 describe("useBacklogDnd", () => {
@@ -135,45 +152,108 @@ describe("useBacklogDnd", () => {
     expect(onAfterDrop).not.toHaveBeenCalled();
   });
 
-  test("非空列の column エリアへのドロップは supabase を呼ばない", async () => {
-    const { result } = renderHook(() =>
-      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
+  test("handleDragEnd 中はサーバー同期前でも localItems を維持してスナップバックしない", async () => {
+    const deferred = createDeferred<{ error: null }>();
+    supabaseMocks.eq.mockReturnValueOnce(deferred.promise);
+    const { result, rerender } = renderHook(
+      ({ items }) =>
+        useBacklogDnd({
+          items,
+          isMobileLayout: false,
+          onAfterDrop,
+          feedback,
+        }),
+      { initialProps: { items: stackedItems } },
     );
-    const rect = makeRect(100, 200);
 
-    await act(async () => {
-      await result.current.handleDragEnd({
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "column:stacked", rect },
+        over: { id: "item-2" },
+      } as unknown as DragOverEvent);
+    });
+
+    act(() => {
+      void result.current.handleDragEnd({
+        active: { id: "item-1" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
         activatorEvent: null,
       } as unknown as DragEndEvent);
     });
 
-    expect(supabaseMocks.update).not.toHaveBeenCalled();
-    expect(onAfterDrop).not.toHaveBeenCalled();
+    rerender({ items: stackedItems });
+
+    expect(result.current.dragItemId).toBeNull();
+    expect(result.current.localItems.map((item) => item.id)).toEqual(["item-2", "item-1"]);
+
+    deferred.resolve({ error: null });
+    await act(async () => {});
   });
 
-  test("top-slot へのドロップは先頭アイテムの前に挿入する", async () => {
+  test("handleDragEnd 後に onAfterDrop が失敗しても次回同期をブロックし続けない", async () => {
+    const failingOnAfterDrop = vi.fn().mockRejectedValue(new Error("reload failed"));
+    const reorderedItems = [
+      createItem({ id: "item-2", status: "stacked", sort_order: 1000 }),
+      createItem({ id: "item-1", status: "stacked", sort_order: 2000 }),
+    ];
+    const { result, rerender } = renderHook(
+      ({ items }) =>
+        useBacklogDnd({
+          items,
+          isMobileLayout: false,
+          onAfterDrop: failingOnAfterDrop,
+          feedback,
+        }),
+      { initialProps: { items: stackedItems } },
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-2" },
+      } as unknown as DragOverEvent);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.handleDragEnd({
+          active: { id: "item-1" },
+          over: { id: "item-2", rect: makeRect(100, 200) },
+          activatorEvent: null,
+        } as unknown as DragEndEvent);
+      }),
+    ).rejects.toThrow("reload failed");
+
+    rerender({ items: reorderedItems });
+
+    expect(result.current.localItems).toEqual(reorderedItems);
+  });
+
+  test("handleDragOver で同列内の並び替えで localItems が更新される", async () => {
     const { result } = renderHook(() =>
       useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
     );
-    const rect = makeRect(100, 8);
 
-    await act(async () => {
-      await result.current.handleDragEnd({
-        active: { id: "item-2" },
-        over: { id: "top-slot:stacked", rect },
-        activatorEvent: null,
-      } as unknown as DragEndEvent);
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
     });
 
-    expect(supabaseMocks.update).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "stacked" }),
-    );
-    expect(onAfterDrop).toHaveBeenCalledTimes(1);
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-2" },
+      } as unknown as DragOverEvent);
+    });
+
+    const stackedOrder = result.current.localItems
+      .filter((i) => i.status === "stacked")
+      .map((i) => i.id);
+    expect(stackedOrder).toEqual(["item-2", "item-1"]);
   });
 
-  test("モバイルレイアウトでは列間ドラッグをブロックする", async () => {
+  test("モバイルレイアウトでは handleDragOver が列間移動をブロックする", () => {
     const crossColumnItems = [
       createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
       createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
@@ -181,17 +261,41 @@ describe("useBacklogDnd", () => {
     const { result } = renderHook(() =>
       useBacklogDnd({ items: crossColumnItems, isMobileLayout: true, onAfterDrop, feedback }),
     );
-    const rect = makeRect(100, 200);
 
-    await act(async () => {
-      await result.current.handleDragEnd({
-        active: { id: "item-1" },
-        over: { id: "item-2", rect },
-        activatorEvent: null,
-      } as unknown as DragEndEvent);
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
     });
 
-    expect(supabaseMocks.update).not.toHaveBeenCalled();
-    expect(onAfterDrop).not.toHaveBeenCalled();
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-2" },
+      } as unknown as DragOverEvent);
+    });
+
+    // モバイルでは列またぎをブロックするので localItems は変わらない
+    const item1 = result.current.localItems.find((i) => i.id === "item-1");
+    expect(item1?.status).toBe("stacked");
+  });
+
+  test("handleDragCancel で localItems がサーバー状態に戻る", () => {
+    const { result } = renderHook(() =>
+      useBacklogDnd({ items: stackedItems, isMobileLayout: false, onAfterDrop, feedback }),
+    );
+
+    act(() => {
+      result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
+      result.current.handleDragOver({
+        active: { id: "item-1" },
+        over: { id: "item-2" },
+      } as unknown as DragOverEvent);
+    });
+
+    act(() => {
+      result.current.handleDragCancel();
+    });
+
+    expect(result.current.dragItemId).toBeNull();
+    expect(result.current.localItems).toEqual(stackedItems);
   });
 });

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -20,6 +20,7 @@ type Props = {
 };
 
 type RectLike = Pick<DOMRect, "top" | "height">;
+type TouchListKey = "touches" | "changedTouches";
 
 function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null {
   return items.find((i) => i.id === id)?.status ?? null;
@@ -32,7 +33,7 @@ function getDropSideFromRect(rect: RectLike, clientY: number) {
 function getClientYFromPointerEvent(
   event: MouseEvent | TouchEvent | null | undefined,
   rect: RectLike,
-  touchListKey: "touches" | "changedTouches" = "touches",
+  touchListKey: TouchListKey = "touches",
 ) {
   const fallbackY = rect.top + rect.height / 2;
 
@@ -202,10 +203,10 @@ export function useBacklogDnd({
       sortOrder = 1000;
     } else if (!prevItem) {
       sortOrder = nextItem!.sort_order - 1000;
-    } else if (!nextItem) {
-      sortOrder = prevItem.sort_order + 1000;
-    } else {
+    } else if (nextItem) {
       sortOrder = (prevItem.sort_order + nextItem.sort_order) / 2;
+    } else {
+      sortOrder = prevItem.sort_order + 1000;
     }
 
     setIsDropSyncPending(true);

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   MouseSensor,
   TouchSensor,
@@ -8,10 +8,9 @@ import {
   type DragOverEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
 import { supabase } from "../../../lib/supabase.ts";
-import { getSortOrderForDrop } from "../backlog-item-utils.ts";
-import { getClientYFromPointerEvent, getDropIndicator, resolveDropTarget } from "../helpers.ts";
-import type { BacklogItem, DropIndicator } from "../types.ts";
+import type { BacklogItem, BacklogStatus } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
 
 type Props = {
@@ -21,6 +20,10 @@ type Props = {
   feedback?: BacklogFeedback;
 };
 
+function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null {
+  return items.find((i) => i.id === id)?.status ?? null;
+}
+
 export function useBacklogDnd({
   items,
   isMobileLayout,
@@ -28,7 +31,15 @@ export function useBacklogDnd({
   feedback = browserBacklogFeedback,
 }: Props) {
   const [dragItemId, setDragItemId] = useState<string | null>(null);
-  const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null);
+  const [isDropSyncPending, setIsDropSyncPending] = useState(false);
+  const [localItems, setLocalItems] = useState<BacklogItem[]>(items);
+
+  // サーバーデータが更新されたら、ドラッグ中またはドロップ反映待ちでない場合に同期
+  useEffect(() => {
+    if (!dragItemId && !isDropSyncPending) {
+      setLocalItems(items);
+    }
+  }, [items, dragItemId, isDropSyncPending]);
 
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: { distance: 8 },
@@ -43,65 +54,127 @@ export function useBacklogDnd({
   };
 
   const handleDragOver = (event: DragOverEvent) => {
-    const { over } = event;
-    if (!over) {
-      setDropIndicator(null);
-      return;
-    }
+    const { active, over } = event;
+    if (!over) return;
 
+    const activeId = active.id as string;
     const overId = over.id as string;
-    const rect = over.rect;
-    const clientY = getClientYFromPointerEvent(
-      event.activatorEvent as MouseEvent | TouchEvent | null | undefined,
-      rect,
-    );
-    setDropIndicator(getDropIndicator(overId, rect, clientY));
+
+    if (activeId === overId) return;
+
+    const activeStatus = findItemStatus(localItems, activeId);
+    const overStatus = overId.startsWith("column:")
+      ? (overId.replace("column:", "") as BacklogStatus)
+      : findItemStatus(localItems, overId);
+
+    if (!activeStatus || !overStatus) return;
+    if (isMobileLayout && activeStatus !== overStatus) return;
+
+    setLocalItems((prev) => {
+      const activeItem = prev.find((i) => i.id === activeId);
+      if (!activeItem) return prev;
+
+      if (activeStatus === overStatus) {
+        // 同列内での並び替え
+        if (overId.startsWith("column:")) return prev;
+        const colItems = prev.filter((i) => i.status === overStatus);
+        const others = prev.filter((i) => i.status !== overStatus);
+        const oldIdx = colItems.findIndex((i) => i.id === activeId);
+        const newIdx = colItems.findIndex((i) => i.id === overId);
+        if (oldIdx === -1 || newIdx === -1) return prev;
+        return [...others, ...arrayMove(colItems, oldIdx, newIdx)];
+      } else {
+        // 列またぎ: ステータスを変更して over アイテムの位置に挿入
+        const withUpdatedStatus = prev.map((i) =>
+          i.id === activeId ? { ...i, status: overStatus } : i,
+        );
+
+        if (overId.startsWith("column:")) {
+          return withUpdatedStatus;
+        }
+
+        const newColItems = withUpdatedStatus.filter((i) => i.status === overStatus);
+        const others = withUpdatedStatus.filter((i) => i.status !== overStatus);
+        const activeIdx = newColItems.findIndex((i) => i.id === activeId);
+        const overIdx = newColItems.findIndex((i) => i.id === overId);
+        if (activeIdx === -1 || overIdx === -1) return withUpdatedStatus;
+        return [...others, ...arrayMove(newColItems, activeIdx, overIdx)];
+      }
+    });
+  };
+
+  const handleDragCancel = () => {
+    setIsDropSyncPending(false);
+    setDragItemId(null);
+    setLocalItems(items);
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
     setDragItemId(null);
-    setDropIndicator(null);
 
-    if (!over) return;
-
-    const draggedId = active.id as string;
-    const overId = over.id as string;
-
-    const target = resolveDropTarget(
-      items,
-      overId,
-      over.rect,
-      getClientYFromPointerEvent(
-        event.activatorEvent as MouseEvent | TouchEvent | null | undefined,
-        over.rect,
-        "changedTouches",
-      ),
-    );
-    if (!target) return;
-
-    const { status: targetStatus, targetItemId, side } = target;
-
-    // モバイルレイアウトでは列間ドラッグを無効化
-    if (isMobileLayout) {
-      const dragItem = items.find((i) => i.id === draggedId);
-      if (dragItem && dragItem.status !== targetStatus) return;
-    }
-
-    const sortOrder = getSortOrderForDrop(items, draggedId, targetStatus, targetItemId, side);
-
-    const { error: updateError } = await supabase
-      .from("backlog_items")
-      .update({ status: targetStatus, sort_order: sortOrder })
-      .eq("id", draggedId);
-
-    if (updateError) {
-      await Promise.resolve(feedback.alert(`ドラッグ移動に失敗しました: ${updateError.message}`));
+    if (!over) {
+      setIsDropSyncPending(false);
+      setLocalItems(items);
       return;
     }
 
-    await onAfterDrop();
+    const activeId = active.id as string;
+    const draggedItem = localItems.find((i) => i.id === activeId);
+    if (!draggedItem) {
+      setIsDropSyncPending(false);
+      setLocalItems(items);
+      return;
+    }
+
+    const targetStatus = draggedItem.status;
+    const columnOrder = localItems.filter((i) => i.status === targetStatus).map((i) => i.id);
+    const insertedIndex = columnOrder.indexOf(activeId);
+
+    const prevId = insertedIndex > 0 ? columnOrder[insertedIndex - 1] : null;
+    const nextId = insertedIndex < columnOrder.length - 1 ? columnOrder[insertedIndex + 1] : null;
+
+    // sort_order はサーバーアイテムの値を使って補間する
+    const prevItem = prevId ? items.find((i) => i.id === prevId) : null;
+    const nextItem = nextId ? items.find((i) => i.id === nextId) : null;
+
+    let sortOrder: number;
+    if (!prevItem && !nextItem) {
+      sortOrder = 1000;
+    } else if (!prevItem) {
+      sortOrder = nextItem!.sort_order - 1000;
+    } else if (!nextItem) {
+      sortOrder = prevItem.sort_order + 1000;
+    } else {
+      sortOrder = (prevItem.sort_order + nextItem.sort_order) / 2;
+    }
+
+    setIsDropSyncPending(true);
+    try {
+      const { error: updateError } = await supabase
+        .from("backlog_items")
+        .update({ status: targetStatus, sort_order: sortOrder })
+        .eq("id", activeId);
+
+      if (updateError) {
+        await Promise.resolve(feedback.alert(`ドラッグ移動に失敗しました: ${updateError.message}`));
+        setLocalItems(items);
+        return;
+      }
+
+      await onAfterDrop();
+    } finally {
+      setIsDropSyncPending(false);
+    }
   };
 
-  return { dragItemId, dropIndicator, sensors, handleDragStart, handleDragOver, handleDragEnd };
+  return {
+    dragItemId,
+    localItems,
+    sensors,
+    handleDragStart,
+    handleDragOver,
+    handleDragCancel,
+    handleDragEnd,
+  };
 }

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -8,7 +8,6 @@ import {
   type DragOverEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { arrayMove } from "@dnd-kit/sortable";
 import { supabase } from "../../../lib/supabase.ts";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
@@ -20,8 +19,53 @@ type Props = {
   feedback?: BacklogFeedback;
 };
 
+type RectLike = Pick<DOMRect, "top" | "height">;
+
 function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null {
   return items.find((i) => i.id === id)?.status ?? null;
+}
+
+function getDropSideFromRect(rect: RectLike, clientY: number) {
+  return clientY < rect.top + rect.height / 2 ? "before" : "after";
+}
+
+function getClientYFromPointerEvent(
+  event: MouseEvent | TouchEvent | null | undefined,
+  rect: RectLike,
+  touchListKey: "touches" | "changedTouches" = "touches",
+) {
+  const fallbackY = rect.top + rect.height / 2;
+
+  if (!event) {
+    return fallbackY;
+  }
+
+  if ("touches" in event && event.type.includes("touch")) {
+    const touchList = touchListKey === "changedTouches" ? event.changedTouches : event.touches;
+    return touchList?.[0]?.clientY ?? fallbackY;
+  }
+
+  return "clientY" in event ? (event.clientY ?? fallbackY) : fallbackY;
+}
+
+function getReorderedColumnItems(
+  columnItems: BacklogItem[],
+  activeId: string,
+  overId: string,
+  side: "before" | "after",
+) {
+  const activeIdx = columnItems.findIndex((i) => i.id === activeId);
+  const overIdx = columnItems.findIndex((i) => i.id === overId);
+  if (activeIdx === -1 || overIdx === -1) return columnItems;
+
+  const baseItems = columnItems.filter((i) => i.id !== activeId);
+  const targetIdx = baseItems.findIndex((i) => i.id === overId);
+  if (targetIdx === -1) return columnItems;
+
+  const insertionIdx = side === "before" ? targetIdx : targetIdx + 1;
+  const activeItem = columnItems[activeIdx];
+
+  return [...baseItems.slice(0, insertionIdx), activeItem, ...baseItems.slice(insertionIdx)];
 }
 
 export function useBacklogDnd({
@@ -54,7 +98,7 @@ export function useBacklogDnd({
   };
 
   const handleDragOver = (event: DragOverEvent) => {
-    const { active, over } = event;
+    const { active, over, activatorEvent } = event;
     if (!over) return;
 
     const activeId = active.id as string;
@@ -79,10 +123,12 @@ export function useBacklogDnd({
         if (overId.startsWith("column:")) return prev;
         const colItems = prev.filter((i) => i.status === overStatus);
         const others = prev.filter((i) => i.status !== overStatus);
-        const oldIdx = colItems.findIndex((i) => i.id === activeId);
-        const newIdx = colItems.findIndex((i) => i.id === overId);
-        if (oldIdx === -1 || newIdx === -1) return prev;
-        return [...others, ...arrayMove(colItems, oldIdx, newIdx)];
+        const clientY = getClientYFromPointerEvent(
+          activatorEvent as MouseEvent | TouchEvent | null | undefined,
+          over.rect,
+        );
+        const side = getDropSideFromRect(over.rect, clientY);
+        return [...others, ...getReorderedColumnItems(colItems, activeId, overId, side)];
       } else {
         // 列またぎ: ステータスを変更して over アイテムの位置に挿入
         const withUpdatedStatus = prev.map((i) =>
@@ -95,10 +141,12 @@ export function useBacklogDnd({
 
         const newColItems = withUpdatedStatus.filter((i) => i.status === overStatus);
         const others = withUpdatedStatus.filter((i) => i.status !== overStatus);
-        const activeIdx = newColItems.findIndex((i) => i.id === activeId);
-        const overIdx = newColItems.findIndex((i) => i.id === overId);
-        if (activeIdx === -1 || overIdx === -1) return withUpdatedStatus;
-        return [...others, ...arrayMove(newColItems, activeIdx, overIdx)];
+        const clientY = getClientYFromPointerEvent(
+          activatorEvent as MouseEvent | TouchEvent | null | undefined,
+          over.rect,
+        );
+        const side = getDropSideFromRect(over.rect, clientY);
+        return [...others, ...getReorderedColumnItems(newColItems, activeId, overId, side)];
       }
     });
   };

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -68,6 +68,17 @@ function getReorderedColumnItems(
   return [...baseItems.slice(0, insertionIdx), activeItem, ...baseItems.slice(insertionIdx)];
 }
 
+function moveItemToColumnEnd(items: BacklogItem[], activeId: string, status: BacklogStatus) {
+  const activeItem = items.find((i) => i.id === activeId);
+  if (!activeItem) return items;
+
+  const updatedItems = items.map((i) => (i.id === activeId ? { ...i, status } : i));
+  const columnItems = updatedItems.filter((i) => i.status === status && i.id !== activeId);
+  const others = updatedItems.filter((i) => i.status !== status);
+
+  return [...others, ...columnItems, { ...activeItem, status }];
+}
+
 export function useBacklogDnd({
   items,
   isMobileLayout,
@@ -136,7 +147,7 @@ export function useBacklogDnd({
         );
 
         if (overId.startsWith("column:")) {
-          return withUpdatedStatus;
+          return moveItemToColumnEnd(prev, activeId, overStatus);
         }
 
         const newColItems = withUpdatedStatus.filter((i) => i.status === overStatus);

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -118,17 +118,16 @@ export function useBacklogDnd({
 
     if (activeId === overId) return;
 
-    const activeStatus = findItemStatus(localItems, activeId);
-    const overStatus = overId.startsWith("column:")
-      ? (overId.replace("column:", "") as BacklogStatus)
-      : findItemStatus(localItems, overId);
-
-    if (!activeStatus || !overStatus) return;
-    if (isMobileLayout && activeStatus !== overStatus) return;
-
     setLocalItems((prev) => {
       const activeItem = prev.find((i) => i.id === activeId);
       if (!activeItem) return prev;
+      const activeStatus = activeItem.status;
+      const overStatus = overId.startsWith("column:")
+        ? (overId.replace("column:", "") as BacklogStatus)
+        : findItemStatus(prev, overId);
+
+      if (!overStatus) return prev;
+      if (isMobileLayout && activeStatus !== overStatus) return prev;
 
       if (activeStatus === overStatus) {
         // 同列内での並び替え

--- a/src/features/backlog/hooks/useBoardPageController.test.tsx
+++ b/src/features/backlog/hooks/useBoardPageController.test.tsx
@@ -29,10 +29,11 @@ vi.mock("./useBacklogItems.ts", () => ({
 vi.mock("./useBacklogDnd.ts", () => ({
   useBacklogDnd: () => ({
     dragItemId: null,
-    dropIndicator: null,
+    localItems: hookMocks.items,
     sensors: [],
     handleDragStart: vi.fn(),
     handleDragOver: vi.fn(),
+    handleDragCancel: vi.fn(),
     handleDragEnd: vi.fn(),
   }),
 }));

--- a/src/features/backlog/hooks/useBoardPageController.ts
+++ b/src/features/backlog/hooks/useBoardPageController.ts
@@ -33,8 +33,10 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
   });
 
   const detailItem = boardPageState.detailModal.openItemId
-    ? (items.find((item) => item.id === boardPageState.detailModal.openItemId) ?? null)
+    ? (dnd.localItems.find((item) => item.id === boardPageState.detailModal.openItemId) ?? null)
     : null;
+
+  const isDragging = dnd.dragItemId !== null;
 
   return {
     isMobileLayout,
@@ -44,10 +46,10 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
     feedback,
     feedbackUi,
     board: {
-      items,
-      dropIndicator: dnd.dropIndicator,
+      items: dnd.localItems,
+      isDragging,
       isMobileLayout,
-      isMobileDragging: isMobileLayout && dnd.dragItemId !== null,
+      isMobileDragging: isMobileLayout && isDragging,
       selectedTabStatus: boardPageState.selectedTabStatus,
       onTabChange: boardPageState.setSelectedTabStatus,
       onOpenAddModal: boardPageState.handleOpenAddModal,
@@ -60,8 +62,10 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
       sensors: dnd.sensors,
       handleDragStart: dnd.handleDragStart,
       handleDragOver: dnd.handleDragOver,
+      handleDragCancel: dnd.handleDragCancel,
       handleDragEnd: dnd.handleDragEnd,
       dragItemId: dnd.dragItemId,
+      localItems: dnd.localItems,
     },
     addModal: {
       isOpen: boardPageState.isAddModalOpen,
@@ -77,7 +81,7 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
       item: detailItem,
       isOpen: boardPageState.detailModal.openItemId !== null,
       state: boardPageState.detailModal,
-      items,
+      items: dnd.localItems,
       onStateChange: boardPageState.setDetailModal,
       onClose: boardPageState.handleCloseDetail,
       onReload: loadItems,

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -56,15 +56,3 @@ export type DetailModalState = {
   draftValue: string;
   message: string | null;
 };
-
-export type DropIndicator =
-  | { type: "card"; itemId: string; side: "before" | "after" }
-  | { type: "column"; status: BacklogStatus }
-  | { type: "top-slot"; status: BacklogStatus }
-  | { type: "bottom-slot"; status: BacklogStatus };
-
-export type ResolvedDropTarget = {
-  status: BacklogStatus;
-  targetItemId: string | null;
-  side: "before" | "after";
-};


### PR DESCRIPTION
## 関連 Issue
Closes #139
Refs #134

## 変更内容
- backlog の DnD を `@dnd-kit/sortable` ベースへ置き換え、`BacklogCard` / `KanbanColumn` / `KanbanBoard` の構成を整理
- `useBacklogDnd` に `localItems` ベースの並び替えとドロップ後同期制御を追加し、スナップバック、列またぎの before/after、非空列背景ドロップ時の末尾挿入を補正
- `BoardPage` / `useBoardPageController` と関連テストを更新し、ドラッグ中オーバーレイと詳細表示がローカル順序に追従するよう調整
- hook / component テストを更新して、同列並び替え、列またぎ、非空列背景ドロップ、同期失敗時の挙動を確認