### PR TITLE
fix: GitHub Actions ワークフローへの最小権限ブロック追加

### DIFF
--- a/.github/workflows/bundle-analyze.yml
+++ b/.github/workflows/bundle-analyze.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   knip:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -58,6 +60,8 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -97,6 +101,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -154,6 +160,8 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -226,6 +234,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,6 +10,8 @@ jobs:
   scan:
     name: Betterleaks Repository Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 関連 Issue

<!-- 関連 Issue があれば Refs #123 または Closes #123 の形式で記載 -->

## 変更内容

- `.github/workflows/ci.yml` の全 5 ジョブ（knip / check / test / e2e / build）に `permissions: contents: read` を追加
- `.github/workflows/deploy-functions.yml` の deploy ジョブに `permissions: contents: read` を追加
- `.github/workflows/bundle-analyze.yml` の analyze ジョブに `permissions: contents: read` を追加
- `.github/workflows/secret-scan.yml` の scan ジョブに `permissions: contents: read` を追加

CodeQL による Code Scanning アラート（`actions/missing-workflow-permissions`、8 件）に対応。
各ジョブはリポジトリの読み取りのみを行うため、最小権限として `contents: read` を設定。