### PR TITLE
refactor: Issue #167 の quick win 対応（window→globalThis・否定条件・不要アサーション）

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -41,7 +41,7 @@ describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authState.callback = null;
-    window.history.replaceState({}, "", "/");
+    globalThis.history.replaceState({}, "", "/");
 
     authRepositoryMock.getSession.mockResolvedValue({ data: { session: null } });
     authRepositoryMock.onAuthStateChange.mockImplementation(
@@ -63,7 +63,7 @@ describe("App", () => {
     authRepositoryMock.getSession.mockResolvedValue({
       data: { session: { user: { id: "user-1" } } },
     });
-    window.history.replaceState({}, "", "/#type=recovery&access_token=token");
+    globalThis.history.replaceState({}, "", "/#type=recovery&access_token=token");
 
     render(<App />);
 
@@ -72,7 +72,7 @@ describe("App", () => {
   });
 
   test("recovery パラメータが残っていてもセッションがなければログイン画面を表示する", async () => {
-    window.history.replaceState({}, "", "/#type=recovery");
+    globalThis.history.replaceState({}, "", "/#type=recovery");
 
     render(<App />);
 
@@ -81,7 +81,7 @@ describe("App", () => {
   });
 
   test("SIGNED_IN が先に来る recovery フローでも再設定画面を維持する", async () => {
-    window.history.replaceState({}, "", "/?type=recovery");
+    globalThis.history.replaceState({}, "", "/?type=recovery");
 
     render(<App />);
     expect(await screen.findByText("LOGIN_PAGE")).toBeInTheDocument();
@@ -97,7 +97,7 @@ describe("App", () => {
     authRepositoryMock.getSession.mockResolvedValue({
       data: { session: { user: { id: "user-1" } } },
     });
-    window.history.replaceState({}, "", "/?type=recovery");
+    globalThis.history.replaceState({}, "", "/?type=recovery");
 
     render(<App />);
     expect(await screen.findByText("RESET_PASSWORD_PAGE")).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe("App", () => {
     });
 
     expect(await screen.findByText("BOARD_PAGE")).toBeInTheDocument();
-    expect(window.location.search).toBe("");
+    expect(globalThis.location.search).toBe("");
   });
 
   test("getSession が失敗してもローディング状態で止まらずログイン画面に戻る", async () => {
@@ -124,7 +124,7 @@ describe("App", () => {
   });
 
   test("/privacy では認証処理を通さずプライバシーポリシーを表示する", () => {
-    window.history.replaceState({}, "", "/privacy");
+    globalThis.history.replaceState({}, "", "/privacy");
 
     render(<App />);
 
@@ -133,7 +133,7 @@ describe("App", () => {
   });
 
   test("/terms では認証処理を通さず利用規約を表示する", () => {
-    window.history.replaceState({}, "", "/terms");
+    globalThis.history.replaceState({}, "", "/terms");
 
     render(<App />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function clearPasswordRecoveryLocation() {
     "type",
     "code",
   ];
-  const url = new URL(window.location.href);
+  const url = new URL(globalThis.location.href);
   let hasChanged = false;
 
   for (const name of authParamNames) {
@@ -59,8 +59,8 @@ function clearPasswordRecoveryLocation() {
 
   if (hasChanged) {
     url.hash = hashParams.toString();
-    window.history.replaceState(
-      window.history.state,
+    globalThis.history.replaceState(
+      globalThis.history.state,
       "",
       `${url.pathname}${url.search}${url.hash}`,
     );
@@ -81,7 +81,7 @@ function LazyRouteErrorFallback() {
           <Button
             type="button"
             className="w-full sm:w-auto"
-            onClick={() => window.location.reload()}
+            onClick={() => globalThis.location.reload()}
           >
             再読み込み
           </Button>
@@ -94,7 +94,7 @@ function LazyRouteErrorFallback() {
 function AuthenticatedApp() {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
   const [isPasswordRecovery, setIsPasswordRecovery] = useState(() =>
-    isPasswordRecoveryLocation(window.location),
+    isPasswordRecoveryLocation(globalThis.location),
   );
 
   useEffect(() => {
@@ -116,7 +116,7 @@ function AuthenticatedApp() {
         setIsPasswordRecovery(false);
         clearPasswordRecoveryLocation();
       } else if (event === "SIGNED_IN") {
-        setIsPasswordRecovery(isPasswordRecoveryLocation(window.location));
+        setIsPasswordRecovery(isPasswordRecoveryLocation(globalThis.location));
       } else if (event === "SIGNED_OUT") {
         setIsPasswordRecovery(false);
         clearPasswordRecoveryLocation();
@@ -160,7 +160,7 @@ function AuthenticatedApp() {
 }
 
 export function App() {
-  const pathname = window.location.pathname;
+  const pathname = globalThis.location.pathname;
   if (pathname === "/privacy") return <PrivacyPolicyPage />;
   if (pathname === "/terms") return <TermsOfServicePage />;
   return <AuthenticatedApp />;

--- a/src/features/backlog/components/AddModal.test.tsx
+++ b/src/features/backlog/components/AddModal.test.tsx
@@ -515,7 +515,7 @@ describe("AddModal", () => {
       data: { id: "existing-work-42" },
       error: null,
     });
-    const confirmSpy = vi.spyOn(window, "confirm");
+    const confirmSpy = vi.spyOn(globalThis, "confirm");
 
     const { user } = renderAddModal({ items: [duplicateItem] });
 

--- a/src/features/backlog/components/AddModalSearchPane.tsx
+++ b/src/features/backlog/components/AddModalSearchPane.tsx
@@ -88,7 +88,7 @@ function SelectedResultFooter({
           onCancel={onCancelPendingSave}
         />
       ) : null}
-      {!pendingSaveMessage ? (
+      {pendingSaveMessage ? null : (
         <div className="flex items-end justify-end gap-3">
           {formMessage && (
             <p className="text-muted-foreground text-sm text-right" aria-live="polite">
@@ -105,7 +105,7 @@ function SelectedResultFooter({
             {selectedTmdbSubmitLabel}
           </Button>
         </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/src/features/backlog/components/DetailModal.tsx
+++ b/src/features/backlog/components/DetailModal.tsx
@@ -33,10 +33,10 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        if (state.editingField !== null) {
-          onStateChange(createDetailModalState(item?.id ?? state.openItemId));
-        } else {
+        if (state.editingField === null) {
           onClose();
+        } else {
+          onStateChange(createDetailModalState(item?.id ?? state.openItemId));
         }
       }
     };

--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -17,7 +17,7 @@ setupTestLifecycle();
 describe("LoginPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    window.history.replaceState({}, "", "/");
+    globalThis.history.replaceState({}, "", "/");
     authRepositoryMock.signInWithPassword.mockResolvedValue({ error: null });
     authRepositoryMock.signUp.mockResolvedValue({
       data: { session: null, user: { id: "user-1" } },
@@ -166,7 +166,7 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: "確認メールを送信して登録" }));
 
     expect(authRepositoryMock.signUp).toHaveBeenCalledWith("new-user@example.com", "password456", {
-      emailRedirectTo: window.location.origin,
+      emailRedirectTo: globalThis.location.origin,
     });
     expect(await screen.findByText("確認メールを送信しました")).toBeInTheDocument();
     expect(
@@ -233,7 +233,7 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: "リセットメールを送信" }));
 
     expect(authRepositoryMock.resetPasswordForEmail).toHaveBeenCalledWith("akari@example.com", {
-      redirectTo: window.location.origin,
+      redirectTo: globalThis.location.origin,
     });
     expect(await screen.findByText("リセットメールを送信しました")).toBeInTheDocument();
     expect(
@@ -336,7 +336,7 @@ describe("LoginPage", () => {
     await user.click(screen.getByRole("button", { name: "Googleでログイン" }));
 
     expect(authRepositoryMock.signInWithOAuth).toHaveBeenCalledWith({
-      redirectTo: window.location.origin,
+      redirectTo: globalThis.location.origin,
     });
   });
 

--- a/src/features/backlog/components/UserMenu.tsx
+++ b/src/features/backlog/components/UserMenu.tsx
@@ -43,21 +43,21 @@ export function UserMenu({ email }: Props) {
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              window.open("/terms", "_blank", "noopener,noreferrer");
+              globalThis.open("/terms", "_blank", "noopener,noreferrer");
             }}
           >
             利用規約
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              window.open("/privacy", "_blank", "noopener,noreferrer");
+              globalThis.open("/privacy", "_blank", "noopener,noreferrer");
             }}
           >
             プライバシーポリシー
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              window.open(BUG_REPORT_URL, "_blank", "noopener,noreferrer");
+              globalThis.open(BUG_REPORT_URL, "_blank", "noopener,noreferrer");
             }}
           >
             不具合を報告

--- a/src/features/backlog/hooks/useLoginPageAuth.ts
+++ b/src/features/backlog/hooks/useLoginPageAuth.ts
@@ -72,7 +72,7 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
   const isForgotPasswordMode = authMode === "forgotPassword";
   const email = isSignUpMode ? signUpEmail : loginEmail;
   const password = isSignUpMode ? signUpPassword : loginPassword;
-  const authRedirectUrl = getAuthRedirectUrl(window.location);
+  const authRedirectUrl = getAuthRedirectUrl(globalThis.location);
   const shouldShowDevLoginHint = showDevLoginHint && !isSignUpMode && !isForgotPasswordMode;
 
   const resetStatusMessage = () => {

--- a/src/features/backlog/hooks/useTmdbSearchRequest.ts
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.ts
@@ -75,7 +75,7 @@ function prioritizeLocalizedResults(results: TmdbSearchResult[]) {
     .map((result, index) => ({ result, index }))
     .sort((left, right) => {
       const scoreDiff = getLocalizationScore(right.result) - getLocalizationScore(left.result);
-      return scoreDiff !== 0 ? scoreDiff : left.index - right.index;
+      return scoreDiff === 0 ? left.index - right.index : scoreDiff;
     })
     .map(({ result }) => result);
 }
@@ -180,7 +180,7 @@ export function useTmdbSearchRequest({
 
     return () => {
       if (searchTimerRef.current !== null) {
-        window.clearTimeout(searchTimerRef.current);
+        globalThis.clearTimeout(searchTimerRef.current);
       }
     };
   }, []);
@@ -194,7 +194,7 @@ export function useTmdbSearchRequest({
   const runSearch = async (query: string) => {
     const trimmed = query.trim();
     if (searchTimerRef.current !== null) {
-      window.clearTimeout(searchTimerRef.current);
+      globalThis.clearTimeout(searchTimerRef.current);
       searchTimerRef.current = null;
     }
 
@@ -228,9 +228,9 @@ export function useTmdbSearchRequest({
 
   const queueSearch = (query: string) => {
     if (searchTimerRef.current !== null) {
-      window.clearTimeout(searchTimerRef.current);
+      globalThis.clearTimeout(searchTimerRef.current);
     }
-    searchTimerRef.current = window.setTimeout(() => {
+    searchTimerRef.current = globalThis.setTimeout(() => {
       void runSearch(query);
     }, SEARCH_DEBOUNCE_MS);
   };

--- a/src/features/backlog/hooks/useWindowSize.test.ts
+++ b/src/features/backlog/hooks/useWindowSize.test.ts
@@ -4,7 +4,7 @@ import { useWindowSize } from "./useWindowSize.ts";
 describe("useWindowSize", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    Object.defineProperty(window, "innerWidth", {
+    Object.defineProperty(globalThis, "innerWidth", {
       writable: true,
       configurable: true,
       value: 1280,
@@ -15,7 +15,7 @@ describe("useWindowSize", () => {
     vi.useRealTimers();
   });
 
-  test("初期値として window.innerWidth を返す", () => {
+  test("初期値として globalThis.innerWidth を返す", () => {
     const { result } = renderHook(() => useWindowSize());
     expect(result.current).toBe(1280);
   });
@@ -24,19 +24,19 @@ describe("useWindowSize", () => {
     const { result } = renderHook(() => useWindowSize());
 
     act(() => {
-      Object.defineProperty(window, "innerWidth", {
+      Object.defineProperty(globalThis, "innerWidth", {
         writable: true,
         configurable: true,
         value: 390,
       });
-      window.dispatchEvent(new Event("resize"));
+      globalThis.dispatchEvent(new Event("resize"));
 
-      Object.defineProperty(window, "innerWidth", {
+      Object.defineProperty(globalThis, "innerWidth", {
         writable: true,
         configurable: true,
         value: 420,
       });
-      window.dispatchEvent(new Event("resize"));
+      globalThis.dispatchEvent(new Event("resize"));
     });
 
     expect(result.current).toBe(1280);
@@ -49,7 +49,7 @@ describe("useWindowSize", () => {
   });
 
   test("アンマウント後は resize リスナーが除去される", () => {
-    const spy = vi.spyOn(window, "removeEventListener");
+    const spy = vi.spyOn(globalThis, "removeEventListener");
     const { unmount } = renderHook(() => useWindowSize());
 
     unmount();

--- a/src/features/backlog/hooks/useWindowSize.ts
+++ b/src/features/backlog/hooks/useWindowSize.ts
@@ -3,11 +3,11 @@ import { useEffect, useState } from "react";
 const RESIZE_THROTTLE_MS = 100;
 
 export function useWindowSize() {
-  const [width, setWidth] = useState(window.innerWidth);
+  const [width, setWidth] = useState(globalThis.innerWidth);
 
   useEffect(() => {
     let resizeTimer: number | null = null;
-    let nextWidth = window.innerWidth;
+    let nextWidth = globalThis.innerWidth;
 
     const flushWidth = () => {
       resizeTimer = null;
@@ -15,16 +15,16 @@ export function useWindowSize() {
     };
 
     const handler = () => {
-      nextWidth = window.innerWidth;
+      nextWidth = globalThis.innerWidth;
       if (resizeTimer !== null) return;
-      resizeTimer = window.setTimeout(flushWidth, RESIZE_THROTTLE_MS);
+      resizeTimer = globalThis.setTimeout(flushWidth, RESIZE_THROTTLE_MS);
     };
 
-    window.addEventListener("resize", handler);
+    globalThis.addEventListener("resize", handler);
     return () => {
-      window.removeEventListener("resize", handler);
+      globalThis.removeEventListener("resize", handler);
       if (resizeTimer !== null) {
-        window.clearTimeout(resizeTimer);
+        globalThis.clearTimeout(resizeTimer);
       }
     };
   }, []);

--- a/src/features/backlog/ui-feedback.ts
+++ b/src/features/backlog/ui-feedback.ts
@@ -5,7 +5,7 @@ export type BacklogFeedback = {
 
 export const browserBacklogFeedback: BacklogFeedback = {
   alert: (message) => {
-    window.alert(message);
+    globalThis.alert(message);
   },
-  confirm: (message) => window.confirm(message),
+  confirm: (message) => globalThis.confirm(message),
 };

--- a/supabase/functions/_shared/tmdb.ts
+++ b/supabase/functions/_shared/tmdb.ts
@@ -229,7 +229,7 @@ async function fetchTmdbJson<T>(
     }
 
     const retryAfterHeader = response.headers.get("retry-after");
-    const retryAfterMs = retryAfterHeader ? Number.parseFloat(retryAfterHeader) * 1000 : NaN;
+    const retryAfterMs = retryAfterHeader ? Number.parseFloat(retryAfterHeader) * 1000 : Number.NaN;
     const backoffMs =
       Number.isFinite(retryAfterMs) && retryAfterMs > 0
         ? retryAfterMs
@@ -260,7 +260,7 @@ async function mapWithConcurrency<TInput, TOutput>(
     while (nextIndex < items.length) {
       const currentIndex = nextIndex;
       nextIndex += 1;
-      results[currentIndex] = await mapper(items[currentIndex]!, currentIndex);
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
     }
   }
 


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- `window` → `globalThis` に統一（src/ 全体 35件、10ファイル）
  - ブラウザ・jsdom 環境では `globalThis === window` のため挙動同一
  - `vi.spyOn`・`Object.defineProperty` の対象も同様に変更
- 否定条件の反転（3件）
  - `AddModalSearchPane.tsx`: `{!pendingSaveMessage ? A : null}` → `{pendingSaveMessage ? null : A}`
  - `DetailModal.tsx`: `if (editingField !== null) { A } else { B }` → `if (editingField === null) { B } else { A }`
  - `useTmdbSearchRequest.ts`: `scoreDiff !== 0 ? scoreDiff : …` → `scoreDiff === 0 ? … : scoreDiff`
- 不要な非 null アサーション除去: `items[currentIndex]!` → `items[currentIndex]`（`noUncheckedIndexedAccess` 非有効のため冗長）
- `NaN` → `Number.NaN`（`supabase/functions/_shared/tmdb.ts`）

## 見送り項目

- 否定条件 4件中 1件（`AddModalDetailsPane.tsx:107` の複合条件 `pendingSaveMessage && !selectedTmdbResult`）は、条件全体が否定ではなく結合条件のため対応を見送り
- `window` 残件（`supabase/` 配下）は今回スコープ外