### PR TITLE
feat: Toast Undo — DnD・視聴済み移動への操作取り消し

### DIFF
--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -65,6 +65,7 @@ function HookHarness({
   feedback = {
     alert: vi.fn().mockResolvedValue(undefined),
     confirm: vi.fn().mockResolvedValue(true),
+    toast: vi.fn(),
   },
 }: {
   items?: BacklogItem[];
@@ -75,6 +76,7 @@ function HookHarness({
   feedback?: {
     alert: (message: string) => void | Promise<void>;
     confirm: (message: string) => boolean | Promise<boolean>;
+    toast: (message: string) => void;
   };
 }) {
   const { handleDeleteItem, handleAddTmdbWorksToStacked } = useBacklogActions({
@@ -114,6 +116,7 @@ describe("useBacklogActions", () => {
     const feedback = {
       alert: vi.fn().mockResolvedValue(undefined),
       confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
     };
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onItemDeleted = vi.fn();
@@ -138,6 +141,7 @@ describe("useBacklogActions", () => {
     const feedback = {
       alert: vi.fn().mockResolvedValue(undefined),
       confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
     };
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onWorksAdded = vi.fn();
@@ -177,6 +181,7 @@ describe("useBacklogActions", () => {
     const feedback = {
       alert: vi.fn().mockResolvedValue(undefined),
       confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
     };
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onWorksAdded = vi.fn();
@@ -209,6 +214,7 @@ describe("useBacklogActions", () => {
     const feedback = {
       alert: vi.fn().mockResolvedValue(undefined),
       confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
     };
     const user = userEvent.setup();
     repositoryMocks.upsertTmdbWork

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -79,7 +79,7 @@ function HookHarness({
     toast: (message: string) => void;
   };
 }) {
-  const { handleDeleteItem, handleAddTmdbWorksToStacked } = useBacklogActions({
+  const { handleDeleteItem, handleMarkAsWatched, handleAddTmdbWorksToStacked } = useBacklogActions({
     items,
     session: { user: { id: "user-1" } } as Session,
     loadItems,
@@ -92,6 +92,9 @@ function HookHarness({
     <>
       <button type="button" onClick={() => void handleDeleteItem("item-1")}>
         削除
+      </button>
+      <button type="button" onClick={() => void handleMarkAsWatched("item-1")}>
+        視聴済み
       </button>
       <button type="button" onClick={() => void handleAddTmdbWorksToStacked(results)}>
         追加
@@ -110,6 +113,54 @@ describe("useBacklogActions", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  test("視聴済みに移動成功後に feedback.toast をタイトル付きメッセージで呼ぶ", async () => {
+    const feedback = {
+      alert: vi.fn().mockResolvedValue(undefined),
+      confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
+    };
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[createItem({ id: "item-1", status: "stacked" })]}
+        feedback={feedback}
+        loadItems={loadItems}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "視聴済み" }));
+
+    await waitFor(() =>
+      expect(feedback.toast).toHaveBeenCalledWith(
+        "「作品1」を「視聴済み」に移動しました",
+        expect.objectContaining({ onUndo: expect.any(Function) }),
+      ),
+    );
+    expect(loadItems).toHaveBeenCalled();
+  });
+
+  test("視聴済みに移動失敗時は toast を呼ばずに alert を出す", async () => {
+    const feedback = {
+      alert: vi.fn().mockResolvedValue(undefined),
+      confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
+    };
+    repositoryMocks.updateBacklogItem.mockResolvedValueOnce({ error: "更新失敗" });
+
+    const user = userEvent.setup();
+    render(<HookHarness feedback={feedback} />);
+
+    await user.click(screen.getByRole("button", { name: "視聴済み" }));
+
+    await waitFor(() =>
+      expect(feedback.alert).toHaveBeenCalledWith(expect.stringContaining("更新失敗")),
+    );
+    expect(feedback.toast).not.toHaveBeenCalled();
   });
 
   test("delete 失敗時は alert を出して reload や state 更新をしない", async () => {

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -52,6 +52,7 @@ export function useBacklogActions({
   };
 
   const handleMarkAsWatched = async (itemId: string) => {
+    const originalItem = items.find((i) => i.id === itemId);
     const sortOrder = getTopSortOrder(items, "watched");
 
     const { error: updateError } = await updateBacklogItem(itemId, {
@@ -63,6 +64,20 @@ export function useBacklogActions({
       await Promise.resolve(feedback.alert(`変更に失敗しました: ${updateError}`));
       return;
     }
+
+    const title = originalItem?.works?.title;
+    feedback.toast(`${title ? `「${title}」を` : ""}「視聴済み」に移動しました`, {
+      onUndo: async () => {
+        if (!originalItem) return;
+        const { error } = await updateBacklogItem(itemId, {
+          status: originalItem.status,
+          sort_order: originalItem.sort_order,
+        });
+        if (!error) {
+          await loadItems();
+        }
+      },
+    });
 
     await loadItems();
   };

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -2,6 +2,7 @@ import { renderHook, act } from "@testing-library/react";
 import type { DragEndEvent, DragOverEvent, DragStartEvent } from "@dnd-kit/core";
 import { useBacklogDnd } from "./useBacklogDnd.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 
 const supabaseMocks = vi.hoisted(() => {
@@ -128,6 +129,7 @@ describe("useBacklogDnd", () => {
     supabaseMocks.update.mockClear();
     onAfterDrop.mockClear();
     feedback.alert.mockClear();
+    feedback.toast.mockClear();
   });
 
   test("handleDragStart で dragItemId がセットされる", () => {
@@ -173,6 +175,62 @@ describe("useBacklogDnd", () => {
     );
     expect(onAfterDrop).toHaveBeenCalledTimes(1);
     expect(result.current.dragItemId).toBeNull();
+  });
+
+  test("handleDragEnd 成功後に列またぎのメッセージで feedback.toast を呼ぶ", async () => {
+    const items = [
+      createItem({
+        id: "item-1",
+        status: "stacked",
+        sort_order: 1000,
+        works: createWorkSummary({ title: "テスト作品" }),
+      }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+    ];
+    const { result } = renderDnd(items);
+
+    dragOver(result, "item-2", 260);
+
+    await act(async () => {
+      await result.current.handleDragEnd({
+        active: { id: "item-1" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: null,
+      } as unknown as DragEndEvent);
+    });
+
+    expect(feedback.toast).toHaveBeenCalledWith(
+      "「テスト作品」を「視聴中」に移動しました",
+      expect.objectContaining({ onUndo: expect.any(Function) }),
+    );
+  });
+
+  test("handleDragEnd 成功後に同列並び替えのメッセージで feedback.toast を呼ぶ", async () => {
+    const items = [
+      createItem({
+        id: "item-1",
+        status: "stacked",
+        sort_order: 1000,
+        works: createWorkSummary({ title: "テスト作品" }),
+      }),
+      createItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
+    ];
+    const { result } = renderDnd(items);
+
+    dragOver(result, "item-2", 220);
+
+    await act(async () => {
+      await result.current.handleDragEnd({
+        active: { id: "item-1" },
+        over: { id: "item-2", rect: makeRect(100, 200) },
+        activatorEvent: null,
+      } as unknown as DragEndEvent);
+    });
+
+    expect(feedback.toast).toHaveBeenCalledWith(
+      "「テスト作品」の並び順を変更しました",
+      expect.objectContaining({ onUndo: expect.any(Function) }),
+    );
   });
 
   test("handleDragEnd で supabase がエラーを返したら alert を出して onAfterDrop を呼ばない", async () => {

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -74,6 +74,7 @@ const onAfterDrop = vi.fn().mockResolvedValue(undefined);
 const feedback = {
   alert: vi.fn().mockResolvedValue(undefined),
   confirm: vi.fn().mockResolvedValue(true),
+  toast: vi.fn(),
 };
 
 function renderDnd(

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -9,6 +9,8 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core";
 import { supabase } from "../../../lib/supabase.ts";
+import { updateBacklogItem } from "../backlog-repository.ts";
+import { statusLabels } from "../constants.ts";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
 
@@ -204,6 +206,7 @@ export function useBacklogDnd({
       return;
     }
 
+    const originalItem = items.find((i) => i.id === activeId);
     const targetStatus = draggedItem.status;
     const columnOrder = localItems.filter((i) => i.status === targetStatus).map((i) => i.id);
     const insertedIndex = columnOrder.indexOf(activeId);
@@ -230,6 +233,25 @@ export function useBacklogDnd({
         await Promise.resolve(feedback.alert(`ドラッグ移動に失敗しました: ${updateError.message}`));
         setLocalItems(items);
         return;
+      }
+
+      if (originalItem) {
+        const isCrossColumn = originalItem.status !== targetStatus;
+        const title = originalItem.works?.title;
+        const message = isCrossColumn
+          ? `${title ? `「${title}」を` : ""}「${statusLabels[targetStatus]}」に移動しました`
+          : `${title ? `「${title}」の` : ""}並び順を変更しました`;
+        feedback.toast(message, {
+          onUndo: async () => {
+            const { error } = await updateBacklogItem(activeId, {
+              status: originalItem.status,
+              sort_order: originalItem.sort_order,
+            });
+            if (!error) {
+              await onAfterDrop();
+            }
+          },
+        });
       }
 
       await onAfterDrop();

--- a/src/features/backlog/hooks/useBacklogFeedback.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.tsx
@@ -1,11 +1,18 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
-import type { BacklogFeedback } from "../ui-feedback.ts";
+import type { BacklogFeedback, ToastOptions } from "../ui-feedback.ts";
 
 type ConfirmState = {
   message: string;
   resolve: (result: boolean) => void;
 };
+
+type ToastState = {
+  message: string;
+  onUndo?: ToastOptions["onUndo"];
+};
+
+const TOAST_AUTO_DISMISS_MS = 5000;
 
 function FeedbackAlert({ message, onClose }: { message: string; onClose: () => void }) {
   return (
@@ -60,9 +67,53 @@ function FeedbackConfirmDialog({
   );
 }
 
+function FeedbackToast({
+  message,
+  onUndo,
+  onClose,
+}: {
+  message: string;
+  onUndo?: () => void | Promise<void>;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-x-0 bottom-6 z-50 flex justify-center px-4"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="w-full max-w-[560px] rounded-[24px] border border-border bg-[rgba(28,28,28,0.96)] px-5 py-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)] backdrop-blur-xl">
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm leading-6 text-foreground">{message}</p>
+          <div className="flex shrink-0 items-center gap-2">
+            {onUndo && (
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-full"
+                onClick={() => {
+                  void onUndo();
+                  onClose();
+                }}
+              >
+                元に戻す
+              </Button>
+            )}
+            <Button type="button" variant="ghost" className="rounded-full" onClick={onClose}>
+              閉じる
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function useBacklogFeedback() {
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
+  const [toastState, setToastState] = useState<ToastState | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
@@ -70,6 +121,9 @@ export function useBacklogFeedback() {
         current?.resolve(false);
         return null;
       });
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
     };
   }, []);
 
@@ -82,12 +136,30 @@ export function useBacklogFeedback() {
         new Promise<boolean>((resolve) => {
           setConfirmState({ message, resolve });
         }),
+      toast: (message, options) => {
+        if (toastTimerRef.current) {
+          clearTimeout(toastTimerRef.current);
+        }
+        setToastState({ message, onUndo: options?.onUndo });
+        toastTimerRef.current = setTimeout(() => {
+          setToastState(null);
+          toastTimerRef.current = null;
+        }, TOAST_AUTO_DISMISS_MS);
+      },
     }),
     [],
   );
 
   const handleCloseAlert = () => {
     setAlertMessage(null);
+  };
+
+  const handleCloseToast = () => {
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = null;
+    }
+    setToastState(null);
   };
 
   const settleConfirm = (result: boolean) => {
@@ -105,6 +177,13 @@ export function useBacklogFeedback() {
           message={confirmState.message}
           onCancel={() => settleConfirm(false)}
           onConfirm={() => settleConfirm(true)}
+        />
+      ) : null}
+      {toastState ? (
+        <FeedbackToast
+          message={toastState.message}
+          onUndo={toastState.onUndo}
+          onClose={handleCloseToast}
         />
       ) : null}
     </>

--- a/src/features/backlog/hooks/useBoardPageController.test.tsx
+++ b/src/features/backlog/hooks/useBoardPageController.test.tsx
@@ -50,6 +50,7 @@ vi.mock("./useBacklogFeedback.tsx", () => ({
     feedback: {
       alert: vi.fn().mockResolvedValue(undefined),
       confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn(),
     },
     feedbackUi: null,
   }),

--- a/src/features/backlog/ui-feedback.ts
+++ b/src/features/backlog/ui-feedback.ts
@@ -1,6 +1,11 @@
+export type ToastOptions = {
+  onUndo?: () => void | Promise<void>;
+};
+
 export type BacklogFeedback = {
   alert: (message: string) => void | Promise<void>;
   confirm: (message: string) => boolean | Promise<boolean>;
+  toast: (message: string, options?: ToastOptions) => void;
 };
 
 export const browserBacklogFeedback: BacklogFeedback = {
@@ -8,4 +13,5 @@ export const browserBacklogFeedback: BacklogFeedback = {
     globalThis.alert(message);
   },
   confirm: (message) => globalThis.confirm(message),
+  toast: () => {},
 };


### PR DESCRIPTION
## 関連 Issue

Closes #160

## 変更内容

- `BacklogFeedback` に `toast(message, options?)` メソッドを追加（`ui-feedback.ts`）
- `useBacklogFeedback` に `FeedbackToast` コンポーネントを追加（画面下部・5秒後自動消去）
- DnD のドロップ成功後に「元に戻す」付き Toast を表示（列またぎ・同列並び替えの両方に対応）
- 「視聴済みに移動」成功後に「元に戻す」付き Toast を表示
- Undo クリックで元の status/sort_order に逆更新し `loadItems` でサーバー反映を確認
- 各フィードバックモックに `toast` を追加してテスト維持
- DnD と `handleMarkAsWatched` の toast 呼び出しテストを追加