### PR TITLE
fix: 本番ビルドのチャンク警告を解消

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { getSession, onAuthStateChange } from "./lib/auth-repository.ts";
 import { LoginPage } from "./features/backlog/components/LoginPage.tsx";
-import { BoardPage } from "./features/backlog/components/BoardPage.tsx";
-import { ResetPasswordPage } from "./features/backlog/components/ResetPasswordPage.tsx";
 import { PrivacyPolicyPage } from "./features/backlog/components/PrivacyPolicyPage.tsx";
 import { TermsOfServicePage } from "./features/backlog/components/TermsOfServicePage.tsx";
+
+const BoardPage = lazy(async () => ({
+  default: (await import("./features/backlog/components/BoardPage.tsx")).BoardPage,
+}));
+
+const ResetPasswordPage = lazy(async () => ({
+  default: (await import("./features/backlog/components/ResetPasswordPage.tsx")).ResetPasswordPage,
+}));
 
 function isPasswordRecoveryLocation(location: Pick<Location, "hash" | "search">) {
   const searchParams = new URLSearchParams(location.search);
@@ -99,14 +105,22 @@ function AuthenticatedApp() {
   }
 
   if (isPasswordRecovery && session) {
-    return <ResetPasswordPage />;
+    return (
+      <Suspense fallback={<LoginPage isSessionLoading />}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
   }
 
   if (!session) {
     return <LoginPage />;
   }
 
-  return <BoardPage session={session} />;
+  return (
+    <Suspense fallback={<LoginPage isSessionLoading />}>
+      <BoardPage session={session} />
+    </Suspense>
+  );
 }
 
 export function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,21 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
+import { Button } from "@/components/ui/button.tsx";
+import { LazyViewBoundary } from "./components/LazyViewBoundary.tsx";
 import { getSession, onAuthStateChange } from "./lib/auth-repository.ts";
+import { lazyNamed } from "./lib/lazy-component.ts";
 import { LoginPage } from "./features/backlog/components/LoginPage.tsx";
 import { PrivacyPolicyPage } from "./features/backlog/components/PrivacyPolicyPage.tsx";
 import { TermsOfServicePage } from "./features/backlog/components/TermsOfServicePage.tsx";
 
-const BoardPage = lazy(async () => ({
-  default: (await import("./features/backlog/components/BoardPage.tsx")).BoardPage,
-}));
-
-const ResetPasswordPage = lazy(async () => ({
-  default: (await import("./features/backlog/components/ResetPasswordPage.tsx")).ResetPasswordPage,
-}));
+const BoardPage = lazyNamed(
+  () => import("./features/backlog/components/BoardPage.tsx"),
+  "BoardPage",
+);
+const ResetPasswordPage = lazyNamed(
+  () => import("./features/backlog/components/ResetPasswordPage.tsx"),
+  "ResetPasswordPage",
+);
 
 function isPasswordRecoveryLocation(location: Pick<Location, "hash" | "search">) {
   const searchParams = new URLSearchParams(location.search);
@@ -63,6 +67,30 @@ function clearPasswordRecoveryLocation() {
   }
 }
 
+function LazyRouteErrorFallback() {
+  return (
+    <main className="min-h-svh px-4 py-10 grid place-items-center bg-background">
+      <section className="w-full max-w-[520px] rounded-[28px] border border-border bg-card px-6 py-7 shadow-[0_24px_60px_rgba(0,0,0,0.24)]">
+        <div className="grid gap-3">
+          <h1 className="text-[1.5rem] leading-tight text-foreground">
+            画面の読み込みに失敗しました。
+          </h1>
+          <p className="text-sm leading-6 text-muted-foreground">
+            デプロイ直後の更新や通信エラーで必要なコードを取得できませんでした。再読み込みしてもう一度お試しください。
+          </p>
+          <Button
+            type="button"
+            className="w-full sm:w-auto"
+            onClick={() => window.location.reload()}
+          >
+            再読み込み
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}
+
 function AuthenticatedApp() {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
   const [isPasswordRecovery, setIsPasswordRecovery] = useState(() =>
@@ -106,9 +134,13 @@ function AuthenticatedApp() {
 
   if (isPasswordRecovery && session) {
     return (
-      <Suspense fallback={<LoginPage isSessionLoading />}>
+      <LazyViewBoundary
+        loadingFallback={<LoginPage isSessionLoading />}
+        errorFallback={<LazyRouteErrorFallback />}
+        resetKey="password-recovery"
+      >
         <ResetPasswordPage />
-      </Suspense>
+      </LazyViewBoundary>
     );
   }
 
@@ -117,9 +149,13 @@ function AuthenticatedApp() {
   }
 
   return (
-    <Suspense fallback={<LoginPage isSessionLoading />}>
+    <LazyViewBoundary
+      loadingFallback={<LoginPage isSessionLoading />}
+      errorFallback={<LazyRouteErrorFallback />}
+      resetKey="board"
+    >
       <BoardPage session={session} />
-    </Suspense>
+    </LazyViewBoundary>
   );
 }
 

--- a/src/components/LazyViewBoundary.test.tsx
+++ b/src/components/LazyViewBoundary.test.tsx
@@ -1,0 +1,42 @@
+import { lazy } from "react";
+import { render, screen } from "@testing-library/react";
+import { setupTestLifecycle } from "../test/test-lifecycle.ts";
+import { LazyViewBoundary } from "./LazyViewBoundary.tsx";
+
+setupTestLifecycle();
+
+describe("LazyViewBoundary", () => {
+  test("lazy component の読み込み中は loading fallback を表示する", async () => {
+    const DeferredView = lazy(
+      () =>
+        new Promise<{
+          default: () => React.JSX.Element;
+        }>(() => {}),
+    );
+
+    render(
+      <LazyViewBoundary loadingFallback={<div>LOADING</div>}>
+        <DeferredView />
+      </LazyViewBoundary>,
+    );
+
+    expect(screen.getByText("LOADING")).toBeInTheDocument();
+  });
+
+  test("描画エラー時は error fallback を表示する", () => {
+    const ThrowingView = () => {
+      throw new Error("boom");
+    };
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <LazyViewBoundary loadingFallback={<div>LOADING</div>} errorFallback={<div>ERROR</div>}>
+        <ThrowingView />
+      </LazyViewBoundary>,
+    );
+
+    expect(screen.getByText("ERROR")).toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/components/LazyViewBoundary.tsx
+++ b/src/components/LazyViewBoundary.tsx
@@ -1,0 +1,57 @@
+import { Component, Suspense, type ReactNode } from "react";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  errorFallback: ReactNode;
+  resetKey?: string;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+class LazyErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("遅延読み込みに失敗しました", error);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.errorFallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+type Props = {
+  children: ReactNode;
+  loadingFallback: ReactNode;
+  errorFallback?: ReactNode;
+  resetKey?: string;
+};
+
+export function LazyViewBoundary({
+  children,
+  loadingFallback,
+  errorFallback = loadingFallback,
+  resetKey,
+}: Props) {
+  return (
+    <LazyErrorBoundary errorFallback={errorFallback} resetKey={resetKey}>
+      <Suspense fallback={loadingFallback}>{children}</Suspense>
+    </LazyErrorBoundary>
+  );
+}

--- a/src/features/backlog/components/BoardPage.test.tsx
+++ b/src/features/backlog/components/BoardPage.test.tsx
@@ -233,7 +233,7 @@ describe("BoardPage", () => {
     expect(screen.getByText("selected-tab:watching")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "追加モーダルを開く" }));
-    await user.click(screen.getByRole("button", { name: "追加完了" }));
+    await user.click(await screen.findByRole("button", { name: "追加完了" }));
 
     expect(screen.getByText("selected-tab:stacked")).toBeInTheDocument();
     deferred.resolve(undefined);
@@ -248,7 +248,7 @@ describe("BoardPage", () => {
     renderBoardPage();
 
     await user.click(screen.getByRole("button", { name: "追加モーダルを開く" }));
-    await user.click(screen.getByRole("button", { name: "追加完了" }));
+    await user.click(await screen.findByRole("button", { name: "追加完了" }));
 
     expect(scrollIntoViewSpy).toHaveBeenCalledWith({
       behavior: "smooth",
@@ -264,7 +264,7 @@ describe("BoardPage", () => {
     renderBoardPage();
 
     await user.click(screen.getByRole("button", { name: "詳細を開く" }));
-    expect(screen.getByText("detail-modal:item-1")).toBeInTheDocument();
+    expect(await screen.findByText("detail-modal:item-1")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "item-1 を削除" }));
 

--- a/src/features/backlog/components/BoardPage.tsx
+++ b/src/features/backlog/components/BoardPage.tsx
@@ -1,20 +1,17 @@
-import { lazy, Suspense } from "react";
 import type { Session } from "@supabase/supabase-js";
+import type { ReactNode } from "react";
 import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
 import { Button } from "@/components/ui/button.tsx";
+import { LazyViewBoundary } from "@/components/LazyViewBoundary.tsx";
 import { signOut } from "../../../lib/auth-repository.ts";
+import { lazyNamed } from "../../../lib/lazy-component.ts";
 import { useBoardPageController } from "../hooks/useBoardPageController.ts";
 import { Header } from "./Header.tsx";
 import { KanbanBoard } from "./KanbanBoard.tsx";
 import { DraggedBacklogCardOverlay } from "./DraggedBacklogCardOverlay.tsx";
 
-const AddModal = lazy(async () => ({
-  default: (await import("./AddModal.tsx")).AddModal,
-}));
-
-const DetailModal = lazy(async () => ({
-  default: (await import("./DetailModal.tsx")).DetailModal,
-}));
+const AddModal = lazyNamed(() => import("./AddModal.tsx"), "AddModal");
+const DetailModal = lazyNamed(() => import("./DetailModal.tsx"), "DetailModal");
 
 type Props = { session: Session };
 
@@ -24,6 +21,77 @@ const shellBoard = `${shellBase} grid grid-rows-[auto_minmax(0,1fr)] h-svh overf
 const shellSimple = `${shellBase} pt-[14px] pb-3 max-[720px]:py-[10px] max-[500px]:py-2 max-[400px]:py-1.5`;
 const headerCard =
   "w-full min-w-0 border border-border bg-[rgba(28,28,28,0.95)] backdrop-blur-xl shadow-[0_24px_60px_rgba(0,0,0,0.5)] grid grid-cols-[minmax(0,1fr)_auto] gap-4 items-center px-[18px] py-[14px] rounded-[28px] relative z-10 max-[720px]:rounded-[22px] max-[720px]:p-4";
+const modalBackdrop =
+  "fixed inset-0 z-10 grid place-items-center p-5 bg-[rgba(51,34,23,0.4)] backdrop-blur-[10px]";
+const modalCard =
+  "w-[min(calc(100%_-_48px),520px)] rounded-[28px] border border-border bg-[#2a2a2a] shadow-[0_24px_60px_rgba(0,0,0,0.5)] p-6 grid gap-3 max-[720px]:w-full max-[720px]:max-w-[560px] max-[720px]:p-5 max-[720px]:rounded-[22px]";
+
+type ModalBoundaryProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  loadingTitle: string;
+  errorTitle: string;
+  children: ReactNode;
+};
+
+function ModalFallback({
+  title,
+  description,
+  onClose,
+}: {
+  title: string;
+  description: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className={modalBackdrop}>
+      <section className={modalCard} role="dialog" aria-modal="true" aria-label={title}>
+        <div className="grid gap-2">
+          <h2 className="text-[1.2rem] leading-tight text-foreground">{title}</h2>
+          <p className="text-sm leading-6 text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex justify-end">
+          <Button type="button" variant="outline" className="rounded-full" onClick={onClose}>
+            閉じる
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function LazyModalBoundary({
+  isOpen,
+  onClose,
+  loadingTitle,
+  errorTitle,
+  children,
+}: ModalBoundaryProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <LazyViewBoundary
+      loadingFallback={
+        <ModalFallback
+          title={loadingTitle}
+          description="必要な画面を読み込んでいます。"
+          onClose={onClose}
+        />
+      }
+      errorFallback={
+        <ModalFallback
+          title={errorTitle}
+          description="通信状況を確認してから、もう一度お試しください。"
+          onClose={onClose}
+        />
+      }
+    >
+      {children}
+    </LazyViewBoundary>
+  );
+}
 
 export function BoardPage({ session }: Props) {
   const { isLoading, error, board, dnd, addModal, detailModal, feedbackUi } =
@@ -76,29 +144,35 @@ export function BoardPage({ session }: Props) {
         </DragOverlay>
       </DndContext>
 
-      {addModal.isOpen && (
-        <Suspense fallback={null}>
-          <AddModal
-            items={addModal.items}
-            session={addModal.session}
-            onClose={addModal.onClose}
-            onAdded={addModal.onAdded}
-          />
-        </Suspense>
-      )}
+      <LazyModalBoundary
+        isOpen={addModal.isOpen}
+        onClose={addModal.onClose}
+        loadingTitle="作品追加の画面を開いています。"
+        errorTitle="作品追加の画面を開けませんでした。"
+      >
+        <AddModal
+          items={addModal.items}
+          session={addModal.session}
+          onClose={addModal.onClose}
+          onAdded={addModal.onAdded}
+        />
+      </LazyModalBoundary>
 
-      {detailModal.isOpen && (
-        <Suspense fallback={null}>
-          <DetailModal
-            item={detailModal.item}
-            state={detailModal.state}
-            items={detailModal.items}
-            onStateChange={detailModal.onStateChange}
-            onClose={detailModal.onClose}
-            onReload={detailModal.onReload}
-          />
-        </Suspense>
-      )}
+      <LazyModalBoundary
+        isOpen={detailModal.isOpen}
+        onClose={detailModal.onClose}
+        loadingTitle="作品詳細の画面を開いています。"
+        errorTitle="作品詳細の画面を開けませんでした。"
+      >
+        <DetailModal
+          item={detailModal.item}
+          state={detailModal.state}
+          items={detailModal.items}
+          onStateChange={detailModal.onStateChange}
+          onClose={detailModal.onClose}
+          onReload={detailModal.onReload}
+        />
+      </LazyModalBoundary>
 
       {feedbackUi}
     </main>

--- a/src/features/backlog/components/BoardPage.tsx
+++ b/src/features/backlog/components/BoardPage.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { DndContext, DragOverlay, pointerWithin } from "@dnd-kit/core";
 import { Button } from "@/components/ui/button.tsx";
@@ -5,9 +6,15 @@ import { signOut } from "../../../lib/auth-repository.ts";
 import { useBoardPageController } from "../hooks/useBoardPageController.ts";
 import { Header } from "./Header.tsx";
 import { KanbanBoard } from "./KanbanBoard.tsx";
-import { AddModal } from "./AddModal.tsx";
-import { DetailModal } from "./DetailModal.tsx";
 import { DraggedBacklogCardOverlay } from "./DraggedBacklogCardOverlay.tsx";
+
+const AddModal = lazy(async () => ({
+  default: (await import("./AddModal.tsx")).AddModal,
+}));
+
+const DetailModal = lazy(async () => ({
+  default: (await import("./DetailModal.tsx")).DetailModal,
+}));
 
 type Props = { session: Session };
 
@@ -70,23 +77,27 @@ export function BoardPage({ session }: Props) {
       </DndContext>
 
       {addModal.isOpen && (
-        <AddModal
-          items={addModal.items}
-          session={addModal.session}
-          onClose={addModal.onClose}
-          onAdded={addModal.onAdded}
-        />
+        <Suspense fallback={null}>
+          <AddModal
+            items={addModal.items}
+            session={addModal.session}
+            onClose={addModal.onClose}
+            onAdded={addModal.onAdded}
+          />
+        </Suspense>
       )}
 
       {detailModal.isOpen && (
-        <DetailModal
-          item={detailModal.item}
-          state={detailModal.state}
-          items={detailModal.items}
-          onStateChange={detailModal.onStateChange}
-          onClose={detailModal.onClose}
-          onReload={detailModal.onReload}
-        />
+        <Suspense fallback={null}>
+          <DetailModal
+            item={detailModal.item}
+            state={detailModal.state}
+            items={detailModal.items}
+            onStateChange={detailModal.onStateChange}
+            onClose={detailModal.onClose}
+            onReload={detailModal.onReload}
+          />
+        </Suspense>
       )}
 
       {feedbackUi}

--- a/src/features/backlog/components/UserMenu.test.tsx
+++ b/src/features/backlog/components/UserMenu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import { UserMenu } from "./UserMenu.tsx";
@@ -34,7 +34,7 @@ describe("UserMenu", () => {
     await user.keyboard("{Enter}");
     await user.click(await screen.findByRole("menuitem", { name: "About" }));
 
-    expect(screen.getByRole("dialog", { name: "みるカンについて" })).toBeInTheDocument();
+    expect(await screen.findByRole("dialog", { name: "みるカンについて" })).toBeInTheDocument();
     expect(
       screen.getByText(
         "みるカンは、積んだ映画やシリーズから次に見る一本を決めるための映像作品バックログです。",
@@ -58,7 +58,9 @@ describe("UserMenu", () => {
     await user.keyboard("{Enter}");
     await user.click(await screen.findByRole("menuitem", { name: "利用規約" }));
 
-    expect(openMock).toHaveBeenCalledWith("/terms", "_blank", "noopener,noreferrer");
+    await waitFor(() =>
+      expect(openMock).toHaveBeenCalledWith("/terms", "_blank", "noopener,noreferrer"),
+    );
   });
 
   test("メニューからプライバシーポリシーページを新しいタブで開ける", async () => {
@@ -71,7 +73,9 @@ describe("UserMenu", () => {
     await user.keyboard("{Enter}");
     await user.click(await screen.findByRole("menuitem", { name: "プライバシーポリシー" }));
 
-    expect(openMock).toHaveBeenCalledWith("/privacy", "_blank", "noopener,noreferrer");
+    await waitFor(() =>
+      expect(openMock).toHaveBeenCalledWith("/privacy", "_blank", "noopener,noreferrer"),
+    );
   });
 
   test("メニューから GitHub Issues の不具合報告導線を開ける", async () => {
@@ -84,10 +88,12 @@ describe("UserMenu", () => {
     await user.keyboard("{Enter}");
     await user.click(await screen.findByRole("menuitem", { name: "不具合を報告" }));
 
-    expect(openMock).toHaveBeenCalledWith(
-      "https://github.com/isshi-hasegawa/mirukan/issues/new/choose",
-      "_blank",
-      "noopener,noreferrer",
+    await waitFor(() =>
+      expect(openMock).toHaveBeenCalledWith(
+        "https://github.com/isshi-hasegawa/mirukan/issues/new/choose",
+        "_blank",
+        "noopener,noreferrer",
+      ),
     );
   });
 });

--- a/src/features/backlog/components/UserMenu.tsx
+++ b/src/features/backlog/components/UserMenu.tsx
@@ -1,6 +1,7 @@
-import { lazy, Suspense, useState } from "react";
+import { Suspense, useState } from "react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { signOut } from "../../../lib/auth-repository.ts";
+import { lazyNamed } from "../../../lib/lazy-component.ts";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -8,9 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
 
-const AboutDialog = lazy(async () => ({
-  default: (await import("./AboutDialog.tsx")).AboutDialog,
-}));
+const AboutDialog = lazyNamed(() => import("./AboutDialog.tsx"), "AboutDialog");
 
 type Props = {
   email: string | null | undefined;

--- a/src/features/backlog/components/UserMenu.tsx
+++ b/src/features/backlog/components/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { signOut } from "../../../lib/auth-repository.ts";
 import {
@@ -7,7 +7,10 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
-import { AboutDialog } from "./AboutDialog.tsx";
+
+const AboutDialog = lazy(async () => ({
+  default: (await import("./AboutDialog.tsx")).AboutDialog,
+}));
 
 type Props = {
   email: string | null | undefined;
@@ -70,7 +73,11 @@ export function UserMenu({ email }: Props) {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {isAboutOpen ? <AboutDialog onClose={() => setIsAboutOpen(false)} /> : null}
+      {isAboutOpen ? (
+        <Suspense fallback={null}>
+          <AboutDialog onClose={() => setIsAboutOpen(false)} />
+        </Suspense>
+      ) : null}
     </>
   );
 }

--- a/src/lib/lazy-component.ts
+++ b/src/lib/lazy-component.ts
@@ -1,0 +1,12 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+
+type ExtractComponent<T> = Extract<T, ComponentType<any>>;
+
+export function lazyNamed<TModule, TKey extends keyof TModule>(
+  loader: () => Promise<TModule>,
+  key: TKey,
+): LazyExoticComponent<ExtractComponent<TModule[TKey]>> {
+  return lazy(async () => ({
+    default: (await loader())[key] as ExtractComponent<TModule[TKey]>,
+  }));
+}


### PR DESCRIPTION
## 関連 Issue

<!-- 関連 Issue があれば Refs #123 または Closes #123 の形式で記載 -->

## 変更内容

- `App` で `BoardPage` と `ResetPasswordPage` を `React.lazy` で遅延読み込みし、初期チャンクから分離
- `BoardPage` で `AddModal` と `DetailModal`、`UserMenu` で `AboutDialog` を遅延読み込みし、初回表示に不要なモーダル系コードを分離
- 遅延読み込みに合わせて関連テストを `findBy*` / `waitFor` ベースに調整

## 検証

- `vp test src/App.test.tsx src/features/backlog/components/BoardPage.test.tsx src/features/backlog/components/UserMenu.test.tsx`
- `vp run build:analyze`