### PR TITLE
refactor: backlog リファクタリング基盤を分割

### DIFF
--- a/src/features/backlog/work-repository-helpers.ts
+++ b/src/features/backlog/work-repository-helpers.ts
@@ -1,0 +1,126 @@
+import type { PostgrestError, PostgrestSingleResponse } from "@supabase/supabase-js";
+import type {
+  TmdbSeasonOption,
+  TmdbSeasonSelectionTarget,
+  TmdbSearchResult,
+  TmdbSelectionTarget,
+} from "../../lib/tmdb.ts";
+import type { WorkType } from "./types.ts";
+import { buildTmdbWorkUpdate } from "./work-metadata.ts";
+
+const TMDB_WORK_REFRESH_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
+const OMDB_WORK_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type OkResponseData = { id: string };
+
+export type TmdbWorkIdResponse = PostgrestSingleResponse<{ id: string }>;
+
+export function shouldRefreshOmdbWork(
+  omdbFetchedAt: string | null,
+  now = Date.now(),
+  refreshIntervalMs = OMDB_WORK_REFRESH_INTERVAL_MS,
+) {
+  return shouldRefreshTimestamp(omdbFetchedAt, now, refreshIntervalMs);
+}
+
+export function shouldRefreshTmdbWork(
+  lastSyncedAt: string | null,
+  now = Date.now(),
+  refreshIntervalMs = TMDB_WORK_REFRESH_INTERVAL_MS,
+) {
+  return shouldRefreshTimestamp(lastSyncedAt, now, refreshIntervalMs);
+}
+
+function shouldRefreshTimestamp(timestamp: string | null, now: number, refreshIntervalMs: number) {
+  if (!timestamp) {
+    return true;
+  }
+
+  const parsedTimestamp = Date.parse(timestamp);
+  if (Number.isNaN(parsedTimestamp)) {
+    return true;
+  }
+
+  return now - parsedTimestamp >= refreshIntervalMs;
+}
+
+export function buildSelectedSeasonTargets(
+  seriesResult: TmdbSearchResult,
+  seasonOptions: TmdbSeasonOption[],
+  seasonNumbers: number[],
+): TmdbSelectionTarget[] {
+  const normalizedSeasonNumbers = [...new Set(seasonNumbers)].sort((left, right) => left - right);
+  const seasonOptionsByNumber = new Map(
+    seasonOptions.map((season) => [season.seasonNumber, season] as const),
+  );
+
+  return normalizedSeasonNumbers.map((seasonNumber) => {
+    if (seasonNumber === 1) {
+      return seriesResult;
+    }
+
+    const season = seasonOptionsByNumber.get(seasonNumber);
+    if (!season) {
+      throw new Error(`シーズン${seasonNumber}の情報が見つかりません`);
+    }
+
+    return {
+      tmdbId: seriesResult.tmdbId,
+      tmdbMediaType: "tv",
+      workType: "season",
+      title: season.title,
+      originalTitle: seriesResult.originalTitle,
+      overview: season.overview,
+      posterPath: season.posterPath,
+      releaseDate: season.releaseDate,
+      seasonNumber,
+      episodeCount: season.episodeCount,
+      seriesTitle: seriesResult.title,
+    };
+  });
+}
+
+export function buildTmdbSeriesTarget(target: TmdbSeasonSelectionTarget): TmdbSearchResult {
+  return {
+    tmdbId: target.tmdbId,
+    tmdbMediaType: "tv",
+    workType: "series",
+    title: target.seriesTitle,
+    originalTitle: target.originalTitle,
+    overview: target.overview,
+    posterPath: target.posterPath,
+    releaseDate: target.releaseDate,
+    jpWatchPlatforms: [],
+    hasJapaneseRelease: false,
+  };
+}
+
+export function buildTmdbWorkInsert(
+  details: Parameters<typeof buildTmdbWorkUpdate>[0],
+  userId: string,
+  workType: WorkType,
+  parentWorkId: string | null = null,
+) {
+  return {
+    created_by: userId,
+    source_type: "tmdb" as const,
+    tmdb_media_type: details.tmdbMediaType,
+    tmdb_id: details.tmdbId,
+    work_type: workType,
+    parent_work_id: parentWorkId,
+    ...buildTmdbWorkUpdate(details),
+  };
+}
+
+export function buildErrorIdResponse(
+  error: PostgrestError,
+  status = 400,
+  statusText = "Bad Request",
+): TmdbWorkIdResponse {
+  return { success: false, data: null, error, count: null, status, statusText };
+}
+
+export function buildOkIdResponse(id: string): TmdbWorkIdResponse {
+  const data: OkResponseData = { id };
+  return { success: true, data, error: null, count: null, status: 200, statusText: "OK" };
+}

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -11,10 +11,22 @@ import { fetchOmdbWorkDetails } from "../../lib/omdb.ts";
 import { buildSearchText } from "./helpers.ts";
 import type { WorkType } from "./types.ts";
 import { buildTmdbWorkUpdate, calcBackgroundFitScore, type RatingInfo } from "./work-metadata.ts";
+import {
+  buildErrorIdResponse,
+  buildOkIdResponse,
+  buildSelectedSeasonTargets,
+  buildTmdbSeriesTarget,
+  buildTmdbWorkInsert,
+  shouldRefreshOmdbWork,
+  shouldRefreshTmdbWork,
+  type TmdbWorkIdResponse,
+} from "./work-repository-helpers.ts";
+export {
+  buildSelectedSeasonTargets,
+  shouldRefreshOmdbWork,
+  shouldRefreshTmdbWork,
+} from "./work-repository-helpers.ts";
 
-const TMDB_WORK_REFRESH_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000;
-const OMDB_WORK_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
-type TmdbWorkIdResponse = PostgrestSingleResponse<{ id: string }>;
 type ExistingTmdbWorkRow = {
   id: string;
   last_tmdb_synced_at: string | null;
@@ -33,41 +45,6 @@ type UpsertFetchedTmdbWorkOptions = {
   seasonNumber?: number;
   workType?: WorkType;
 };
-type OkResponseData = { id: string };
-
-export function shouldRefreshOmdbWork(
-  omdbFetchedAt: string | null,
-  now = Date.now(),
-  refreshIntervalMs = OMDB_WORK_REFRESH_INTERVAL_MS,
-) {
-  if (!omdbFetchedAt) {
-    return true;
-  }
-
-  const fetchedAtMs = Date.parse(omdbFetchedAt);
-  if (Number.isNaN(fetchedAtMs)) {
-    return true;
-  }
-
-  return now - fetchedAtMs >= refreshIntervalMs;
-}
-
-export function shouldRefreshTmdbWork(
-  lastSyncedAt: string | null,
-  now = Date.now(),
-  refreshIntervalMs = TMDB_WORK_REFRESH_INTERVAL_MS,
-) {
-  if (!lastSyncedAt) {
-    return true;
-  }
-
-  const syncedAtMs = Date.parse(lastSyncedAt);
-  if (Number.isNaN(syncedAtMs)) {
-    return true;
-  }
-
-  return now - syncedAtMs >= refreshIntervalMs;
-}
 
 export async function upsertTmdbWork(
   target: TmdbSelectionTarget,
@@ -138,42 +115,6 @@ export async function upsertManualWork(
   return buildErrorIdResponse(insertResult.error, 409, "Conflict");
 }
 
-export function buildSelectedSeasonTargets(
-  seriesResult: TmdbSearchResult,
-  seasonOptions: TmdbSeasonOption[],
-  seasonNumbers: number[],
-): TmdbSelectionTarget[] {
-  const normalizedSeasonNumbers = [...new Set(seasonNumbers)].sort((left, right) => left - right);
-  const seasonOptionsByNumber = new Map(
-    seasonOptions.map((season) => [season.seasonNumber, season] as const),
-  );
-
-  return normalizedSeasonNumbers.map((seasonNumber) => {
-    if (seasonNumber === 1) {
-      return seriesResult;
-    }
-
-    const season = seasonOptionsByNumber.get(seasonNumber);
-    if (!season) {
-      throw new Error(`シーズン${seasonNumber}の情報が見つかりません`);
-    }
-
-    return {
-      tmdbId: seriesResult.tmdbId,
-      tmdbMediaType: "tv",
-      workType: "season",
-      title: season.title,
-      originalTitle: seriesResult.originalTitle,
-      overview: season.overview,
-      posterPath: season.posterPath,
-      releaseDate: season.releaseDate,
-      seasonNumber,
-      episodeCount: season.episodeCount,
-      seriesTitle: seriesResult.title,
-    };
-  });
-}
-
 type ResolveSelectedSeasonWorkIdsOptions = {
   seasonOptions: TmdbSeasonOption[];
 };
@@ -212,23 +153,6 @@ export async function resolveSelectedSeasonWorkIds(
   }
 
   return { error: null, workIds };
-}
-
-function buildTmdbWorkInsert(
-  details: Parameters<typeof buildTmdbWorkUpdate>[0],
-  userId: string,
-  workType: WorkType,
-  parentWorkId: string | null = null,
-) {
-  return {
-    created_by: userId,
-    source_type: "tmdb" as const,
-    tmdb_media_type: details.tmdbMediaType,
-    tmdb_id: details.tmdbId,
-    work_type: workType,
-    parent_work_id: parentWorkId,
-    ...buildTmdbWorkUpdate(details),
-  };
 }
 
 async function upsertTmdbSeasonWork(
@@ -278,113 +202,23 @@ async function upsertFetchedTmdbWork(
   userId: string,
   options: UpsertFetchedTmdbWorkOptions = {},
 ): Promise<TmdbWorkIdResponse> {
-  const workType = options.workType ?? target.workType;
-  const seasonNumber =
-    options.seasonNumber ?? (target.workType === "season" ? target.seasonNumber : undefined);
-  const { data: existing, error: selectError } = await findExistingTmdbWork({
-    tmdbMediaType: target.tmdbMediaType,
-    tmdbId: target.tmdbId,
-    workType,
-    seasonNumber,
-  });
+  const lookup = buildTmdbWorkLookup(target, options);
+  const { data: existing, error: selectError } = await findExistingTmdbWork(lookup);
 
   if (selectError) {
     return buildErrorIdResponse(selectError);
   }
 
-  const shouldRefreshTmdb = !existing || shouldRefreshTmdbWork(existing.last_tmdb_synced_at);
-  const shouldRefreshOmdb = !existing || shouldRefreshOmdbWork(existing.omdb_fetched_at);
-  const shouldSyncTmdbForOmdb = Boolean(existing && shouldRefreshOmdb && !existing.imdb_id);
-
-  if (existing && !shouldRefreshTmdb && !shouldSyncTmdbForOmdb) {
-    if (existing.imdb_id && shouldRefreshOmdb) {
-      try {
-        const omdb = await fetchOmdbWorkDetails(existing.imdb_id);
-        const omdbRatings: RatingInfo = {
-          imdbRating: omdb.imdbRating,
-          rottenTomatoesScore: omdb.rottenTomatoesScore,
-        };
-        await supabase
-          .from("works")
-          .update({
-            rotten_tomatoes_score: omdb.rottenTomatoesScore,
-            imdb_rating: omdb.imdbRating,
-            imdb_votes: omdb.imdbVotes,
-            metacritic_score: omdb.metacriticScore,
-            background_fit_score: calcBackgroundFitScore(existing.genres, omdbRatings),
-            omdb_fetched_at: new Date().toISOString(),
-          })
-          .eq("id", existing.id);
-      } catch {
-        // OMDb 更新の失敗は TMDb の early return をブロックしない
-      }
-    }
+  const syncState = buildTmdbSyncState(existing);
+  if (existing && !syncState.shouldRefreshTmdb && !syncState.shouldSyncTmdbForOmdb) {
+    await refreshExistingOmdbFields(existing, syncState.shouldRefreshOmdb);
     return buildOkIdResponse(existing.id);
   }
 
   const details = await fetchTmdbWorkDetails(target);
-
-  const omdbFields = await (async () => {
-    const omdbFetchedAt = new Date().toISOString();
-
-    if (details.imdbId === null) {
-      if (
-        existing &&
-        !shouldRefreshOmdbWork(existing.omdb_fetched_at) &&
-        existing.imdb_id === null
-      ) {
-        return {};
-      }
-
-      return {
-        rotten_tomatoes_score: null,
-        imdb_rating: null,
-        imdb_votes: null,
-        metacritic_score: null,
-        omdb_fetched_at: omdbFetchedAt,
-      };
-    }
-
-    if (!details.imdbId) return {};
-    if (
-      existing &&
-      !shouldRefreshOmdbWork(existing.omdb_fetched_at) &&
-      existing.imdb_id === details.imdbId
-    ) {
-      return {};
-    }
-    try {
-      const omdb = await fetchOmdbWorkDetails(details.imdbId);
-      return {
-        rotten_tomatoes_score: omdb.rottenTomatoesScore,
-        imdb_rating: omdb.imdbRating,
-        imdb_votes: omdb.imdbVotes,
-        metacritic_score: omdb.metacriticScore,
-        omdb_fetched_at: omdbFetchedAt,
-      };
-    } catch {
-      return {};
-    }
-  })();
-
-  const omdbRatings: RatingInfo = {
-    imdbRating: "imdb_rating" in omdbFields ? (omdbFields.imdb_rating ?? null) : null,
-    rottenTomatoesScore:
-      "rotten_tomatoes_score" in omdbFields ? (omdbFields.rotten_tomatoes_score ?? null) : null,
-  };
-  const updatePayload =
-    options.parentWorkId === undefined
-      ? {
-          ...buildTmdbWorkUpdate(details),
-          ...omdbFields,
-          background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
-        }
-      : {
-          ...buildTmdbWorkUpdate(details),
-          ...omdbFields,
-          background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
-          parent_work_id: options.parentWorkId,
-        };
+  const omdbFields = await buildOmdbFields(details, existing);
+  const omdbRatings = buildOmdbRatings(omdbFields);
+  const updatePayload = buildTmdbUpdatePayload(details, omdbFields, options.parentWorkId);
 
   if (existing) {
     const { error: updateError } = await supabase
@@ -402,7 +236,7 @@ async function upsertFetchedTmdbWork(
   return supabase
     .from("works")
     .insert({
-      ...buildTmdbWorkInsert(details, userId, workType, options.parentWorkId ?? null),
+      ...buildTmdbWorkInsert(details, userId, lookup.workType, options.parentWorkId ?? null),
       ...omdbFields,
       background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
     })
@@ -410,30 +244,135 @@ async function upsertFetchedTmdbWork(
     .single();
 }
 
-function buildTmdbSeriesTarget(target: TmdbSeasonSelectionTarget): TmdbSearchResult {
+function buildTmdbWorkLookup(
+  target: TmdbSelectionTarget,
+  options: UpsertFetchedTmdbWorkOptions,
+): TmdbWorkLookup {
   return {
+    tmdbMediaType: target.tmdbMediaType,
     tmdbId: target.tmdbId,
-    tmdbMediaType: "tv",
-    workType: "series",
-    title: target.seriesTitle,
-    originalTitle: target.originalTitle,
-    overview: target.overview,
-    posterPath: target.posterPath,
-    releaseDate: target.releaseDate,
-    jpWatchPlatforms: [],
-    hasJapaneseRelease: false,
+    workType: options.workType ?? target.workType,
+    seasonNumber:
+      options.seasonNumber ?? (target.workType === "season" ? target.seasonNumber : undefined),
   };
 }
 
-function buildErrorIdResponse(
-  error: PostgrestError,
-  status = 400,
-  statusText = "Bad Request",
-): TmdbWorkIdResponse {
-  return { success: false, data: null, error, count: null, status, statusText };
+function buildTmdbSyncState(existing: ExistingTmdbWorkRow | null) {
+  const shouldRefreshTmdb = !existing || shouldRefreshTmdbWork(existing.last_tmdb_synced_at);
+  const shouldRefreshOmdb = !existing || shouldRefreshOmdbWork(existing.omdb_fetched_at);
+
+  return {
+    shouldRefreshTmdb,
+    shouldRefreshOmdb,
+    shouldSyncTmdbForOmdb: Boolean(existing && shouldRefreshOmdb && !existing.imdb_id),
+  };
 }
 
-function buildOkIdResponse(id: string): TmdbWorkIdResponse {
-  const data: OkResponseData = { id };
-  return { success: true, data, error: null, count: null, status: 200, statusText: "OK" };
+async function refreshExistingOmdbFields(
+  existing: ExistingTmdbWorkRow,
+  shouldRefreshOmdb: boolean,
+) {
+  if (!existing.imdb_id || !shouldRefreshOmdb) {
+    return;
+  }
+
+  try {
+    const omdb = await fetchOmdbWorkDetails(existing.imdb_id);
+    const omdbRatings: RatingInfo = {
+      imdbRating: omdb.imdbRating,
+      rottenTomatoesScore: omdb.rottenTomatoesScore,
+    };
+
+    await supabase
+      .from("works")
+      .update({
+        rotten_tomatoes_score: omdb.rottenTomatoesScore,
+        imdb_rating: omdb.imdbRating,
+        imdb_votes: omdb.imdbVotes,
+        metacritic_score: omdb.metacriticScore,
+        background_fit_score: calcBackgroundFitScore(existing.genres, omdbRatings),
+        omdb_fetched_at: new Date().toISOString(),
+      })
+      .eq("id", existing.id);
+  } catch {
+    // OMDb 更新の失敗は TMDb の early return をブロックしない
+  }
+}
+
+type OmdbFields = {
+  rotten_tomatoes_score?: number | null;
+  imdb_rating?: number | null;
+  imdb_votes?: number | null;
+  metacritic_score?: number | null;
+  omdb_fetched_at?: string;
+};
+
+async function buildOmdbFields(
+  details: Awaited<ReturnType<typeof fetchTmdbWorkDetails>>,
+  existing: ExistingTmdbWorkRow | null,
+): Promise<OmdbFields> {
+  const omdbFetchedAt = new Date().toISOString();
+
+  if (details.imdbId === null) {
+    return shouldKeepExistingNullOmdbState(existing)
+      ? {}
+      : {
+          rotten_tomatoes_score: null,
+          imdb_rating: null,
+          imdb_votes: null,
+          metacritic_score: null,
+          omdb_fetched_at: omdbFetchedAt,
+        };
+  }
+
+  if (!details.imdbId || shouldSkipOmdbRefresh(existing, details.imdbId)) {
+    return {};
+  }
+
+  try {
+    const omdb = await fetchOmdbWorkDetails(details.imdbId);
+    return {
+      rotten_tomatoes_score: omdb.rottenTomatoesScore,
+      imdb_rating: omdb.imdbRating,
+      imdb_votes: omdb.imdbVotes,
+      metacritic_score: omdb.metacriticScore,
+      omdb_fetched_at: omdbFetchedAt,
+    };
+  } catch {
+    return {};
+  }
+}
+
+function shouldKeepExistingNullOmdbState(existing: ExistingTmdbWorkRow | null) {
+  return Boolean(
+    existing && !shouldRefreshOmdbWork(existing.omdb_fetched_at) && existing.imdb_id === null,
+  );
+}
+
+function shouldSkipOmdbRefresh(existing: ExistingTmdbWorkRow | null, imdbId: string) {
+  return Boolean(
+    existing && !shouldRefreshOmdbWork(existing.omdb_fetched_at) && existing.imdb_id === imdbId,
+  );
+}
+
+function buildOmdbRatings(omdbFields: OmdbFields): RatingInfo {
+  return {
+    imdbRating: "imdb_rating" in omdbFields ? (omdbFields.imdb_rating ?? null) : null,
+    rottenTomatoesScore:
+      "rotten_tomatoes_score" in omdbFields ? (omdbFields.rotten_tomatoes_score ?? null) : null,
+  };
+}
+
+function buildTmdbUpdatePayload(
+  details: Awaited<ReturnType<typeof fetchTmdbWorkDetails>>,
+  omdbFields: OmdbFields,
+  parentWorkId: string | undefined,
+) {
+  const omdbRatings = buildOmdbRatings(omdbFields);
+  return {
+    ...buildTmdbWorkUpdate(details),
+    ...omdbFields,
+    background_fit_score: calcBackgroundFitScore(details.genres, omdbRatings),
+    ...(parentWorkId === undefined ? {} : { parent_work_id: parentWorkId }),
+  };
 }

--- a/src/lib/refactoring-backlog-paths.ts
+++ b/src/lib/refactoring-backlog-paths.ts
@@ -1,0 +1,85 @@
+const REPO_PATH_SEGMENTS = ["src/", "supabase/", ".github/", "docs/", "public/"] as const;
+
+export function matchesAnyPattern(path: string, patterns: readonly string[]) {
+  return patterns.some((pattern) => matchesGlobPattern(path, pattern));
+}
+
+export function sanitizeAbsolutePaths(value: string) {
+  return value.replaceAll(
+    /(^|[\s("'`[])(\/[^\s"'`)\]]*)/g,
+    (fullMatch, prefix: string, candidate: string) => {
+      const { path, suffix } = splitTrailingPunctuation(candidate);
+      const sanitized = toDisplayPath(path);
+      return sanitized === path ? fullMatch : `${prefix}${sanitized}${suffix}`;
+    },
+  );
+}
+
+export function toDisplayPath(value: string) {
+  const normalized = normalizePathForMatch(value);
+  if (!normalized.startsWith("/")) {
+    return normalized;
+  }
+
+  const repoRelative = stripRepoPrefix(normalized);
+  if (repoRelative !== null) {
+    return repoRelative;
+  }
+
+  if (normalized.endsWith("/pnpm-lock.yaml")) {
+    return "pnpm-lock.yaml";
+  }
+
+  return normalized.split("/").findLast(Boolean) ?? normalized;
+}
+
+function matchesGlobPattern(path: string, pattern: string) {
+  const normalizedPath = normalizePathForMatch(path);
+  const normalizedPattern = normalizePathForMatch(pattern);
+  const source = normalizedPattern
+    .replaceAll(/[|\\{}()[\]^$+?.]/g, String.raw`\$&`)
+    .replaceAll(/\*\*/g, "__DOUBLE_STAR__")
+    .replaceAll(/\*/g, "[^/]*")
+    .replaceAll(/__DOUBLE_STAR__/g, ".*");
+  return new RegExp(`^${source}$`).test(normalizedPath);
+}
+
+function normalizePathForMatch(value: string) {
+  return value.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function stripRepoPrefix(normalizedPath: string): string | null {
+  for (const segment of REPO_PATH_SEGMENTS) {
+    const marker = `/${segment}`;
+    const index = normalizedPath.lastIndexOf(marker);
+    if (index >= 0) {
+      return normalizedPath.slice(index + 1);
+    }
+  }
+
+  return null;
+}
+
+function splitTrailingPunctuation(value: string) {
+  let index = value.length;
+
+  while (index > 0 && isTrailingPunctuation(value[index - 1])) {
+    index -= 1;
+  }
+
+  return {
+    path: value.slice(0, index),
+    suffix: value.slice(index),
+  };
+}
+
+function isTrailingPunctuation(value: string) {
+  return (
+    value === "." ||
+    value === "," ||
+    value === ":" ||
+    value === ";" ||
+    value === "!" ||
+    value === "?"
+  );
+}

--- a/src/lib/refactoring-backlog-render.ts
+++ b/src/lib/refactoring-backlog-render.ts
@@ -1,0 +1,187 @@
+import { sanitizeAbsolutePaths, toDisplayPath } from "./refactoring-backlog-paths.ts";
+
+type SonarIssueLike = {
+  key: string;
+  message: string;
+  component: string;
+  line?: number;
+  rule?: string;
+  effortMinutes?: number;
+};
+
+type RankedSignalLike = {
+  path: string;
+  value: number;
+  detail: string;
+};
+
+type QuickWinGroup = {
+  key: string;
+  label: string;
+  count: number;
+  examples: SonarIssueLike[];
+  minEffortMinutes?: number;
+};
+
+export function renderQuickWinIssues(
+  projectKey: string,
+  sonarBaseUrl: string,
+  issues: SonarIssueLike[],
+) {
+  if (issues.length === 0) {
+    return ["- 今回は quick win 候補なし"];
+  }
+
+  return groupQuickWinIssues(issues, projectKey).flatMap((group) => [
+    renderQuickWinGroupHeader(group),
+    ...group.examples.map((example) => renderQuickWinExample(example, projectKey, sonarBaseUrl)),
+  ]);
+}
+
+export function renderRankedSignals(
+  rows: RankedSignalLike[],
+  valueLabel: string,
+  detailLabel: string,
+) {
+  if (rows.length === 0) {
+    return ["- 該当なし"];
+  }
+
+  return [
+    `| file | ${valueLabel} | ${detailLabel} |`,
+    "| --- | ---: | --- |",
+    ...rows.map(
+      (row) =>
+        `| \`${toDisplayPath(row.path)}\` | ${formatRankValue(valueLabel, row.value)} | ${row.detail} |`,
+    ),
+  ];
+}
+
+export function formatMinutes(value: number | undefined) {
+  if (value == null) {
+    return "-";
+  }
+
+  const hours = Math.floor(value / 60);
+  const minutes = value % 60;
+
+  if (hours === 0) {
+    return `${minutes} min`;
+  }
+
+  if (minutes === 0) {
+    return `${hours} h`;
+  }
+
+  return `${hours} h ${minutes} min`;
+}
+
+export function formatPercent(value: number | undefined) {
+  if (value == null) {
+    return "-";
+  }
+
+  return `${value.toFixed(1)}%`;
+}
+
+export function formatNumber(value: number | undefined) {
+  if (value == null) {
+    return "-";
+  }
+
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+}
+
+function renderQuickWinGroupHeader(group: QuickWinGroup) {
+  const effortLabel = group.minEffortMinutes
+    ? `最短 ${group.minEffortMinutes} min`
+    : "effort unknown";
+  return `- ${group.label} - ${formatNumber(group.count)}件 (${effortLabel})`;
+}
+
+function renderQuickWinExample(example: SonarIssueLike, projectKey: string, sonarBaseUrl: string) {
+  const path = toDisplayPath(normalizeComponentPath(example.component, projectKey));
+  const line = example.line ? `:${example.line}` : "";
+  const issueUrl = `${trimTrailingSlash(sonarBaseUrl)}/project/issues?id=${encodeURIComponent(projectKey)}&open=${encodeURIComponent(example.key)}`;
+  return `  - 例: [${path}${line}](${issueUrl})`;
+}
+
+function formatRankValue(label: string, value: number) {
+  return label === "duplicated lines density" ? formatPercent(value) : formatNumber(value);
+}
+
+function groupQuickWinIssues(issues: SonarIssueLike[], projectKey: string): QuickWinGroup[] {
+  const grouped = new Map<string, QuickWinGroup>();
+
+  for (const issue of issues) {
+    const label = sanitizeAbsolutePaths(issue.message);
+    const key = issue.rule ? `${issue.rule}::${label}` : label;
+    mergeIssueIntoGroup(grouped, key, label, issue);
+  }
+
+  return [...grouped.values()].sort((left, right) =>
+    compareQuickWinGroups(left, right, projectKey),
+  );
+}
+
+function mergeIssueIntoGroup(
+  grouped: Map<string, QuickWinGroup>,
+  key: string,
+  label: string,
+  issue: SonarIssueLike,
+) {
+  const current = grouped.get(key);
+  if (!current) {
+    grouped.set(key, {
+      key,
+      label,
+      count: 1,
+      examples: [issue],
+      minEffortMinutes: issue.effortMinutes,
+    });
+    return;
+  }
+
+  current.count += 1;
+  current.minEffortMinutes = minDefined(current.minEffortMinutes, issue.effortMinutes);
+  if (current.examples.length < 3) {
+    current.examples.push(issue);
+  }
+}
+
+function compareQuickWinGroups(left: QuickWinGroup, right: QuickWinGroup, projectKey: string) {
+  const leftExamplePath = normalizeComponentPath(left.examples[0]?.component ?? "", projectKey);
+  const rightExamplePath = normalizeComponentPath(right.examples[0]?.component ?? "", projectKey);
+
+  return (
+    effortOrInfinity(left.minEffortMinutes) - effortOrInfinity(right.minEffortMinutes) ||
+    right.count - left.count ||
+    leftExamplePath.localeCompare(rightExamplePath) ||
+    left.key.localeCompare(right.key)
+  );
+}
+
+function normalizeComponentPath(component: string, projectKey: string) {
+  const prefix = `${projectKey}:`;
+  return component.startsWith(prefix) ? component.slice(prefix.length) : component;
+}
+
+function trimTrailingSlash(value: string) {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function effortOrInfinity(value: number | undefined) {
+  return value ?? Number.POSITIVE_INFINITY;
+}
+
+function minDefined(left: number | undefined, right: number | undefined) {
+  if (left == null) {
+    return right;
+  }
+
+  if (right == null) {
+    return left;
+  }
+
+  return Math.min(left, right);
+}

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -1,10 +1,18 @@
+import { matchesAnyPattern } from "./refactoring-backlog-paths.ts";
+import {
+  formatMinutes,
+  formatNumber,
+  formatPercent,
+  renderQuickWinIssues,
+  renderRankedSignals,
+} from "./refactoring-backlog-render.ts";
+
 const REFACTORING_BACKLOG_MARKER = "<!-- refactoring-backlog:sonarcloud -->";
 const DEFAULT_BACKLOG_EXCLUDE_PATTERNS = [
   "pnpm-lock.yaml",
   "supabase/templates/**",
   "supabase/seed.sql",
 ] as const;
-const REPO_PATH_SEGMENTS = ["src/", "supabase/", ".github/", "docs/", "public/"] as const;
 
 export type SonarMeasureKey =
   | "code_smells"
@@ -35,14 +43,6 @@ type RankedSignal = {
   path: string;
   value: number;
   detail: string;
-};
-
-type QuickWinGroup = {
-  key: string;
-  label: string;
-  count: number;
-  examples: SonarIssue[];
-  minEffortMinutes?: number;
 };
 
 type RefactoringBacklogInput = {
@@ -249,235 +249,6 @@ export function buildRefactoringBacklogIssue({
   };
 }
 
-function renderQuickWinIssues(projectKey: string, sonarBaseUrl: string, issues: SonarIssue[]) {
-  if (issues.length === 0) {
-    return ["- 今回は quick win 候補なし"];
-  }
-
-  return groupQuickWinIssues(issues, projectKey).flatMap((group) => [
-    renderQuickWinGroupHeader(group),
-    ...group.examples.map((example) => renderQuickWinExample(example, projectKey, sonarBaseUrl)),
-  ]);
-}
-
-function renderQuickWinGroupHeader(group: QuickWinGroup) {
-  const effortLabel = group.minEffortMinutes
-    ? `最短 ${group.minEffortMinutes} min`
-    : "effort unknown";
-  return `- ${group.label} - ${formatNumber(group.count)}件 (${effortLabel})`;
-}
-
-function renderQuickWinExample(example: SonarIssue, projectKey: string, sonarBaseUrl: string) {
-  const path = toDisplayPath(normalizeComponentPath(example.component, projectKey));
-  const line = example.line ? `:${example.line}` : "";
-  const issueUrl = `${trimTrailingSlash(sonarBaseUrl)}/project/issues?id=${encodeURIComponent(projectKey)}&open=${encodeURIComponent(example.key)}`;
-  return `  - 例: [${path}${line}](${issueUrl})`;
-}
-
-function renderRankedSignals(rows: RankedSignal[], valueLabel: string, detailLabel: string) {
-  if (rows.length === 0) {
-    return ["- 該当なし"];
-  }
-
-  return [
-    `| file | ${valueLabel} | ${detailLabel} |`,
-    "| --- | ---: | --- |",
-    ...rows.map(
-      (row) =>
-        `| \`${toDisplayPath(row.path)}\` | ${formatRankValue(valueLabel, row.value)} | ${row.detail} |`,
-    ),
-  ];
-}
-
-function formatRankValue(label: string, value: number) {
-  return label === "duplicated lines density" ? formatPercent(value) : formatNumber(value);
-}
-
-function formatMinutes(value: number | undefined) {
-  if (value == null) {
-    return "-";
-  }
-
-  const hours = Math.floor(value / 60);
-  const minutes = value % 60;
-
-  if (hours === 0) {
-    return `${minutes} min`;
-  }
-
-  if (minutes === 0) {
-    return `${hours} h`;
-  }
-
-  return `${hours} h ${minutes} min`;
-}
-
-function formatPercent(value: number | undefined) {
-  if (value == null) {
-    return "-";
-  }
-
-  return `${value.toFixed(1)}%`;
-}
-
-function formatNumber(value: number | undefined) {
-  if (value == null) {
-    return "-";
-  }
-
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
-}
-
 function trimTrailingSlash(value: string) {
   return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
-function groupQuickWinIssues(issues: SonarIssue[], projectKey: string): QuickWinGroup[] {
-  const grouped = new Map<string, QuickWinGroup>();
-
-  for (const issue of issues) {
-    const label = sanitizeQuickWinLabel(issue.message);
-    const key = issue.rule ? `${issue.rule}::${label}` : label;
-    mergeIssueIntoGroup(grouped, key, label, issue);
-  }
-
-  return [...grouped.values()].sort((left, right) =>
-    compareQuickWinGroups(left, right, projectKey),
-  );
-}
-
-function mergeIssueIntoGroup(
-  grouped: Map<string, QuickWinGroup>,
-  key: string,
-  label: string,
-  issue: SonarIssue,
-) {
-  const current = grouped.get(key);
-  if (!current) {
-    grouped.set(key, {
-      key,
-      label,
-      count: 1,
-      examples: [issue],
-      minEffortMinutes: issue.effortMinutes,
-    });
-    return;
-  }
-
-  current.count += 1;
-  current.minEffortMinutes = minDefined(current.minEffortMinutes, issue.effortMinutes);
-  if (current.examples.length < 3) {
-    current.examples.push(issue);
-  }
-}
-
-function compareQuickWinGroups(left: QuickWinGroup, right: QuickWinGroup, projectKey: string) {
-  const leftExamplePath = normalizeComponentPath(left.examples[0]?.component ?? "", projectKey);
-  const rightExamplePath = normalizeComponentPath(right.examples[0]?.component ?? "", projectKey);
-
-  return (
-    effortOrInfinity(left.minEffortMinutes) - effortOrInfinity(right.minEffortMinutes) ||
-    right.count - left.count ||
-    leftExamplePath.localeCompare(rightExamplePath) ||
-    left.key.localeCompare(right.key)
-  );
-}
-
-function sanitizeQuickWinLabel(message: string) {
-  return sanitizeAbsolutePaths(message);
-}
-
-function matchesAnyPattern(path: string, patterns: readonly string[]) {
-  return patterns.some((pattern) => matchesGlobPattern(path, pattern));
-}
-
-function matchesGlobPattern(path: string, pattern: string) {
-  const normalizedPath = normalizePathForMatch(path);
-  const normalizedPattern = normalizePathForMatch(pattern);
-  const source = normalizedPattern
-    .replaceAll(/[|\\{}()[\]^$+?.]/g, String.raw`\$&`)
-    .replaceAll(/\*\*/g, "__DOUBLE_STAR__")
-    .replaceAll(/\*/g, "[^/]*")
-    .replaceAll(/__DOUBLE_STAR__/g, ".*");
-  return new RegExp(`^${source}$`).test(normalizedPath);
-}
-
-function normalizePathForMatch(value: string) {
-  return value.replaceAll("\\", "/").replace(/^\.\//, "");
-}
-
-function sanitizeAbsolutePaths(value: string) {
-  return value.replaceAll(
-    /(^|[\s("'`[])(\/[^\s"'`)\]]*)/g,
-    (fullMatch, prefix: string, candidate: string) => {
-      const { path, suffix } = splitTrailingPunctuation(candidate);
-      const sanitized = toDisplayPath(path);
-      return sanitized === path ? fullMatch : `${prefix}${sanitized}${suffix}`;
-    },
-  );
-}
-
-function toDisplayPath(value: string) {
-  const normalized = normalizePathForMatch(value);
-  if (!normalized.startsWith("/")) {
-    return normalized;
-  }
-
-  const repoRelative = stripRepoPrefix(normalized);
-  if (repoRelative !== null) {
-    return repoRelative;
-  }
-
-  if (normalized.endsWith("/pnpm-lock.yaml")) {
-    return "pnpm-lock.yaml";
-  }
-
-  return normalized.split("/").findLast(Boolean) ?? normalized;
-}
-
-function stripRepoPrefix(normalizedPath: string): string | null {
-  for (const segment of REPO_PATH_SEGMENTS) {
-    const marker = `/${segment}`;
-    const index = normalizedPath.lastIndexOf(marker);
-    if (index >= 0) {
-      return normalizedPath.slice(index + 1);
-    }
-  }
-  return null;
-}
-
-function splitTrailingPunctuation(value: string) {
-  let index = value.length;
-
-  while (index > 0 && isTrailingPunctuation(value[index - 1])) {
-    index -= 1;
-  }
-
-  return {
-    path: value.slice(0, index),
-    suffix: value.slice(index),
-  };
-}
-
-function minDefined(left: number | undefined, right: number | undefined) {
-  if (left == null) {
-    return right;
-  }
-
-  if (right == null) {
-    return left;
-  }
-
-  return Math.min(left, right);
-}
-
-function isTrailingPunctuation(value: string) {
-  return (
-    value === "." ||
-    value === "," ||
-    value === ":" ||
-    value === ";" ||
-    value === "!" ||
-    value === "?"
-  );
 }

--- a/src/lib/tmdb-recommendation-cache.ts
+++ b/src/lib/tmdb-recommendation-cache.ts
@@ -1,0 +1,173 @@
+import type { TmdbSearchResult } from "./tmdb.ts";
+
+const RECOMMENDATIONS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+type RecommendationCacheEntry = {
+  results: TmdbSearchResult[];
+  fetchedAt: number;
+};
+
+type RecommendationSourceItem = {
+  tmdbId: number;
+  tmdbMediaType: "movie" | "tv";
+};
+
+let trendingCache: RecommendationCacheEntry | null = null;
+let trendingCachePromise: Promise<TmdbSearchResult[]> | null = null;
+const similarCache = new Map<string, RecommendationCacheEntry>();
+const similarCachePromises = new Map<string, Promise<TmdbSearchResult[]>>();
+
+export function normalizeRecommendationSources(sourceItems: RecommendationSourceItem[]) {
+  const seen = new Set<string>();
+  const uniqueItems: RecommendationSourceItem[] = [];
+
+  for (const item of sourceItems) {
+    const key = buildRecommendationKey(item);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    uniqueItems.push(item);
+  }
+
+  return uniqueItems.slice(0, 8);
+}
+
+export async function fetchCachedSimilarResults(
+  sourceItems: RecommendationSourceItem[],
+  load: () => Promise<TmdbSearchResult[]>,
+) {
+  const cacheKey = buildRecommendationSourceCacheKey(sourceItems);
+  return readCachedCollection({
+    cacheKey,
+    entries: similarCache,
+    inFlight: similarCachePromises,
+    load,
+  });
+}
+
+export async function fetchCachedTrendingResults(load: () => Promise<TmdbSearchResult[]>) {
+  if (hasFreshEntry(trendingCache)) {
+    return shuffleResults(trendingCache.results);
+  }
+
+  if (trendingCachePromise) {
+    return shuffleResults(await trendingCachePromise);
+  }
+
+  const request = loadAndPersist(load, (results) => {
+    trendingCache = { results, fetchedAt: Date.now() };
+  });
+  trendingCachePromise = request.finally(() => {
+    trendingCachePromise = null;
+  });
+
+  return shuffleResults(await request);
+}
+
+export function mergeRecommendationResults(
+  primary: TmdbSearchResult[],
+  fallback: TmdbSearchResult[],
+) {
+  const seen = new Set<string>();
+  const dedupedPrimary = dedupeRecommendationResults(primary, seen);
+  const dedupedFallback = dedupeRecommendationResults(fallback, seen);
+  return [...shuffleResults(dedupedPrimary), ...shuffleResults(dedupedFallback)];
+}
+
+export function resetTmdbRecommendationCachesForTest() {
+  trendingCache = null;
+  trendingCachePromise = null;
+  similarCache.clear();
+  similarCachePromises.clear();
+}
+
+function buildRecommendationSourceCacheKey(sourceItems: RecommendationSourceItem[]) {
+  return [...sourceItems]
+    .sort((left, right) =>
+      left.tmdbMediaType === right.tmdbMediaType
+        ? left.tmdbId - right.tmdbId
+        : left.tmdbMediaType.localeCompare(right.tmdbMediaType),
+    )
+    .map((item) => buildRecommendationKey(item))
+    .join("|");
+}
+
+function buildRecommendationKey({
+  tmdbId,
+  tmdbMediaType,
+}: RecommendationSourceItem | TmdbSearchResult) {
+  return `${tmdbMediaType}-${tmdbId}`;
+}
+
+async function readCachedCollection({
+  cacheKey,
+  entries,
+  inFlight,
+  load,
+}: {
+  cacheKey: string;
+  entries: Map<string, RecommendationCacheEntry>;
+  inFlight: Map<string, Promise<TmdbSearchResult[]>>;
+  load: () => Promise<TmdbSearchResult[]>;
+}) {
+  const cached = entries.get(cacheKey);
+  if (hasFreshEntry(cached)) {
+    return shuffleResults(cached.results);
+  }
+
+  const pending = inFlight.get(cacheKey);
+  if (pending) {
+    return shuffleResults(await pending);
+  }
+
+  const request = loadAndPersist(load, (results) => {
+    entries.set(cacheKey, { results, fetchedAt: Date.now() });
+  });
+
+  inFlight.set(
+    cacheKey,
+    request.finally(() => {
+      inFlight.delete(cacheKey);
+    }),
+  );
+
+  return shuffleResults(await request);
+}
+
+async function loadAndPersist(
+  load: () => Promise<TmdbSearchResult[]>,
+  persist: (results: TmdbSearchResult[]) => void,
+) {
+  const results = await load();
+  persist(results);
+  return results;
+}
+
+function hasFreshEntry(entry: RecommendationCacheEntry | null | undefined) {
+  return Boolean(entry && Date.now() - entry.fetchedAt < RECOMMENDATIONS_CACHE_TTL_MS);
+}
+
+function dedupeRecommendationResults(results: TmdbSearchResult[], seen: Set<string>) {
+  return results.filter((item) => {
+    const key = buildRecommendationKey(item);
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function shuffleResults(results: TmdbSearchResult[]) {
+  const shuffled = [...results];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+
+  return shuffled;
+}

--- a/src/lib/tmdb-recommendation-cache.ts
+++ b/src/lib/tmdb-recommendation-cache.ts
@@ -165,9 +165,28 @@ function shuffleResults(results: TmdbSearchResult[]) {
   const shuffled = [...results];
 
   for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const swapIndex = Math.floor(Math.random() * (index + 1));
+    const swapIndex = getSecureRandomInt(index + 1);
     [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
   }
 
   return shuffled;
+}
+
+function getSecureRandomInt(maxExclusive: number) {
+  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
+    throw new RangeError("maxExclusive must be a positive integer");
+  }
+
+  const maxUint32 = 0x100000000;
+  const upperBound = maxUint32 - (maxUint32 % maxExclusive);
+  const randomBuffer = new Uint32Array(1);
+
+  while (true) {
+    globalThis.crypto.getRandomValues(randomBuffer);
+    const value = randomBuffer[0] ?? 0;
+
+    if (value < upperBound) {
+      return value % maxExclusive;
+    }
+  }
 }

--- a/src/lib/tmdb-recommendation-cache.ts
+++ b/src/lib/tmdb-recommendation-cache.ts
@@ -145,8 +145,10 @@ async function loadAndPersist(
   return results;
 }
 
-function hasFreshEntry(entry: RecommendationCacheEntry | null | undefined) {
-  return Boolean(entry && Date.now() - entry.fetchedAt < RECOMMENDATIONS_CACHE_TTL_MS);
+function hasFreshEntry(
+  entry: RecommendationCacheEntry | null | undefined,
+): entry is RecommendationCacheEntry {
+  return entry != null && Date.now() - entry.fetchedAt < RECOMMENDATIONS_CACHE_TTL_MS;
 }
 
 function dedupeRecommendationResults(results: TmdbSearchResult[], seen: Set<string>) {

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -4,6 +4,13 @@ import {
   FunctionsRelayError,
 } from "@supabase/supabase-js";
 import { supabase } from "./supabase.ts";
+import {
+  fetchCachedSimilarResults,
+  fetchCachedTrendingResults,
+  mergeRecommendationResults,
+  normalizeRecommendationSources,
+  resetTmdbRecommendationCachesForTest,
+} from "./tmdb-recommendation-cache.ts";
 
 export type TmdbWatchPlatform = {
   key: string;
@@ -67,20 +74,7 @@ export type TmdbWorkDetails = {
   imdbId?: string | null;
 };
 
-type RecommendationCacheEntry = {
-  results: TmdbSearchResult[];
-  fetchedAt: number;
-};
-
 type ResponseValidator<TResponse> = (data: unknown) => data is TResponse;
-
-const RECOMMENDATIONS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const MAX_RECOMMENDATION_SOURCE_ITEMS = 8;
-
-let trendingCache: RecommendationCacheEntry | null = null;
-let trendingCachePromise: Promise<TmdbSearchResult[]> | null = null;
-const similarCache = new Map<string, RecommendationCacheEntry>();
-const similarCachePromises = new Map<string, Promise<TmdbSearchResult[]>>();
 
 async function readSupabaseFunctionErrorDetail(response: Response): Promise<string | null> {
   const contentType = response.headers.get("content-type") ?? "";
@@ -236,44 +230,6 @@ function isTmdbWorkDetails(value: unknown): value is TmdbWorkDetails {
   );
 }
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const shuffled = [...arr];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-  return shuffled;
-}
-
-function normalizeRecommendationSources(
-  sourceItems: Array<{ tmdbId: number; tmdbMediaType: "movie" | "tv" }>,
-): Array<{ tmdbId: number; tmdbMediaType: "movie" | "tv" }> {
-  const seen = new Set<string>();
-  const uniqueItems: Array<{ tmdbId: number; tmdbMediaType: "movie" | "tv" }> = [];
-
-  for (const item of sourceItems) {
-    const key = `${item.tmdbMediaType}-${item.tmdbId}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    uniqueItems.push(item);
-  }
-
-  return uniqueItems.slice(0, MAX_RECOMMENDATION_SOURCE_ITEMS);
-}
-
-function buildRecommendationSourceCacheKey(
-  sourceItems: Array<{ tmdbId: number; tmdbMediaType: "movie" | "tv" }>,
-): string {
-  return [...sourceItems]
-    .sort((a, b) =>
-      a.tmdbMediaType === b.tmdbMediaType
-        ? a.tmdbId - b.tmdbId
-        : a.tmdbMediaType.localeCompare(b.tmdbMediaType),
-    )
-    .map((item) => `${item.tmdbMediaType}-${item.tmdbId}`)
-    .join("|");
-}
-
 export async function fetchTmdbSimilar(
   sourceItems: Array<{ tmdbId: number; tmdbMediaType: "movie" | "tv" }>,
 ): Promise<TmdbSearchResult[]> {
@@ -283,38 +239,15 @@ export async function fetchTmdbSimilar(
     return [];
   }
 
-  const cacheKey = buildRecommendationSourceCacheKey(normalizedSourceItems);
-  const cached = similarCache.get(cacheKey);
-  if (cached && Date.now() - cached.fetchedAt < RECOMMENDATIONS_CACHE_TTL_MS) {
-    return shuffleArray(cached.results);
-  }
-
-  const inFlight = similarCachePromises.get(cacheKey);
-  if (inFlight) {
-    return shuffleArray(await inFlight);
-  }
-
-  const request = (async () => {
-    const results = await invokeTmdbFunction<TmdbSearchResult[]>(
+  return fetchCachedSimilarResults(normalizedSourceItems, async () => {
+    return invokeTmdbFunction<TmdbSearchResult[]>(
       "fetch-tmdb-similar",
       {
         sourceItems: normalizedSourceItems,
       },
       isTmdbSearchResultArray,
     );
-
-    similarCache.set(cacheKey, { results, fetchedAt: Date.now() });
-    return results;
-  })();
-
-  similarCachePromises.set(
-    cacheKey,
-    request.finally(() => {
-      similarCachePromises.delete(cacheKey);
-    }),
-  );
-
-  return shuffleArray(await request);
+  });
 }
 
 export async function fetchTmdbRecommendations(
@@ -324,55 +257,22 @@ export async function fetchTmdbRecommendations(
     fetchTmdbSimilar(sourceItems),
     fetchTmdbTrending(),
   ]);
-  const seen = new Set<string>();
-  const dedupedSimilar = similar.filter((item) => {
-    const key = `${item.tmdbMediaType}-${item.tmdbId}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-  const trendingSupplement = trending.filter((item) => {
-    const key = `${item.tmdbMediaType}-${item.tmdbId}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 
-  return [...shuffleArray(dedupedSimilar), ...shuffleArray(trendingSupplement)];
+  return mergeRecommendationResults(similar, trending);
 }
 
 export async function fetchTmdbTrending(): Promise<TmdbSearchResult[]> {
-  if (trendingCache && Date.now() - trendingCache.fetchedAt < RECOMMENDATIONS_CACHE_TTL_MS) {
-    return shuffleArray(trendingCache.results);
-  }
-
-  if (trendingCachePromise) {
-    return shuffleArray(await trendingCachePromise);
-  }
-
-  const request = (async () => {
+  return fetchCachedTrendingResults(async () => {
     const results = await invokeTmdbFunction<TmdbSearchResult[]>(
       "fetch-tmdb-trending",
       undefined,
       isTmdbSearchResultArray,
     );
-    trendingCache = { results, fetchedAt: Date.now() };
     return results;
-  })();
-
-  trendingCachePromise = request.finally(() => {
-    trendingCachePromise = null;
   });
-
-  return shuffleArray(await request);
 }
 
-export function resetTmdbRecommendationCachesForTest() {
-  trendingCache = null;
-  trendingCachePromise = null;
-  similarCache.clear();
-  similarCachePromises.clear();
-}
+export { resetTmdbRecommendationCachesForTest };
 
 export function searchTmdbWorks(query: string) {
   return invokeTmdbFunction<TmdbSearchResult[]>(


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- `src/features/backlog/work-repository.ts` から season target 組み立て、refresh 判定、TMDb insert/response helper を `work-repository-helpers.ts` に分離
- `work-repository.ts` 内の TMDb/OMDb 同期分岐を helper 関数へ整理し、既存作品の early return と OMDb payload 構築を読みやすく再構成
- `src/lib/tmdb.ts` から recommendation cache 制御を `tmdb-recommendation-cache.ts` に抽出し、similar/trending の重複ロジックを共通化
- `src/lib/refactoring-backlog.ts` から path 正規化と quick win/render 系処理を helper へ切り出し、本体を issue 生成ロジック中心に整理

## 検証

- `vp test src/features/backlog/work-repository.test.ts src/lib/tmdb.test.ts src/lib/refactoring-backlog.test.ts`
- `vp build`
- `vp run knip`