### PR TITLE
fix: refactoring backlog の出力ノイズを削減

### DIFF
--- a/.github/scripts/refactoring-backlog.ts
+++ b/.github/scripts/refactoring-backlog.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import {
   buildRefactoringBacklogIssue,
+  filterBacklogSignals,
   normalizeComponentPath,
   parseMeasureValue,
   parseMinutes,
@@ -86,9 +87,10 @@ async function main() {
     }).format(new Date()) + " UTC";
 
   const quickWinIssues = selectQuickWinIssues(issues);
-  const longFiles = rankLongFiles(fileSignals);
-  const complexFiles = rankComplexFiles(fileSignals);
-  const duplicateFiles = rankDuplicateFiles(fileSignals);
+  const filteredFileSignals = filterBacklogSignals(fileSignals);
+  const longFiles = rankLongFiles(filteredFileSignals);
+  const complexFiles = rankComplexFiles(filteredFileSignals);
+  const duplicateFiles = rankDuplicateFiles(filteredFileSignals);
   const issue = buildRefactoringBacklogIssue({
     projectKey,
     observedAt,

--- a/.github/workflows/refactoring-backlog.yml
+++ b/.github/workflows/refactoring-backlog.yml
@@ -76,6 +76,7 @@ jobs:
 
           issue_number=$(
             gh issue list \
+              --label "$REFACTORING_BACKLOG_LABEL" \
               --state open \
               --limit 100 \
               --json number,title,body \

--- a/.github/workflows/refactoring-backlog.yml
+++ b/.github/workflows/refactoring-backlog.yml
@@ -9,6 +9,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   VP_BOOTSTRAP_VERSION: 0.1.14
   REFACTORING_BACKLOG_LABEL: refactoring-backlog
+  REFACTORING_BACKLOG_MARKER: <!-- refactoring-backlog:sonarcloud -->
+  REFACTORING_BACKLOG_TITLE: refactoring backlog
   REFACTORING_BACKLOG_OUTPUT_DIR: artifacts/refactoring-backlog
   SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
   SONAR_BRANCH: main
@@ -72,20 +74,21 @@ jobs:
             --color "0969da" \
             || true
 
-          issue_number=$(gh issue list \
-            --label "$REFACTORING_BACKLOG_LABEL" \
-            --state open \
-            --limit 100 \
-            --json number,title,body \
-            --jq 'map(select(.body | contains("<!-- refactoring-backlog:sonarcloud -->")) | .number) | first')
+          issue_number=$(
+            gh issue list \
+              --state open \
+              --limit 100 \
+              --json number,title,body \
+              --jq 'map(select(.body | contains(env.REFACTORING_BACKLOG_MARKER))) | first | .number // empty'
+          )
 
-          if [[ -n "${issue_number}" && "${issue_number}" != "null" ]]; then
+          if [[ -n "${issue_number}" ]]; then
             gh issue edit "$issue_number" \
-              --title "$(cat "$REFACTORING_BACKLOG_OUTPUT_DIR/title.txt")" \
+              --title "$REFACTORING_BACKLOG_TITLE" \
               --body-file "$REFACTORING_BACKLOG_OUTPUT_DIR/body.md"
           else
             gh issue create \
-              --title "$(cat "$REFACTORING_BACKLOG_OUTPUT_DIR/title.txt")" \
+              --title "$REFACTORING_BACKLOG_TITLE" \
               --body-file "$REFACTORING_BACKLOG_OUTPUT_DIR/body.md" \
               --label "$REFACTORING_BACKLOG_LABEL"
           fi

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -181,7 +181,7 @@ describe("buildRefactoringBacklogIssue", () => {
         },
         {
           key: "issue-3",
-          message: "'/tmp/clone123/src/lib/example.ts' imported multiple times.",
+          message: "'/opt/clone123/src/lib/example.ts' imported multiple times.",
           component: "mirukan:src/lib/consumer.ts",
           line: 7,
           rule: "typescript:S3863",
@@ -204,7 +204,7 @@ describe("buildRefactoringBacklogIssue", () => {
     expect(result.body).toContain(
       "- 'src/lib/example.ts' imported multiple times. - 1件 (最短 1 min)",
     );
-    expect(result.body).not.toContain("/tmp/clone123");
+    expect(result.body).not.toContain("/opt/clone123");
     expect(result.body).toContain("| `src/lib/example.ts` | 6.5% | 520 lines |");
   });
 });

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -1,5 +1,6 @@
 import {
   buildRefactoringBacklogIssue,
+  filterBacklogSignals,
   normalizeComponentPath,
   parseMeasureValue,
   parseMinutes,
@@ -94,6 +95,22 @@ describe("signal ranking", () => {
       { path: "src/c.ts", value: 3.4, detail: "410 lines" },
     ]);
   });
+
+  test("backlog 出力時だけ除外パターンに一致するファイルを落とす", () => {
+    expect(
+      filterBacklogSignals([
+        ...files,
+        {
+          path: "pnpm-lock.yaml",
+          measures: { ncloc: 999 },
+        },
+        {
+          path: "supabase/templates/confirmation.html",
+          measures: { duplicated_lines_density: 88 },
+        },
+      ]),
+    ).toEqual(files);
+  });
 });
 
 describe("selectQuickWinIssues", () => {
@@ -108,6 +125,21 @@ describe("selectQuickWinIssues", () => {
       { key: "2", message: "B", component: "mirukan:src/b.ts", effortMinutes: 10 },
       { key: "1", message: "A", component: "mirukan:src/a.ts", effortMinutes: 45 },
       { key: "3", message: "C", component: "mirukan:src/c.ts" },
+    ]);
+  });
+
+  test("limit 境界と同じ effort の issue は集約用に残す", () => {
+    const issues = [
+      { key: "1", message: "A", component: "mirukan:src/a.ts", effortMinutes: 1 },
+      { key: "2", message: "A", component: "mirukan:src/b.ts", effortMinutes: 1 },
+      { key: "3", message: "B", component: "mirukan:src/c.ts", effortMinutes: 1 },
+      { key: "4", message: "C", component: "mirukan:src/d.ts", effortMinutes: 5 },
+    ];
+
+    expect(selectQuickWinIssues(issues, 2)).toEqual([
+      { key: "1", message: "A", component: "mirukan:src/a.ts", effortMinutes: 1 },
+      { key: "2", message: "A", component: "mirukan:src/b.ts", effortMinutes: 1 },
+      { key: "3", message: "B", component: "mirukan:src/c.ts", effortMinutes: 1 },
     ]);
   });
 });
@@ -131,10 +163,29 @@ describe("buildRefactoringBacklogIssue", () => {
       quickWinIssues: [
         {
           key: "issue-1",
-          message: "Extract duplicated branch",
+          message:
+            "This assertion is unnecessary since it does not change the type of the expression.",
           component: "mirukan:src/lib/example.ts",
           line: 42,
-          effortMinutes: 15,
+          rule: "typescript:S4325",
+          effortMinutes: 1,
+        },
+        {
+          key: "issue-2",
+          message:
+            "This assertion is unnecessary since it does not change the type of the expression.",
+          component: "mirukan:src/lib/example.test.ts",
+          line: 18,
+          rule: "typescript:S4325",
+          effortMinutes: 1,
+        },
+        {
+          key: "issue-3",
+          message: "'/tmp/clone123/src/lib/example.ts' imported multiple times.",
+          component: "mirukan:src/lib/consumer.ts",
+          line: 7,
+          rule: "typescript:S3863",
+          effortMinutes: 1,
         },
       ],
       longFiles: [{ path: "src/lib/example.ts", value: 520, detail: "8 code smells" }],
@@ -145,7 +196,15 @@ describe("buildRefactoringBacklogIssue", () => {
     expect(result.title).toBe("refactoring backlog");
     expect(result.body).toContain("<!-- refactoring-backlog:sonarcloud -->");
     expect(result.body).toContain("maintainability debt: 2 h 15 min");
-    expect(result.body).toContain("Extract duplicated branch");
+    expect(result.body).toContain(
+      "- This assertion is unnecessary since it does not change the type of the expression. - 2件 (最短 1 min)",
+    );
+    expect(result.body).toContain("  - 例: [src/lib/example.ts:42]");
+    expect(result.body).toContain("  - 例: [src/lib/example.test.ts:18]");
+    expect(result.body).toContain(
+      "- 'src/lib/example.ts' imported multiple times. - 1件 (最短 1 min)",
+    );
+    expect(result.body).not.toContain("/tmp/clone123");
     expect(result.body).toContain("| `src/lib/example.ts` | 6.5% | 520 lines |");
   });
 });

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -1,4 +1,6 @@
 const REFACTORING_BACKLOG_MARKER = "<!-- refactoring-backlog:sonarcloud -->";
+const DEFAULT_BACKLOG_EXCLUDE_PATTERNS = ["pnpm-lock.yaml", "supabase/templates/**"] as const;
+const REPO_PATH_SEGMENTS = ["src/", "supabase/", ".github/", "docs/", "public/"] as const;
 
 export type SonarMeasureKey =
   | "code_smells"
@@ -29,6 +31,14 @@ type RankedSignal = {
   path: string;
   value: number;
   detail: string;
+};
+
+type QuickWinGroup = {
+  key: string;
+  label: string;
+  count: number;
+  examples: SonarIssue[];
+  minEffortMinutes?: number;
 };
 
 type RefactoringBacklogInput = {
@@ -111,6 +121,13 @@ export function normalizeComponentPath(component: string, projectKey: string): s
   return component.startsWith(prefix) ? component.slice(prefix.length) : component;
 }
 
+export function filterBacklogSignals(
+  files: SonarFileSignal[],
+  excludePatterns: readonly string[] = DEFAULT_BACKLOG_EXCLUDE_PATTERNS,
+) {
+  return files.filter((file) => !matchesAnyPattern(file.path, excludePatterns));
+}
+
 export function rankLongFiles(files: SonarFileSignal[], limit = 5): RankedSignal[] {
   return files
     .map((file) => ({
@@ -152,13 +169,24 @@ export function rankDuplicateFiles(files: SonarFileSignal[], limit = 5): RankedS
 }
 
 export function selectQuickWinIssues(issues: SonarIssue[], limit = 7): SonarIssue[] {
-  return [...issues]
-    .sort((left, right) => {
-      const leftEffort = left.effortMinutes ?? Number.POSITIVE_INFINITY;
-      const rightEffort = right.effortMinutes ?? Number.POSITIVE_INFINITY;
-      return leftEffort - rightEffort || left.component.localeCompare(right.component);
-    })
-    .slice(0, limit);
+  const sorted = [...issues].sort((left, right) => {
+    const leftEffort = left.effortMinutes ?? Number.POSITIVE_INFINITY;
+    const rightEffort = right.effortMinutes ?? Number.POSITIVE_INFINITY;
+    return leftEffort - rightEffort || left.component.localeCompare(right.component);
+  });
+
+  if (sorted.length <= limit) {
+    return sorted;
+  }
+
+  const cutoffEffort = sorted[limit - 1]?.effortMinutes;
+  if (cutoffEffort == null) {
+    return sorted.slice(0, limit);
+  }
+
+  return sorted.filter(
+    (issue) => (issue.effortMinutes ?? Number.POSITIVE_INFINITY) <= cutoffEffort,
+  );
 }
 
 export function buildRefactoringBacklogIssue({
@@ -235,12 +263,20 @@ function renderQuickWinIssues(projectKey: string, sonarBaseUrl: string, issues: 
     return ["- 今回は quick win 候補なし"];
   }
 
-  return issues.map((issue) => {
-    const path = normalizeComponentPath(issue.component, projectKey);
-    const effort = issue.effortMinutes ? `${issue.effortMinutes} min` : "effort unknown";
-    const line = issue.line ? `:${issue.line}` : "";
-    const issueUrl = `${trimTrailingSlash(sonarBaseUrl)}/project/issues?id=${encodeURIComponent(projectKey)}&open=${encodeURIComponent(issue.key)}`;
-    return `- [${path}${line}](${issueUrl}) - ${issue.message} (${effort})`;
+  return groupQuickWinIssues(issues, projectKey).flatMap((group) => {
+    const effortLabel = group.minEffortMinutes
+      ? `最短 ${group.minEffortMinutes} min`
+      : "effort unknown";
+    const lines = [`- ${group.label} - ${formatNumber(group.count)}件 (${effortLabel})`];
+
+    for (const example of group.examples) {
+      const path = toDisplayPath(normalizeComponentPath(example.component, projectKey));
+      const line = example.line ? `:${example.line}` : "";
+      const issueUrl = `${trimTrailingSlash(sonarBaseUrl)}/project/issues?id=${encodeURIComponent(projectKey)}&open=${encodeURIComponent(example.key)}`;
+      lines.push(`  - 例: [${path}${line}](${issueUrl})`);
+    }
+
+    return lines;
   });
 }
 
@@ -253,7 +289,8 @@ function renderRankedSignals(rows: RankedSignal[], valueLabel: string, detailLab
     `| file | ${valueLabel} | ${detailLabel} |`,
     "| --- | ---: | --- |",
     ...rows.map(
-      (row) => `| \`${row.path}\` | ${formatRankValue(valueLabel, row.value)} | ${row.detail} |`,
+      (row) =>
+        `| \`${toDisplayPath(row.path)}\` | ${formatRankValue(valueLabel, row.value)} | ${row.detail} |`,
     ),
   ];
 }
@@ -299,4 +336,105 @@ function formatNumber(value: number | undefined) {
 
 function trimTrailingSlash(value: string) {
   return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function groupQuickWinIssues(issues: SonarIssue[], projectKey: string): QuickWinGroup[] {
+  const grouped = new Map<string, QuickWinGroup>();
+
+  for (const issue of issues) {
+    const label = sanitizeQuickWinLabel(issue.message);
+    const key = issue.rule ? `${issue.rule}::${label}` : label;
+    const current = grouped.get(key);
+
+    if (current) {
+      current.count += 1;
+      current.minEffortMinutes = minDefined(current.minEffortMinutes, issue.effortMinutes);
+      if (current.examples.length < 3) {
+        current.examples.push(issue);
+      }
+      continue;
+    }
+
+    grouped.set(key, {
+      key,
+      label,
+      count: 1,
+      examples: [issue],
+      minEffortMinutes: issue.effortMinutes,
+    });
+  }
+
+  return [...grouped.values()].sort((left, right) => {
+    const leftEffort = left.minEffortMinutes ?? Number.POSITIVE_INFINITY;
+    const rightEffort = right.minEffortMinutes ?? Number.POSITIVE_INFINITY;
+    const leftExamplePath = normalizeComponentPath(left.examples[0]!.component, projectKey);
+    const rightExamplePath = normalizeComponentPath(right.examples[0]!.component, projectKey);
+
+    return (
+      leftEffort - rightEffort ||
+      right.count - left.count ||
+      leftExamplePath.localeCompare(rightExamplePath) ||
+      left.key.localeCompare(right.key)
+    );
+  });
+}
+
+function sanitizeQuickWinLabel(message: string) {
+  return sanitizeAbsolutePaths(message);
+}
+
+function matchesAnyPattern(path: string, patterns: readonly string[]) {
+  return patterns.some((pattern) => matchesGlobPattern(path, pattern));
+}
+
+function matchesGlobPattern(path: string, pattern: string) {
+  const normalizedPath = normalizePathForMatch(path);
+  const normalizedPattern = normalizePathForMatch(pattern);
+  const source = normalizedPattern
+    .replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+    .replace(/\*\*/g, "__DOUBLE_STAR__")
+    .replace(/\*/g, "[^/]*")
+    .replace(/__DOUBLE_STAR__/g, ".*");
+  return new RegExp(`^${source}$`).test(normalizedPath);
+}
+
+function normalizePathForMatch(value: string) {
+  return value.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function sanitizeAbsolutePaths(value: string) {
+  return value.replace(/\/[^"'`\s)]+/g, (token) => toDisplayPath(token));
+}
+
+function toDisplayPath(value: string) {
+  const normalized = normalizePathForMatch(value);
+  if (!normalized.startsWith("/")) {
+    return normalized;
+  }
+
+  for (const segment of REPO_PATH_SEGMENTS) {
+    const marker = `/${segment}`;
+    const index = normalized.lastIndexOf(marker);
+    if (index >= 0) {
+      return normalized.slice(index + 1);
+    }
+  }
+
+  if (normalized.endsWith("/pnpm-lock.yaml")) {
+    return "pnpm-lock.yaml";
+  }
+
+  return normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+}
+
+function minDefined(left: number | undefined, right: number | undefined) {
+  if (left == null) {
+    return right;
+  }
+
+  if (right == null) {
+    return left;
+  }
+
+  return Math.min(left, right);
 }

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -367,8 +367,8 @@ function groupQuickWinIssues(issues: SonarIssue[], projectKey: string): QuickWin
   return [...grouped.values()].sort((left, right) => {
     const leftEffort = left.minEffortMinutes ?? Number.POSITIVE_INFINITY;
     const rightEffort = right.minEffortMinutes ?? Number.POSITIVE_INFINITY;
-    const leftExamplePath = normalizeComponentPath(left.examples[0]!.component, projectKey);
-    const rightExamplePath = normalizeComponentPath(right.examples[0]!.component, projectKey);
+    const leftExamplePath = normalizeComponentPath(left.examples[0]?.component ?? "", projectKey);
+    const rightExamplePath = normalizeComponentPath(right.examples[0]?.component ?? "", projectKey);
 
     return (
       leftEffort - rightEffort ||
@@ -391,10 +391,10 @@ function matchesGlobPattern(path: string, pattern: string) {
   const normalizedPath = normalizePathForMatch(path);
   const normalizedPattern = normalizePathForMatch(pattern);
   const source = normalizedPattern
-    .replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
-    .replace(/\*\*/g, "__DOUBLE_STAR__")
-    .replace(/\*/g, "[^/]*")
-    .replace(/__DOUBLE_STAR__/g, ".*");
+    .replaceAll(/[|\\{}()[\]^$+?.]/g, String.raw`\$&`)
+    .replaceAll(/\*\*/g, "__DOUBLE_STAR__")
+    .replaceAll(/\*/g, "[^/]*")
+    .replaceAll(/__DOUBLE_STAR__/g, ".*");
   return new RegExp(`^${source}$`).test(normalizedPath);
 }
 
@@ -403,7 +403,7 @@ function normalizePathForMatch(value: string) {
 }
 
 function sanitizeAbsolutePaths(value: string) {
-  return value.replace(/\/[^"'`\s)]+/g, (token) => toDisplayPath(token));
+  return value.replaceAll(/\/[^"'`\s)]+/g, (token) => toDisplayPath(token));
 }
 
 function toDisplayPath(value: string) {
@@ -424,7 +424,7 @@ function toDisplayPath(value: string) {
     return "pnpm-lock.yaml";
   }
 
-  return normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+  return normalized.split("/").findLast(Boolean) ?? normalized;
 }
 
 function minDefined(left: number | undefined, right: number | undefined) {


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- refactoring backlog の本文生成時だけ適用する除外リストを追加し、`pnpm-lock.yaml` と `supabase/templates/**` を構造改善セクションから除外
- `すぐ直す` を rule / message 単位で集約し、件数と代表例リンクを表示する形式に変更
- 一時ディレクトリの絶対パスを repo 相対パスに正規化し、workflow 側の marker ベース update/create ロジックを明確化

## 検証

- `vp test src/lib/refactoring-backlog.test.ts`