### PR TITLE
ci: knip チェックを CI に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack install
+
+      - name: Get pnpm store path
+        id: pnpm-cache-dir
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.pnpm-cache-dir.outputs.STORE_PATH }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm --package="vite-plus@${VP_BOOTSTRAP_VERSION}" dlx vp install --frozen-lockfile
+
+      - name: Add local binaries to PATH
+        run: echo "${GITHUB_WORKSPACE}/node_modules/.bin" >> "$GITHUB_PATH"
+
+      - name: Run knip
+        run: vp run knip
+
   check:
     runs-on: ubuntu-latest
 

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,22 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["supabase/functions/*/index.ts"],
+  "entry": ["supabase/functions/*/index.ts", "supabase/functions/**/*_test.ts"],
+  "project": [
+    "src/**/*.{ts,tsx}",
+    "supabase/functions/**/*.ts",
+    "e2e/**/*.ts",
+    "*.config.{js,ts}",
+    "!**/dist/**",
+    "!.claude/worktrees/**"
+  ],
   "ignoreFiles": ["postcss.config.js"],
-  "ignoreDependencies": ["@tailwindcss/postcss", "autoprefixer", "npm"]
+  "ignoreDependencies": [
+    "@tailwindcss/postcss",
+    "autoprefixer",
+    "jsr",
+    "npm",
+    "shadcn",
+    "tailwindcss",
+    "tw-animate-css"
+  ]
 }

--- a/src/lib/omdb.ts
+++ b/src/lib/omdb.ts
@@ -1,6 +1,6 @@
 import { supabase } from "./supabase.ts";
 
-export type OmdbWorkDetails = {
+type OmdbWorkDetails = {
   rottenTomatoesScore: number | null;
   imdbRating: number | null;
   imdbVotes: number | null;

--- a/supabase/functions/_shared/omdb.ts
+++ b/supabase/functions/_shared/omdb.ts
@@ -1,4 +1,4 @@
-export type OmdbApiResponse = {
+type OmdbApiResponse = {
   Response: string;
   Error?: string;
   Ratings?: Array<{
@@ -23,27 +23,27 @@ function getOmdbApiKey(): string {
   return apiKey;
 }
 
-export function parseRottenTomatoesScore(value: string): number | null {
+function parseRottenTomatoesScore(value: string): number | null {
   const match = value.match(/^(\d+)%$/);
   if (!match) return null;
   const score = Number.parseInt(match[1], 10);
   return score >= 0 && score <= 100 ? score : null;
 }
 
-export function parseImdbRating(value: string): number | null {
+function parseImdbRating(value: string): number | null {
   const match = value.match(/^(\d+(?:\.\d+)?)\/10$/);
   if (!match) return null;
   const rating = Number.parseFloat(match[1]);
   return rating >= 0 && rating <= 10 ? rating : null;
 }
 
-export function parseImdbVotes(value: string): number | null {
+function parseImdbVotes(value: string): number | null {
   const cleaned = value.replace(/,/g, "");
   const votes = Number.parseInt(cleaned, 10);
   return Number.isNaN(votes) ? null : votes;
 }
 
-export function parseMetacriticScore(value: string): number | null {
+function parseMetacriticScore(value: string): number | null {
   const match = value.match(/^(\d+)\/100$/);
   if (!match) return null;
   const score = Number.parseInt(match[1], 10);

--- a/supabase/functions/_shared/tmdb.ts
+++ b/supabase/functions/_shared/tmdb.ts
@@ -556,7 +556,7 @@ function normalizeCachedOmdbWorkDetails(payload: unknown): OmdbWorkDetails | nul
   };
 }
 
-export type ImdbIdLookupResult =
+type ImdbIdLookupResult =
   | { kind: "found"; imdbId: string }
   | { kind: "missing" }
   | { kind: "unavailable" };


### PR DESCRIPTION
## 関連 Issue

Closes #162

## 変更内容

- CI に `vp run knip` を実行する `knip` job を追加
- `knip.json` を見直し、Supabase Functions の Deno テストを entry に含めつつ、解析対象をリポジトリ本体に限定
- ツールチェーン経由で使う依存のみ `ignoreDependencies` に整理
- `knip` が検出した未使用 export のうち、実際に公開不要な型・helper を内部化
