### PR TITLE
refactor: テスト重複削減のための WorkSummary 共有 fixture 導入

### DIFF
--- a/src/features/backlog/add-submit-flow.test.ts
+++ b/src/features/backlog/add-submit-flow.test.ts
@@ -1,4 +1,5 @@
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../test/backlog-fixtures.ts";
 import {
   buildSelectedSubject,
   buildStackedBacklogOptions,
@@ -31,49 +32,19 @@ function createItem(
   workId: string,
   workOverrides: Partial<NonNullable<BacklogItem["works"]>> = {},
 ): BacklogItem {
-  const baseWorks: NonNullable<BacklogItem["works"]> = {
-    id: workId,
-    title: `作品 ${id}`,
-    work_type: "movie",
-    source_type: "tmdb",
-    tmdb_id: null,
-    tmdb_media_type: null,
-    original_title: null,
-    overview: null,
-    poster_path: null,
-    release_date: null,
-    runtime_minutes: null,
-    typical_episode_runtime_minutes: null,
-    duration_bucket: null,
-    genres: [],
-    season_count: null,
-    season_number: null,
-    focus_required_score: null,
-    background_fit_score: null,
-    completion_load_score: null,
-    rotten_tomatoes_score: null,
-    imdb_rating: null,
-    imdb_votes: null,
-    metacritic_score: null,
-  };
-  const works = {
-    ...baseWorks,
-    ...workOverrides,
-  };
-
   return {
     id,
     status,
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      ...works,
-      rotten_tomatoes_score: works.rotten_tomatoes_score ?? null,
-      imdb_rating: works.imdb_rating ?? null,
-      imdb_votes: works.imdb_votes ?? null,
-      metacritic_score: works.metacritic_score ?? null,
-    },
+    works: createWorkSummary({
+      id: workId,
+      title: `作品 ${id}`,
+      tmdb_id: null,
+      tmdb_media_type: null,
+      ...workOverrides,
+    }),
   };
 }
 

--- a/src/features/backlog/backlog-item-utils.test.ts
+++ b/src/features/backlog/backlog-item-utils.test.ts
@@ -1,4 +1,5 @@
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../test/backlog-fixtures.ts";
 import {
   buildDetailFieldUpdate,
   buildMoveToStatusConfirmMessage,
@@ -9,7 +10,7 @@ import {
   normalizeBacklogItems,
   planBacklogItemUpserts,
 } from "./backlog-item-utils.ts";
-import type { BacklogItem, WorkSummary } from "./types.ts";
+import type { BacklogItem } from "./types.ts";
 
 setupTestLifecycle();
 
@@ -25,71 +26,13 @@ function createItem(
     primary_platform: null,
     note: null,
     sort_order: sortOrder,
-    works: {
+    works: createWorkSummary({
       id: workId,
       title: `Title ${id}`,
-      work_type: "movie",
       source_type: "manual",
       tmdb_id: null,
       tmdb_media_type: null,
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
-  };
-}
-
-function createWork(overrides: Partial<WorkSummary> = {}): WorkSummary {
-  const baseWork: WorkSummary = {
-    id: "w1",
-    title: "Test",
-    work_type: "movie",
-    source_type: "tmdb",
-    tmdb_id: 1,
-    tmdb_media_type: "movie",
-    original_title: null,
-    overview: null,
-    poster_path: null,
-    release_date: null,
-    runtime_minutes: null,
-    typical_episode_runtime_minutes: null,
-    duration_bucket: null,
-    genres: [],
-    season_count: null,
-    season_number: null,
-    focus_required_score: null,
-    background_fit_score: null,
-    completion_load_score: null,
-    rotten_tomatoes_score: null,
-    imdb_rating: null,
-    imdb_votes: null,
-    metacritic_score: null,
-  };
-  const work = {
-    ...baseWork,
-    ...overrides,
-  };
-
-  return {
-    ...work,
-    rotten_tomatoes_score: work.rotten_tomatoes_score ?? null,
-    imdb_rating: work.imdb_rating ?? null,
-    imdb_votes: work.imdb_votes ?? null,
-    metacritic_score: work.metacritic_score ?? null,
+    }),
   };
 }
 
@@ -232,14 +175,14 @@ describe("normalizeBacklogItems", () => {
         primary_platform: null,
         note: null,
         sort_order: 1000,
-        works: [createWork({ id: "w1" })],
+        works: [createWorkSummary({ id: "w1" })],
       },
     ];
 
     const result = normalizeBacklogItems(rows);
 
     expect(result).toHaveLength(1);
-    expect(result[0].works).toEqual(createWork({ id: "w1" }));
+    expect(result[0].works).toEqual(createWorkSummary({ id: "w1" }));
   });
 
   test("passes through single work objects", () => {
@@ -250,14 +193,14 @@ describe("normalizeBacklogItems", () => {
         primary_platform: null,
         note: null,
         sort_order: 1000,
-        works: createWork({ id: "w1" }),
+        works: createWorkSummary({ id: "w1" }),
       },
     ];
 
     const result = normalizeBacklogItems(rows);
 
     expect(result).toHaveLength(1);
-    expect(result[0].works).toEqual(createWork({ id: "w1" }));
+    expect(result[0].works).toEqual(createWorkSummary({ id: "w1" }));
   });
 
   test("excludes rows with null works", () => {
@@ -283,7 +226,7 @@ describe("normalizeBacklogItems", () => {
         primary_platform: "unsupported",
         note: null,
         sort_order: 1000,
-        works: createWork({ id: "w1" }),
+        works: createWorkSummary({ id: "w1" }),
       },
     ];
 

--- a/src/features/backlog/backlog-repository.test.ts
+++ b/src/features/backlog/backlog-repository.test.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../test/backlog-fixtures.ts";
 import { getMockBacklogItems, setMockBacklogItems } from "../../test/mocks/handlers";
 import { server } from "../../test/mocks/server";
 import {
@@ -34,31 +35,13 @@ function createItem(
     primary_platform: null,
     note: null,
     sort_order: sortOrder,
-    works: {
+    works: createWorkSummary({
       id: workId,
       title: `Title ${id}`,
-      work_type: "movie",
       source_type: "manual",
       tmdb_id: null,
       tmdb_media_type: null,
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    }),
   };
 }
 

--- a/src/features/backlog/components/AddModal.test.tsx
+++ b/src/features/backlog/components/AddModal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { Session } from "@supabase/supabase-js";
 import type { TmdbSearchResult, TmdbSeasonOption } from "../../../lib/tmdb.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { AddModal } from "./AddModal.tsx";
 
@@ -88,31 +89,7 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
-      title: "既存作品",
-      work_type: "movie",
-      source_type: "tmdb",
-      tmdb_id: 1,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: "2024-01-01",
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    works: createWorkSummary({ title: "既存作品", release_date: "2024-01-01" }),
     ...overrides,
   };
 }

--- a/src/features/backlog/components/BacklogCard.test.tsx
+++ b/src/features/backlog/components/BacklogCard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { BacklogCard } from "./BacklogCard.tsx";
 
@@ -28,31 +29,13 @@ function createItem(): BacklogItem {
     primary_platform: null,
     note: "メモあり",
     sort_order: 1000,
-    works: {
-      id: "work-1",
+    works: createWorkSummary({
       title: "テスト作品",
-      work_type: "movie",
       source_type: "manual",
       tmdb_id: null,
       tmdb_media_type: null,
-      original_title: null,
-      overview: null,
-      poster_path: null,
       release_date: "2024-01-01",
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    }),
   };
 }
 

--- a/src/features/backlog/components/BoardPage.test.tsx
+++ b/src/features/backlog/components/BoardPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
 import { BoardPage } from "./BoardPage.tsx";
 
@@ -140,31 +141,7 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
-      title: "作品1",
-      work_type: "movie",
-      source_type: "tmdb",
-      tmdb_id: 1,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    works: createWorkSummary({ title: "作品1" }),
     ...overrides,
   };
 }

--- a/src/features/backlog/components/DetailModal.test.tsx
+++ b/src/features/backlog/components/DetailModal.test.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import { createDetailModalState } from "../helpers.ts";
 import type { BacklogItem, DetailModalState } from "../types.ts";
 import { DetailModal } from "./DetailModal.tsx";
@@ -29,31 +30,14 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
+    works: createWorkSummary({
       title: "テスト作品",
-      work_type: "movie",
-      source_type: "tmdb",
       tmdb_id: 10,
-      tmdb_media_type: "movie",
-      original_title: null,
       overview: "overview",
-      poster_path: null,
       release_date: "2024-01-01",
       runtime_minutes: 120,
-      typical_episode_runtime_minutes: null,
       duration_bucket: "long",
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    }),
     ...overrides,
   };
 }

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -3,7 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
 import type { OnUrlUpdateFunction } from "nuqs/adapters/testing";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
-import type { BacklogItem, BacklogStatus, ViewingMode, WorkSummary } from "../types.ts";
+import { createWorkSummary as createWorkSummaryFromFixtures } from "../../../test/backlog-fixtures.ts";
+import type { BacklogItem, BacklogStatus, ViewingMode } from "../types.ts";
 import { KanbanBoard } from "./KanbanBoard.tsx";
 
 vi.mock("./KanbanColumn.tsx", () => ({
@@ -61,61 +62,22 @@ function createItem(
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
+    works: createWorkSummaryFromFixtures({
       id: `work-${id}`,
       title,
-      work_type: "movie",
-      source_type: "tmdb",
       tmdb_id: Number(id.replace(/\D/g, "")) || 1,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    }),
     ...overrides,
   };
 }
 
-function createWorkSummary(id: string, title: string, runtimeMinutes: number): WorkSummary {
-  return {
+function createWorkSummary(id: string, title: string, runtimeMinutes: number) {
+  return createWorkSummaryFromFixtures({
     id: `work-${id}`,
     title,
-    work_type: "movie",
-    source_type: "tmdb",
     tmdb_id: Number(id.replace(/\D/g, "")) || 1,
-    tmdb_media_type: "movie",
-    original_title: null,
-    overview: null,
-    poster_path: null,
-    release_date: null,
     runtime_minutes: runtimeMinutes,
-    typical_episode_runtime_minutes: null,
-    duration_bucket: null,
-    genres: [],
-    season_count: null,
-    season_number: null,
-    focus_required_score: null,
-    background_fit_score: null,
-    completion_load_score: null,
-    rotten_tomatoes_score: null,
-    imdb_rating: null,
-    imdb_votes: null,
-    metacritic_score: null,
-  };
+  });
 }
 
 function renderKanbanBoard(

--- a/src/features/backlog/components/KanbanColumn.test.tsx
+++ b/src/features/backlog/components/KanbanColumn.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { KanbanColumn } from "./KanbanColumn.tsx";
 
@@ -28,31 +29,7 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
-      title: "作品1",
-      work_type: "movie",
-      source_type: "tmdb",
-      tmdb_id: 1,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    works: createWorkSummary({ title: "作品1" }),
     ...overrides,
   };
 }

--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -13,6 +13,7 @@ import {
 import type { TmdbSearchResult } from "../../lib/tmdb.ts";
 import type { BacklogItem } from "./types.ts";
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../test/backlog-fixtures.ts";
 
 setupTestLifecycle();
 
@@ -140,31 +141,11 @@ describe("getWorkTypeLabel", () => {
 });
 
 describe("getWorkMetadataLabels", () => {
-  const baseWork: NonNullable<BacklogItem["works"]> = {
-    id: "work-1",
+  const baseWork = createWorkSummary({
     title: "テスト作品",
-    work_type: "movie",
-    source_type: "tmdb",
-    tmdb_id: 1,
-    tmdb_media_type: "movie",
-    original_title: null,
-    overview: null,
-    poster_path: null,
     release_date: "2024-01-01",
     runtime_minutes: 120,
-    typical_episode_runtime_minutes: null,
-    duration_bucket: null,
-    genres: [],
-    season_count: null,
-    season_number: null,
-    focus_required_score: null,
-    background_fit_score: null,
-    completion_load_score: null,
-    rotten_tomatoes_score: null,
-    imdb_rating: null,
-    imdb_votes: null,
-    metacritic_score: null,
-  };
+  });
 
   test("映画は公開年と上映時間をそのまま表示する", () => {
     expect(

--- a/src/features/backlog/hooks/useAddSubmit.test.tsx
+++ b/src/features/backlog/hooks/useAddSubmit.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Session } from "@supabase/supabase-js";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { useAddSubmit } from "./useAddSubmit.ts";
 
@@ -42,31 +43,7 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
-      title: "作品1",
-      work_type: "movie",
-      source_type: "tmdb",
-      tmdb_id: 1,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    works: createWorkSummary({ title: "作品1" }),
     ...overrides,
   };
 }

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import type { Session } from "@supabase/supabase-js";
 import type { TmdbSearchResult } from "../../../lib/tmdb.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { useBacklogActions } from "./useBacklogActions.ts";
 
@@ -34,31 +35,7 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
-      title: "作品1",
-      work_type: "movie",
-      source_type: "tmdb",
-      tmdb_id: 1,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    works: createWorkSummary({ title: "作品1" }),
     ...overrides,
   };
 }

--- a/src/features/backlog/hooks/useTmdbSearchRequest.test.tsx
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { useTmdbSearchRequest } from "./useTmdbSearchRequest.ts";
 
@@ -27,31 +28,11 @@ function createItem(id: string, status: BacklogItem["status"], tmdbId: number): 
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
+    works: createWorkSummary({
       id: `work-${id}`,
       title: `title-${id}`,
-      work_type: "movie",
-      source_type: "tmdb",
       tmdb_id: tmdbId,
-      tmdb_media_type: "movie",
-      original_title: null,
-      overview: null,
-      poster_path: null,
-      release_date: null,
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
-      season_count: null,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    }),
   };
 }
 

--- a/src/features/backlog/tmdb-search-state.test.ts
+++ b/src/features/backlog/tmdb-search-state.test.ts
@@ -1,4 +1,5 @@
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../test/backlog-fixtures.ts";
 import {
   buildDuplicateState,
   buildTvSelectionState,
@@ -33,31 +34,13 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: 1000,
-    works: {
-      id: "work-1",
+    works: createWorkSummary({
       title: "既存作品",
       work_type: "series",
-      source_type: "tmdb",
-      tmdb_id: 1,
       tmdb_media_type: "tv",
-      original_title: null,
-      overview: null,
-      poster_path: null,
       release_date: "2024-01-01",
-      runtime_minutes: null,
-      typical_episode_runtime_minutes: null,
-      duration_bucket: null,
-      genres: [],
       season_count: 2,
-      season_number: null,
-      focus_required_score: null,
-      background_fit_score: null,
-      completion_load_score: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-    },
+    }),
     ...overrides,
   };
 }

--- a/src/features/backlog/viewing-mode.test.ts
+++ b/src/features/backlog/viewing-mode.test.ts
@@ -1,6 +1,7 @@
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../test/backlog-fixtures.ts";
 import { applyModeFilter, sortStackedItemsByViewingMode } from "./viewing-mode.ts";
-import type { BacklogItem, WorkSummary } from "./types.ts";
+import type { BacklogItem } from "./types.ts";
 
 setupTestLifecycle();
 
@@ -11,113 +12,81 @@ function createItem(id: string, sortOrder: number): BacklogItem {
     primary_platform: null,
     note: null,
     sort_order: sortOrder,
-    works: createWork({ id: `work-${id}` }),
-  };
-}
-
-function createWork(overrides: Partial<WorkSummary> = {}): WorkSummary {
-  const baseWork: WorkSummary = {
-    id: "w1",
-    title: "Test",
-    work_type: "movie",
-    source_type: "tmdb",
-    tmdb_id: 1,
-    tmdb_media_type: "movie",
-    original_title: null,
-    overview: null,
-    poster_path: null,
-    release_date: null,
-    runtime_minutes: null,
-    typical_episode_runtime_minutes: null,
-    duration_bucket: null,
-    genres: [],
-    season_count: null,
-    season_number: null,
-    focus_required_score: null,
-    background_fit_score: null,
-    completion_load_score: null,
-    rotten_tomatoes_score: null,
-    imdb_rating: null,
-    imdb_votes: null,
-    metacritic_score: null,
-  };
-  const work = {
-    ...baseWork,
-    ...overrides,
-  };
-
-  return {
-    ...work,
-    rotten_tomatoes_score: work.rotten_tomatoes_score ?? null,
-    imdb_rating: work.imdb_rating ?? null,
-    imdb_votes: work.imdb_votes ?? null,
-    metacritic_score: work.metacritic_score ?? null,
+    works: createWorkSummary({ id: `work-${id}` }),
   };
 }
 
 describe("applyModeFilter", () => {
   describe("focus モード (≥80分)", () => {
     test("映画80分以上 → true", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 120 }), "focus")).toBe(true);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 120 }), "focus")).toBe(true);
     });
 
     test("映画79分 → false", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 79 }), "focus")).toBe(false);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 79 }), "focus")).toBe(false);
     });
 
     test("シリーズ1話80分 → true", () => {
       expect(
         applyModeFilter(
-          createWork({ work_type: "series", typical_episode_runtime_minutes: 80 }),
+          createWorkSummary({ work_type: "series", typical_episode_runtime_minutes: 80 }),
           "focus",
         ),
       ).toBe(true);
     });
 
     test("尺不明 → false", () => {
-      expect(applyModeFilter(createWork(), "focus")).toBe(false);
+      expect(applyModeFilter(createWorkSummary(), "focus")).toBe(false);
     });
   });
 
   describe("thoughtful モード (40-79分)", () => {
     test("映画50分 → true", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 50 }), "thoughtful")).toBe(true);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 50 }), "thoughtful")).toBe(true);
     });
 
     test("映画39分 → false", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 39 }), "thoughtful")).toBe(false);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 39 }), "thoughtful")).toBe(false);
     });
 
     test("映画80分 → false", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 80 }), "thoughtful")).toBe(false);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 80 }), "thoughtful")).toBe(false);
     });
   });
 
   describe("quick モード (<40分)", () => {
     test("映画30分 → true", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 30 }), "quick")).toBe(true);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 30 }), "quick")).toBe(true);
     });
 
     test("映画40分 → false", () => {
-      expect(applyModeFilter(createWork({ runtime_minutes: 40 }), "quick")).toBe(false);
+      expect(applyModeFilter(createWorkSummary({ runtime_minutes: 40 }), "quick")).toBe(false);
     });
   });
 
   describe("background モード (background_fit_score ≥50)", () => {
     test("スコア75 → true", () => {
-      expect(applyModeFilter(createWork({ background_fit_score: 75 }), "background")).toBe(true);
+      expect(applyModeFilter(createWorkSummary({ background_fit_score: 75 }), "background")).toBe(
+        true,
+      );
     });
 
     test("スコア50 → true", () => {
-      expect(applyModeFilter(createWork({ background_fit_score: 50 }), "background")).toBe(true);
+      expect(applyModeFilter(createWorkSummary({ background_fit_score: 50 }), "background")).toBe(
+        true,
+      );
     });
 
     test("スコア25 → false", () => {
-      expect(applyModeFilter(createWork({ background_fit_score: 25 }), "background")).toBe(false);
+      expect(applyModeFilter(createWorkSummary({ background_fit_score: 25 }), "background")).toBe(
+        false,
+      );
     });
 
     test("スコア null → false", () => {
-      expect(applyModeFilter(createWork({ background_fit_score: null }), "background")).toBe(false);
+      expect(applyModeFilter(createWorkSummary({ background_fit_score: null }), "background")).toBe(
+        false,
+      );
     });
   });
 });
@@ -131,10 +100,10 @@ describe("sortStackedItemsByViewingMode", () => {
       createItem("d", 4000),
     ];
 
-    items[0].works = createWork({ id: "wa", runtime_minutes: 95 });
-    items[1].works = createWork({ id: "wb", runtime_minutes: 25 });
-    items[2].works = createWork({ id: "wc", runtime_minutes: 110 });
-    items[3].works = createWork({ id: "wd", runtime_minutes: 55 });
+    items[0].works = createWorkSummary({ id: "wa", runtime_minutes: 95 });
+    items[1].works = createWorkSummary({ id: "wb", runtime_minutes: 25 });
+    items[2].works = createWorkSummary({ id: "wc", runtime_minutes: 110 });
+    items[3].works = createWorkSummary({ id: "wd", runtime_minutes: 55 });
 
     expect(sortStackedItemsByViewingMode(items, "focus").map((item) => item.id)).toEqual([
       "a",

--- a/src/test/backlog-fixtures.ts
+++ b/src/test/backlog-fixtures.ts
@@ -1,4 +1,4 @@
-import type { BacklogItem, WorkSummary } from "../features/backlog/types.ts";
+import type { WorkSummary } from "../features/backlog/types.ts";
 
 export function createWorkSummary(overrides: Partial<WorkSummary> = {}): WorkSummary {
   return {
@@ -25,18 +25,6 @@ export function createWorkSummary(overrides: Partial<WorkSummary> = {}): WorkSum
     imdb_rating: null,
     imdb_votes: null,
     metacritic_score: null,
-    ...overrides,
-  };
-}
-
-export function createBacklogItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
-  return {
-    id: "item-1",
-    status: "stacked",
-    primary_platform: null,
-    note: null,
-    sort_order: 1000,
-    works: createWorkSummary(),
     ...overrides,
   };
 }

--- a/src/test/backlog-fixtures.ts
+++ b/src/test/backlog-fixtures.ts
@@ -1,0 +1,42 @@
+import type { BacklogItem, WorkSummary } from "../features/backlog/types.ts";
+
+export function createWorkSummary(overrides: Partial<WorkSummary> = {}): WorkSummary {
+  return {
+    id: "work-1",
+    title: "Test",
+    work_type: "movie",
+    source_type: "tmdb",
+    tmdb_id: 1,
+    tmdb_media_type: "movie",
+    original_title: null,
+    overview: null,
+    poster_path: null,
+    release_date: null,
+    runtime_minutes: null,
+    typical_episode_runtime_minutes: null,
+    duration_bucket: null,
+    genres: [],
+    season_count: null,
+    season_number: null,
+    focus_required_score: null,
+    background_fit_score: null,
+    completion_load_score: null,
+    rotten_tomatoes_score: null,
+    imdb_rating: null,
+    imdb_votes: null,
+    metacritic_score: null,
+    ...overrides,
+  };
+}
+
+export function createBacklogItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
+  return {
+    id: "item-1",
+    status: "stacked",
+    primary_platform: null,
+    note: null,
+    sort_order: 1000,
+    works: createWorkSummary(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- `src/test/backlog-fixtures.ts` を新規作成し、`createWorkSummary()` と `createBacklogItem()` ファクトリを提供
- `WorkSummary` のデフォルトオブジェクト（22フィールド）を各テストファイルに重複して持っていた `createWork` / inline works 定義を、shared fixture に集約
- 対象 16 ファイル：455 行削除、122 行追加（差し引き −333 行）

### 見送った項目

- `UserMenu.test.tsx` の重複（メニュー開閉手順の繰り返し）— fixture 抽出ではなくヘルパー関数化が必要で、別 PR が適切と判断
- 長大ファイル・高複雑度ファイルの構造改善 — 局所修正では片付きにくく、別途検討