### PR TITLE
fix: quick win の絶対パス正規化を限定

### DIFF
--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -207,4 +207,88 @@ describe("buildRefactoringBacklogIssue", () => {
     expect(result.body).not.toContain("/opt/clone123");
     expect(result.body).toContain("| `src/lib/example.ts` | 6.5% | 520 lines |");
   });
+
+  test("絶対パスだけを repo 相対に正規化し、相対パスの quick win label は壊さない", () => {
+    const result = buildRefactoringBacklogIssue({
+      projectKey: "mirukan",
+      observedAt: "2026-04-11 10:00 UTC",
+      sonarBaseUrl: "https://sonarcloud.io",
+      branchName: "main",
+      projectMeasures: {},
+      quickWinIssues: [
+        {
+          key: "issue-1",
+          message: "'/tmp/clone123/src/lib/example.ts' imported multiple times.",
+          component: "mirukan:src/lib/consumer-a.ts",
+          rule: "typescript:S3863",
+          effortMinutes: 1,
+        },
+        {
+          key: "issue-2",
+          message:
+            "'/opt/actions-runner/_work/mirukan/mirukan/src/features/backlog/types.ts' imported multiple times.",
+          component: "mirukan:src/lib/consumer-b.ts",
+          rule: "typescript:S3863",
+          effortMinutes: 1,
+        },
+        {
+          key: "issue-3",
+          message: "'src/lib/example.ts' imported multiple times.",
+          component: "mirukan:src/lib/consumer-c.ts",
+          rule: "typescript:S3863",
+          effortMinutes: 1,
+        },
+        {
+          key: "issue-4",
+          message: "'supabase/functions/foo.ts' imported multiple times.",
+          component: "mirukan:src/lib/consumer-d.ts",
+          rule: "typescript:S3863",
+          effortMinutes: 1,
+        },
+      ],
+      longFiles: [],
+      complexFiles: [],
+      duplicateFiles: [],
+    });
+
+    expect(result.body).toContain(
+      "- 'src/lib/example.ts' imported multiple times. - 2件 (最短 1 min)",
+    );
+    expect(result.body).toContain(
+      "- 'src/features/backlog/types.ts' imported multiple times. - 1件 (最短 1 min)",
+    );
+    expect(result.body).toContain(
+      "- 'supabase/functions/foo.ts' imported multiple times. - 1件 (最短 1 min)",
+    );
+    expect(result.body).not.toContain("srclib/example.ts");
+    expect(result.body).not.toContain("supabasefunctions/foo.ts");
+    expect(result.body).not.toContain("/tmp/clone123");
+    expect(result.body).not.toContain("/opt/actions-runner/_work/mirukan/mirukan");
+  });
+
+  test("通常の slash を含むだけのメッセージは変更しない", () => {
+    const result = buildRefactoringBacklogIssue({
+      projectKey: "mirukan",
+      observedAt: "2026-04-11 10:00 UTC",
+      sonarBaseUrl: "https://sonarcloud.io",
+      branchName: "main",
+      projectMeasures: {},
+      quickWinIssues: [
+        {
+          key: "issue-1",
+          message: "See docs/ui.md and keep src/lib/example.ts as-is.",
+          component: "mirukan:src/lib/consumer.ts",
+          rule: "custom:message",
+          effortMinutes: 1,
+        },
+      ],
+      longFiles: [],
+      complexFiles: [],
+      duplicateFiles: [],
+    });
+
+    expect(result.body).toContain(
+      "- See docs/ui.md and keep src/lib/example.ts as-is. - 1件 (最短 1 min)",
+    );
+  });
 });

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -262,7 +262,7 @@ describe("buildRefactoringBacklogIssue", () => {
     );
     expect(result.body).not.toContain("srclib/example.ts");
     expect(result.body).not.toContain("supabasefunctions/foo.ts");
-    expect(result.body).not.toContain("/tmp/clone123");
+    expect(result.body).not.toContain("/tmp");
     expect(result.body).not.toContain("/opt/actions-runner/_work/mirukan/mirukan");
   });
 

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -435,10 +435,15 @@ function toDisplayPath(value: string) {
 }
 
 function splitTrailingPunctuation(value: string) {
-  const match = value.match(/^(.*?)([.,:;!?]+)?$/);
+  let index = value.length;
+
+  while (index > 0 && isTrailingPunctuation(value[index - 1])) {
+    index -= 1;
+  }
+
   return {
-    path: match?.[1] ?? value,
-    suffix: match?.[2] ?? "",
+    path: value.slice(0, index),
+    suffix: value.slice(index),
   };
 }
 
@@ -452,4 +457,15 @@ function minDefined(left: number | undefined, right: number | undefined) {
   }
 
   return Math.min(left, right);
+}
+
+function isTrailingPunctuation(value: string) {
+  return (
+    value === "." ||
+    value === "," ||
+    value === ":" ||
+    value === ";" ||
+    value === "!" ||
+    value === "?"
+  );
 }

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -403,7 +403,14 @@ function normalizePathForMatch(value: string) {
 }
 
 function sanitizeAbsolutePaths(value: string) {
-  return value.replaceAll(/\/[^"'`\s)]+/g, (token) => toDisplayPath(token));
+  return value.replaceAll(
+    /(^|[\s("'`[])(\/[^\s"'`)\]]*)/g,
+    (fullMatch, prefix: string, candidate: string) => {
+      const { path, suffix } = splitTrailingPunctuation(candidate);
+      const sanitized = toDisplayPath(path);
+      return sanitized === path ? fullMatch : `${prefix}${sanitized}${suffix}`;
+    },
+  );
 }
 
 function toDisplayPath(value: string) {
@@ -425,6 +432,14 @@ function toDisplayPath(value: string) {
   }
 
   return normalized.split("/").findLast(Boolean) ?? normalized;
+}
+
+function splitTrailingPunctuation(value: string) {
+  const match = value.match(/^(.*?)([.,:;!?]+)?$/);
+  return {
+    path: match?.[1] ?? value,
+    suffix: match?.[2] ?? "",
+  };
 }
 
 function minDefined(left: number | undefined, right: number | undefined) {


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- `sanitizeAbsolutePaths` を区切られた absolute path candidate だけ処理する実装に変更し、repo 配下セグメントへ落とせた場合だけ repo 相対パスへ正規化
- 相対パスや通常の `/` を含むだけの quick win message はそのまま維持し、grouping key の誤破壊を防止
- absolute path 正規化・相対パス維持・quick win 集約の回帰を確認するテストを追加

## 検証

- `vp test src/lib/refactoring-backlog.test.ts`