### PR TITLE
fix: effort token を digit run 途中から誤マッチしないよう \b を前置

### DIFF
--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -32,6 +32,15 @@ describe("parseMinutes", () => {
     expect(parseMinutes("unknown")).toBeUndefined();
   });
 
+  test("7 桁超の digit run を途中から誤マッチしない", () => {
+    // \b がないと "1234567h" が "234567h" としてマッチし、
+    // 234567 時間という過小値に誤解釈される。
+    expect(parseMinutes("1234567h")).toBeUndefined();
+    expect(parseMinutes("1234567min")).toBeUndefined();
+    // 6 桁以内は正常にマッチする
+    expect(parseMinutes("123456h")).toBe(123456 * 60);
+  });
+
   test("長大な非マッチ入力でも super-linear にならず短時間で完了する", () => {
     // ReDoS 回帰テスト: 量化子が上限付きで固定コストのため、
     // 桁数を増やしても線形時間で完了すること。

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -74,10 +74,12 @@ const MINUTES_PER_UNIT = {
 
 type EffortUnit = keyof typeof MINUTES_PER_UNIT;
 
-// 量化子は明示的に上限を付けて super-linear backtracking を防ぐ。
+// \b で単語境界にアンカーし、長い digit run の途中にマッチしないようにする
+// (例: "1234567h" が "234567h" として誤解釈されるのを防ぐ)。
+// 量化子は明示的に上限を付けて super-linear backtracking も防ぐ。
 // SonarCloud の effort 文字列 (例: "2d 1h 30min") は小さい整数と最小限の空白で
 // 表現されるため、6 桁 / 4 空白で十分な余白がある。
-const EFFORT_TOKEN_PATTERN = /(\d{1,6})\s{0,4}(min|h|d)/g;
+const EFFORT_TOKEN_PATTERN = /\b(\d{1,6})\s{0,4}(min|h|d)/g;
 
 export function parseMinutes(value: string | undefined): number | undefined {
   if (!value) {


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- `EFFORT_TOKEN_PATTERN` に `\b` を前置し、長い digit run の途中からマッチしないようにする
  - 修正前: `"1234567h"` が `"234567h"` (内側 6 桁) にマッチし、effort を過小評価していた
  - 修正後: `\b` により digit run の先頭のみでマッチを試みるため `"1234567h"` は non-match
  - `\b` はゼロ幅アサーションで backtracking しないため、#171 で対応した ReDoS 対策は維持される
- 誤マッチ回帰テストを追加 (`"1234567h"` / `"1234567min"` が undefined を返すこと)

## 検証

- `vp test src/lib/refactoring-backlog.test.ts` — 16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)