### PR TITLE
fix: refactoring backlog の除外リストに supabase/seed.sql を追加

### DIFF
--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -117,6 +117,10 @@ describe("signal ranking", () => {
           path: "supabase/templates/confirmation.html",
           measures: { duplicated_lines_density: 88 },
         },
+        {
+          path: "supabase/seed.sql",
+          measures: { ncloc: 500 },
+        },
       ]),
     ).toEqual(files);
   });

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -1,5 +1,9 @@
 const REFACTORING_BACKLOG_MARKER = "<!-- refactoring-backlog:sonarcloud -->";
-const DEFAULT_BACKLOG_EXCLUDE_PATTERNS = ["pnpm-lock.yaml", "supabase/templates/**"] as const;
+const DEFAULT_BACKLOG_EXCLUDE_PATTERNS = [
+  "pnpm-lock.yaml",
+  "supabase/templates/**",
+  "supabase/seed.sql",
+] as const;
 const REPO_PATH_SEGMENTS = ["src/", "supabase/", ".github/", "docs/", "public/"] as const;
 
 export type SonarMeasureKey =


### PR DESCRIPTION
## 関連 Issue

SonarCloud 観測は継続するため、Issue 連携なし

## 変更内容

- refactoring backlog 出力の除外パターンに `supabase/seed.sql` を追加
- 既存の `pnpm-lock.yaml` と `supabase/templates/**` に合わせて除外対象を統一
- SonarCloud 側の分析設定は変更なし（workflow / issue 生成ロジック側のみで対応）
- `supabase/seed.sql` はデータファイルのため refactoring backlog では不要だが、SonarCloud では観測を継続
- PR #171 での運用方針（データファイルは対象外）に統一