### PR TITLE
ci: Bundle Analyze を main push から削除

### DIFF
--- a/.github/workflows/bundle-analyze.yml
+++ b/.github/workflows/bundle-analyze.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
   schedule:
     - cron: "0 3 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
## 関連 Issue

なし

## 変更内容

- Bundle Analyze workflow から `push: branches: [main]` トリガーを削除
- PR トリガー・定期実行（毎週月曜）・手動実行のみを残す
- main push 後に不要に実行されていたため、PR でのチェックに限定