### PR TITLE
chore: SonarCloud backlog から migration を除外

### DIFF
--- a/.github/scripts/refactoring-backlog.ts
+++ b/.github/scripts/refactoring-backlog.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import {
   buildRefactoringBacklogIssue,
+  filterBacklogIssues,
   filterBacklogSignals,
   normalizeComponentPath,
   parseMeasureValue,
@@ -86,7 +87,7 @@ async function main() {
       timeStyle: "short",
     }).format(new Date()) + " UTC";
 
-  const quickWinIssues = selectQuickWinIssues(issues);
+  const quickWinIssues = selectQuickWinIssues(filterBacklogIssues(issues, projectKey));
   const filteredFileSignals = filterBacklogSignals(fileSignals);
   const longFiles = rankLongFiles(filteredFileSignals);
   const complexFiles = rankComplexFiles(filteredFileSignals);

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -1,5 +1,6 @@
 import {
   buildRefactoringBacklogIssue,
+  filterBacklogIssues,
   filterBacklogSignals,
   normalizeComponentPath,
   parseMeasureValue,
@@ -127,11 +128,29 @@ describe("signal ranking", () => {
           measures: { duplicated_lines_density: 88 },
         },
         {
-          path: "supabase/seed.sql",
+          path: "supabase/migrations/20260412000000_create_items.sql",
           measures: { ncloc: 500 },
         },
       ]),
     ).toEqual(files);
+  });
+
+  test("seed.sql は backlog 保守対象として残す", () => {
+    expect(
+      filterBacklogSignals([
+        ...files,
+        {
+          path: "supabase/seed.sql",
+          measures: { ncloc: 500 },
+        },
+      ]),
+    ).toEqual([
+      ...files,
+      {
+        path: "supabase/seed.sql",
+        measures: { ncloc: 500 },
+      },
+    ]);
   });
 });
 
@@ -162,6 +181,44 @@ describe("selectQuickWinIssues", () => {
       { key: "1", message: "A", component: "mirukan:src/a.ts", effortMinutes: 1 },
       { key: "2", message: "A", component: "mirukan:src/b.ts", effortMinutes: 1 },
       { key: "3", message: "B", component: "mirukan:src/c.ts", effortMinutes: 1 },
+    ]);
+  });
+
+  test("migration 配下の issue は backlog 候補から外す", () => {
+    const issues = [
+      {
+        key: "1",
+        message: "A",
+        component: "mirukan:supabase/migrations/20260412000000_create_items.sql",
+        effortMinutes: 1,
+      },
+      {
+        key: "2",
+        message: "B",
+        component: "mirukan:supabase/seed.sql",
+        effortMinutes: 1,
+      },
+      {
+        key: "3",
+        message: "C",
+        component: "mirukan:src/lib/example.ts",
+        effortMinutes: 1,
+      },
+    ];
+
+    expect(filterBacklogIssues(issues, "mirukan")).toEqual([
+      {
+        key: "2",
+        message: "B",
+        component: "mirukan:supabase/seed.sql",
+        effortMinutes: 1,
+      },
+      {
+        key: "3",
+        message: "C",
+        component: "mirukan:src/lib/example.ts",
+        effortMinutes: 1,
+      },
     ]);
   });
 });

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -10,8 +10,8 @@ import {
 const REFACTORING_BACKLOG_MARKER = "<!-- refactoring-backlog:sonarcloud -->";
 const DEFAULT_BACKLOG_EXCLUDE_PATTERNS = [
   "pnpm-lock.yaml",
+  "supabase/migrations/**",
   "supabase/templates/**",
-  "supabase/seed.sql",
 ] as const;
 
 export type SonarMeasureKey =
@@ -112,6 +112,17 @@ export function filterBacklogSignals(
   excludePatterns: readonly string[] = DEFAULT_BACKLOG_EXCLUDE_PATTERNS,
 ) {
   return files.filter((file) => !matchesAnyPattern(file.path, excludePatterns));
+}
+
+export function filterBacklogIssues(
+  issues: SonarIssue[],
+  projectKey: string,
+  excludePatterns: readonly string[] = DEFAULT_BACKLOG_EXCLUDE_PATTERNS,
+) {
+  return issues.filter(
+    (issue) =>
+      !matchesAnyPattern(normalizeComponentPath(issue.component, projectKey), excludePatterns),
+  );
 }
 
 export function rankLongFiles(files: SonarFileSignal[], limit = 5): RankedSignal[] {


### PR DESCRIPTION
## 関連 Issue

-

## 変更内容

- SonarCloud refactoring backlog の除外対象に `supabase/migrations/**` を追加
- quick win issue 集計にも同じ除外条件を適用し、migration 配下の指摘が backlog に残らないよう修正
- `supabase/seed.sql` は除外対象から外し、保守対象として残ることをテストで追加
