### PR TITLE
feat: 削除の楽観的 UI と Toast Undo

### DIFF
--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { Session } from "@supabase/supabase-js";
@@ -56,29 +57,37 @@ function createSearchResult(overrides: Partial<TmdbSearchResult> = {}): TmdbSear
   };
 }
 
+function createToastFeedback(undone = false) {
+  return {
+    alert: vi.fn().mockResolvedValue(undefined),
+    confirm: vi.fn().mockResolvedValue(true),
+    toast: vi.fn().mockResolvedValue({ undone }),
+  };
+}
+
 function HookHarness({
   items = [createItem()],
+  localItems,
+  setLocalItems = vi.fn(),
   loadItems = vi.fn().mockResolvedValue(undefined),
   onItemDeleted = vi.fn(),
   onWorksAdded = vi.fn(),
   results = [createSearchResult()],
-  feedback = {
-    alert: vi.fn().mockResolvedValue(undefined),
-    confirm: vi.fn().mockResolvedValue(true),
-  },
+  feedback = createToastFeedback(),
 }: {
   items?: BacklogItem[];
+  localItems?: BacklogItem[];
+  setLocalItems?: React.Dispatch<React.SetStateAction<BacklogItem[]>>;
   loadItems?: () => Promise<void>;
   onItemDeleted?: (itemId: string) => void;
   onWorksAdded?: () => void;
   results?: TmdbSearchResult[];
-  feedback?: {
-    alert: (message: string) => void | Promise<void>;
-    confirm: (message: string) => boolean | Promise<boolean>;
-  };
+  feedback?: ReturnType<typeof createToastFeedback>;
 }) {
   const { handleDeleteItem, handleAddTmdbWorksToStacked } = useBacklogActions({
     items,
+    localItems: localItems ?? items,
+    setLocalItems,
     session: { user: { id: "user-1" } } as Session,
     loadItems,
     onItemDeleted,
@@ -110,11 +119,52 @@ describe("useBacklogActions", () => {
     vi.clearAllMocks();
   });
 
-  test("delete 失敗時は alert を出して reload や state 更新をしない", async () => {
-    const feedback = {
-      alert: vi.fn().mockResolvedValue(undefined),
-      confirm: vi.fn().mockResolvedValue(true),
-    };
+  test("delete 成功時は楽観的除去後に toast を表示し、完了後に reload する", async () => {
+    const feedback = createToastFeedback(false);
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    const onItemDeleted = vi.fn();
+    const setLocalItems = vi.fn();
+
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        feedback={feedback}
+        loadItems={loadItems}
+        onItemDeleted={onItemDeleted}
+        setLocalItems={setLocalItems}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(loadItems).toHaveBeenCalled());
+    expect(setLocalItems).toHaveBeenCalled();
+    expect(onItemDeleted).toHaveBeenCalledWith("item-1");
+    expect(feedback.toast).toHaveBeenCalledWith("削除しました", {
+      undoLabel: "元に戻す",
+      timeoutMs: 5000,
+    });
+  });
+
+  test("undo 時は setLocalItems で復元して削除 API を呼ばない", async () => {
+    const feedback = createToastFeedback(true);
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    const setLocalItems = vi.fn();
+
+    const user = userEvent.setup();
+
+    render(<HookHarness feedback={feedback} loadItems={loadItems} setLocalItems={setLocalItems} />);
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(setLocalItems).toHaveBeenCalledTimes(2));
+    expect(repositoryMocks.deleteBacklogItem).not.toHaveBeenCalled();
+    expect(loadItems).not.toHaveBeenCalled();
+  });
+
+  test("delete 失敗時は alert を出して reload する", async () => {
+    const feedback = createToastFeedback(false);
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onItemDeleted = vi.fn();
     repositoryMocks.deleteBacklogItem.mockResolvedValueOnce({
@@ -130,15 +180,12 @@ describe("useBacklogActions", () => {
     await waitFor(() =>
       expect(feedback.alert).toHaveBeenCalledWith("削除に失敗しました: row not found"),
     );
-    expect(onItemDeleted).not.toHaveBeenCalled();
-    expect(loadItems).not.toHaveBeenCalled();
+    expect(onItemDeleted).toHaveBeenCalledWith("item-1");
+    expect(loadItems).toHaveBeenCalled();
   });
 
   test("複数追加で一部失敗したら成功分は反映しつつ失敗作品を通知する", async () => {
-    const feedback = {
-      alert: vi.fn().mockResolvedValue(undefined),
-      confirm: vi.fn().mockResolvedValue(true),
-    };
+    const feedback = createToastFeedback();
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onWorksAdded = vi.fn();
     repositoryMocks.upsertTmdbWork
@@ -174,10 +221,7 @@ describe("useBacklogActions", () => {
   });
 
   test("複数追加がすべて失敗したら詳細を通知して追加処理を中断する", async () => {
-    const feedback = {
-      alert: vi.fn().mockResolvedValue(undefined),
-      confirm: vi.fn().mockResolvedValue(true),
-    };
+    const feedback = createToastFeedback();
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onWorksAdded = vi.fn();
     repositoryMocks.upsertTmdbWork
@@ -206,10 +250,7 @@ describe("useBacklogActions", () => {
   });
 
   test("確認ダイアログの件数は追加成功した作品数を使う", async () => {
-    const feedback = {
-      alert: vi.fn().mockResolvedValue(undefined),
-      confirm: vi.fn().mockResolvedValue(true),
-    };
+    const feedback = createToastFeedback();
     const user = userEvent.setup();
     repositoryMocks.upsertTmdbWork
       .mockResolvedValueOnce({ data: { id: "work-1" }, error: null })

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -69,6 +69,7 @@ function HookHarness({
   items = [createItem()],
   localItems,
   setLocalItems = vi.fn(),
+  setPendingDeleteIds = vi.fn(),
   loadItems = vi.fn().mockResolvedValue(undefined),
   onItemDeleted = vi.fn(),
   onWorksAdded = vi.fn(),
@@ -78,6 +79,7 @@ function HookHarness({
   items?: BacklogItem[];
   localItems?: BacklogItem[];
   setLocalItems?: React.Dispatch<React.SetStateAction<BacklogItem[]>>;
+  setPendingDeleteIds?: React.Dispatch<React.SetStateAction<ReadonlySet<string>>>;
   loadItems?: () => Promise<void>;
   onItemDeleted?: (itemId: string) => void;
   onWorksAdded?: () => void;
@@ -88,6 +90,7 @@ function HookHarness({
     items,
     localItems: localItems ?? items,
     setLocalItems,
+    setPendingDeleteIds,
     session: { user: { id: "user-1" } } as Session,
     loadItems,
     onItemDeleted,

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from "react";
 import type { Session } from "@supabase/supabase-js";
 import type { TmdbSearchResult } from "../../../lib/tmdb.ts";
 import {
@@ -16,6 +17,8 @@ import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts"
 
 type Props = {
   items: BacklogItem[];
+  localItems: BacklogItem[];
+  setLocalItems: Dispatch<SetStateAction<BacklogItem[]>>;
   session: Session;
   loadItems: () => Promise<void>;
   onItemDeleted: (itemId: string) => void;
@@ -33,6 +36,8 @@ function buildWorkFailureMessage(failedTitles: string[], prefix: string) {
 
 export function useBacklogActions({
   items,
+  localItems,
+  setLocalItems,
   session,
   loadItems,
   onItemDeleted,
@@ -40,14 +45,35 @@ export function useBacklogActions({
   feedback = browserBacklogFeedback,
 }: Props) {
   const handleDeleteItem = async (itemId: string) => {
-    const { error: deleteError } = await deleteBacklogItem(itemId);
+    const itemToDelete = localItems.find((i) => i.id === itemId);
+    if (!itemToDelete) return;
 
-    if (deleteError) {
-      await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError}`));
+    const itemIndex = localItems.findIndex((i) => i.id === itemId);
+
+    // 楽観的除去: 即座に UI から消す
+    setLocalItems((prev) => prev.filter((i) => i.id !== itemId));
+    onItemDeleted(itemId);
+
+    const { undone } = await feedback.toast("削除しました", {
+      undoLabel: "元に戻す",
+      timeoutMs: 5000,
+    });
+
+    if (undone) {
+      // 元の位置に戻す
+      setLocalItems((prev) => {
+        const next = [...prev];
+        next.splice(Math.min(itemIndex, next.length), 0, itemToDelete);
+        return next;
+      });
       return;
     }
 
-    onItemDeleted(itemId);
+    // 実際に削除
+    const { error: deleteError } = await deleteBacklogItem(itemId);
+    if (deleteError) {
+      await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError}`));
+    }
     await loadItems();
   };
 

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -60,8 +60,9 @@ export function useBacklogActions({
     });
 
     if (undone) {
-      // 元の位置に戻す
+      // 元の位置に戻す（loadItems による再同期で既に復元済みの場合は挿入しない）
       setLocalItems((prev) => {
+        if (prev.some((i) => i.id === itemToDelete.id)) return prev;
         const next = [...prev];
         next.splice(Math.min(itemIndex, next.length), 0, itemToDelete);
         return next;

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -78,17 +78,19 @@ export function useBacklogActions({
       return;
     }
 
-    // 実際に削除して登録を解除
+    // 実際に削除し、loadItems 完了後にフィルタを解除
+    // loadItems の完了まで pendingDeleteIds を保持することで、再フェッチ遅延中に
+    // サーバーキャッシュから削除済みアイテムが復活するのを防ぐ
     const { error: deleteError } = await deleteBacklogItem(itemId);
+    if (deleteError) {
+      await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError}`));
+    }
+    await loadItems();
     setPendingDeleteIds((prev) => {
       const next = new Set(prev);
       next.delete(itemId);
       return next;
     });
-    if (deleteError) {
-      await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError}`));
-    }
-    await loadItems();
   };
 
   const handleMarkAsWatched = async (itemId: string) => {

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -19,6 +19,7 @@ type Props = {
   items: BacklogItem[];
   localItems: BacklogItem[];
   setLocalItems: Dispatch<SetStateAction<BacklogItem[]>>;
+  setPendingDeleteIds: Dispatch<SetStateAction<ReadonlySet<string>>>;
   session: Session;
   loadItems: () => Promise<void>;
   onItemDeleted: (itemId: string) => void;
@@ -38,6 +39,7 @@ export function useBacklogActions({
   items,
   localItems,
   setLocalItems,
+  setPendingDeleteIds,
   session,
   loadItems,
   onItemDeleted,
@@ -50,7 +52,8 @@ export function useBacklogActions({
 
     const itemIndex = localItems.findIndex((i) => i.id === itemId);
 
-    // 楽観的除去: 即座に UI から消す
+    // 楽観的除去: 即座に UI から消し、サーバー同期でも除外されるよう登録
+    setPendingDeleteIds((prev) => new Set([...prev, itemId]));
     setLocalItems((prev) => prev.filter((i) => i.id !== itemId));
     onItemDeleted(itemId);
 
@@ -60,7 +63,12 @@ export function useBacklogActions({
     });
 
     if (undone) {
-      // 元の位置に戻す（loadItems による再同期で既に復元済みの場合は挿入しない）
+      // 登録を解除して元の位置に戻す（既に復元済みの場合は挿入しない）
+      setPendingDeleteIds((prev) => {
+        const next = new Set(prev);
+        next.delete(itemId);
+        return next;
+      });
       setLocalItems((prev) => {
         if (prev.some((i) => i.id === itemToDelete.id)) return prev;
         const next = [...prev];
@@ -70,8 +78,13 @@ export function useBacklogActions({
       return;
     }
 
-    // 実際に削除
+    // 実際に削除して登録を解除
     const { error: deleteError } = await deleteBacklogItem(itemId);
+    setPendingDeleteIds((prev) => {
+      const next = new Set(prev);
+      next.delete(itemId);
+      return next;
+    });
     if (deleteError) {
       await Promise.resolve(feedback.alert(`削除に失敗しました: ${deleteError}`));
     }

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -74,6 +74,7 @@ const onAfterDrop = vi.fn().mockResolvedValue(undefined);
 const feedback = {
   alert: vi.fn().mockResolvedValue(undefined),
   confirm: vi.fn().mockResolvedValue(true),
+  toast: vi.fn().mockResolvedValue({ undone: false }),
 };
 
 function renderDnd(

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -82,11 +82,13 @@ function renderDnd(
   options?: {
     isMobileLayout?: boolean;
     onAfterDropOverride?: () => Promise<void>;
+    pendingDeleteIds?: ReadonlySet<string>;
   },
 ) {
   return renderHook(() =>
     useBacklogDnd({
       items,
+      pendingDeleteIds: options?.pendingDeleteIds ?? new Set(),
       isMobileLayout: options?.isMobileLayout ?? false,
       onAfterDrop: options?.onAfterDropOverride ?? onAfterDrop,
       feedback,

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -255,6 +255,7 @@ export function useBacklogDnd({
   return {
     dragItemId,
     localItems,
+    setLocalItems,
     sensors,
     handleDragStart,
     handleDragOver,

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -12,8 +12,11 @@ import { supabase } from "../../../lib/supabase.ts";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
 
+const EMPTY_PENDING_DELETES: ReadonlySet<string> = new Set();
+
 type Props = {
   items: BacklogItem[];
+  pendingDeleteIds?: ReadonlySet<string>;
   isMobileLayout: boolean;
   onAfterDrop: () => Promise<void>;
   feedback?: BacklogFeedback;
@@ -120,6 +123,7 @@ function calculateInsertedSortOrder(
 
 export function useBacklogDnd({
   items,
+  pendingDeleteIds = EMPTY_PENDING_DELETES,
   isMobileLayout,
   onAfterDrop,
   feedback = browserBacklogFeedback,
@@ -129,11 +133,14 @@ export function useBacklogDnd({
   const [localItems, setLocalItems] = useState<BacklogItem[]>(items);
 
   // サーバーデータが更新されたら、ドラッグ中またはドロップ反映待ちでない場合に同期
+  // 楽観的削除中の項目は除外してサーバーデータで上書きされないようにする
   useEffect(() => {
     if (!dragItemId && !isDropSyncPending) {
-      setLocalItems(items);
+      setLocalItems(
+        pendingDeleteIds.size > 0 ? items.filter((i) => !pendingDeleteIds.has(i.id)) : items,
+      );
     }
-  }, [items, dragItemId, isDropSyncPending]);
+  }, [items, dragItemId, isDropSyncPending, pendingDeleteIds]);
 
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: { distance: 8 },

--- a/src/features/backlog/hooks/useBacklogFeedback.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.tsx
@@ -73,13 +73,13 @@ function ToastNotification({
   timeoutMs,
   onUndo,
   onClose,
-}: {
+}: Readonly<{
   message: string;
   undoLabel?: string;
   timeoutMs: number;
   onUndo: () => void;
   onClose: () => void;
-}) {
+}>) {
   useEffect(() => {
     const id = setTimeout(onClose, timeoutMs);
     return () => clearTimeout(id);
@@ -135,11 +135,15 @@ export function useBacklogFeedback() {
         }),
       toast: (message, options) =>
         new Promise<ToastResult>((resolve) => {
-          setToastState({
-            message,
-            undoLabel: options?.undoLabel,
-            timeoutMs: options?.timeoutMs ?? 5000,
-            resolve,
+          setToastState((current) => {
+            // 既存トーストがあれば先に settle して Promise を解決させる
+            current?.resolve({ undone: false });
+            return {
+              message,
+              undoLabel: options?.undoLabel,
+              timeoutMs: options?.timeoutMs ?? 5000,
+              resolve,
+            };
           });
         }),
     }),

--- a/src/features/backlog/hooks/useBacklogFeedback.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.tsx
@@ -1,10 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
-import type { BacklogFeedback } from "../ui-feedback.ts";
+import type { BacklogFeedback, ToastResult } from "../ui-feedback.ts";
 
 type ConfirmState = {
   message: string;
   resolve: (result: boolean) => void;
+};
+
+type ToastState = {
+  message: string;
+  undoLabel?: string;
+  timeoutMs: number;
+  resolve: (result: ToastResult) => void;
 };
 
 function FeedbackAlert({ message, onClose }: { message: string; onClose: () => void }) {
@@ -60,14 +67,62 @@ function FeedbackConfirmDialog({
   );
 }
 
+function ToastNotification({
+  message,
+  undoLabel,
+  timeoutMs,
+  onUndo,
+  onClose,
+}: {
+  message: string;
+  undoLabel?: string;
+  timeoutMs: number;
+  onUndo: () => void;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const id = setTimeout(onClose, timeoutMs);
+    return () => clearTimeout(id);
+  }, [onClose, timeoutMs]);
+
+  return (
+    <div
+      className="fixed inset-x-0 top-4 z-50 flex justify-center px-4"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="w-full max-w-[560px] rounded-[24px] border border-border bg-[rgba(28,28,28,0.96)] px-5 py-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)] backdrop-blur-xl">
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-sm leading-6 text-foreground">{message}</p>
+          {undoLabel ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="shrink-0 rounded-full"
+              onClick={onUndo}
+            >
+              {undoLabel}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function useBacklogFeedback() {
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
+  const [toastState, setToastState] = useState<ToastState | null>(null);
 
   useEffect(() => {
     return () => {
       setConfirmState((current) => {
         current?.resolve(false);
+        return null;
+      });
+      setToastState((current) => {
+        current?.resolve({ undone: false });
         return null;
       });
     };
@@ -81,6 +136,15 @@ export function useBacklogFeedback() {
       confirm: (message) =>
         new Promise<boolean>((resolve) => {
           setConfirmState({ message, resolve });
+        }),
+      toast: (message, options) =>
+        new Promise<ToastResult>((resolve) => {
+          setToastState({
+            message,
+            undoLabel: options?.undoLabel,
+            timeoutMs: options?.timeoutMs ?? 5000,
+            resolve,
+          });
         }),
     }),
     [],
@@ -97,8 +161,24 @@ export function useBacklogFeedback() {
     });
   };
 
+  const settleToast = (undone: boolean) => {
+    setToastState((current) => {
+      current?.resolve({ undone });
+      return null;
+    });
+  };
+
   const feedbackUi = (
     <>
+      {toastState ? (
+        <ToastNotification
+          message={toastState.message}
+          undoLabel={toastState.undoLabel}
+          timeoutMs={toastState.timeoutMs}
+          onUndo={() => settleToast(true)}
+          onClose={() => settleToast(false)}
+        />
+      ) : null}
       {alertMessage ? <FeedbackAlert message={alertMessage} onClose={handleCloseAlert} /> : null}
       {confirmState ? (
         <FeedbackConfirmDialog

--- a/src/features/backlog/hooks/useBacklogFeedback.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
 import type { BacklogFeedback, ToastOptions, ToastResult } from "../ui-feedback.ts";
 
@@ -28,6 +28,16 @@ function buildNextToastState(
     timeoutMs: options?.timeoutMs ?? 5000,
     resolve,
   };
+}
+
+function createToastPromise(
+  message: string,
+  options: ToastOptions | undefined,
+  setToastState: Dispatch<SetStateAction<ToastState | null>>,
+): Promise<ToastResult> {
+  return new Promise<ToastResult>((resolve) => {
+    setToastState((current) => buildNextToastState(current, message, options, resolve));
+  });
 }
 
 function FeedbackAlert({ message, onClose }: { message: string; onClose: () => void }) {
@@ -149,10 +159,7 @@ export function useBacklogFeedback() {
         new Promise<boolean>((resolve) => {
           setConfirmState({ message, resolve });
         }),
-      toast: (message, options) =>
-        new Promise<ToastResult>((resolve) => {
-          setToastState((current) => buildNextToastState(current, message, options, resolve));
-        }),
+      toast: (message, options) => createToastPromise(message, options, setToastState),
     }),
     [],
   );

--- a/src/features/backlog/hooks/useBacklogFeedback.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.tsx
@@ -86,13 +86,9 @@ function ToastNotification({
   }, [onClose, timeoutMs]);
 
   return (
-    <div
-      className="fixed inset-x-0 top-4 z-50 flex justify-center px-4"
-      role="status"
-      aria-live="polite"
-    >
-      <div className="w-full max-w-[560px] rounded-[24px] border border-border bg-[rgba(28,28,28,0.96)] px-5 py-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)] backdrop-blur-xl">
-        <div className="flex items-start justify-between gap-4">
+    <div className="fixed bottom-4 right-4 z-50" role="status" aria-live="polite">
+      <div className="w-full max-w-[360px] rounded-[24px] border border-border bg-[rgba(28,28,28,0.96)] px-5 py-4 shadow-[0_24px_60px_rgba(0,0,0,0.45)] backdrop-blur-xl">
+        <div className="flex items-center justify-between gap-4">
           <p className="text-sm leading-6 text-foreground">{message}</p>
           {undoLabel ? (
             <Button

--- a/src/features/backlog/hooks/useBacklogFeedback.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
-import type { BacklogFeedback, ToastResult } from "../ui-feedback.ts";
+import type { BacklogFeedback, ToastOptions, ToastResult } from "../ui-feedback.ts";
 
 type ConfirmState = {
   message: string;
@@ -13,6 +13,22 @@ type ToastState = {
   timeoutMs: number;
   resolve: (result: ToastResult) => void;
 };
+
+function buildNextToastState(
+  current: ToastState | null,
+  message: string,
+  options: ToastOptions | undefined,
+  resolve: (result: ToastResult) => void,
+): ToastState {
+  // 既存トーストがあれば先に settle して Promise を解決させる
+  current?.resolve({ undone: false });
+  return {
+    message,
+    undoLabel: options?.undoLabel,
+    timeoutMs: options?.timeoutMs ?? 5000,
+    resolve,
+  };
+}
 
 function FeedbackAlert({ message, onClose }: { message: string; onClose: () => void }) {
   return (
@@ -135,16 +151,7 @@ export function useBacklogFeedback() {
         }),
       toast: (message, options) =>
         new Promise<ToastResult>((resolve) => {
-          setToastState((current) => {
-            // 既存トーストがあれば先に settle して Promise を解決させる
-            current?.resolve({ undone: false });
-            return {
-              message,
-              undoLabel: options?.undoLabel,
-              timeoutMs: options?.timeoutMs ?? 5000,
-              resolve,
-            };
-          });
+          setToastState((current) => buildNextToastState(current, message, options, resolve));
         }),
     }),
     [],

--- a/src/features/backlog/hooks/useBoardPageController.test.tsx
+++ b/src/features/backlog/hooks/useBoardPageController.test.tsx
@@ -30,6 +30,7 @@ vi.mock("./useBacklogDnd.ts", () => ({
   useBacklogDnd: () => ({
     dragItemId: null,
     localItems: hookMocks.items,
+    setLocalItems: vi.fn(),
     sensors: [],
     handleDragStart: vi.fn(),
     handleDragOver: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock("./useBacklogActions.ts", () => ({
   useBacklogActions: () => ({
     handleDeleteItem: vi.fn(),
     handleMarkAsWatched: vi.fn(),
+    handleAddTmdbWorksToStacked: vi.fn(),
   }),
 }));
 
@@ -50,6 +52,7 @@ vi.mock("./useBacklogFeedback.tsx", () => ({
     feedback: {
       alert: vi.fn().mockResolvedValue(undefined),
       confirm: vi.fn().mockResolvedValue(true),
+      toast: vi.fn().mockResolvedValue({ undone: false }),
     },
     feedbackUi: null,
   }),

--- a/src/features/backlog/hooks/useBoardPageController.ts
+++ b/src/features/backlog/hooks/useBoardPageController.ts
@@ -25,6 +25,8 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
 
   const actions = useBacklogActions({
     items,
+    localItems: dnd.localItems,
+    setLocalItems: dnd.setLocalItems,
     session,
     loadItems,
     onItemDeleted: boardPageState.handleItemDeleted,

--- a/src/features/backlog/hooks/useBoardPageController.ts
+++ b/src/features/backlog/hooks/useBoardPageController.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { useBacklogActions } from "./useBacklogActions.ts";
 import { useBacklogDnd } from "./useBacklogDnd.ts";
@@ -15,9 +16,11 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
   const { feedback, feedbackUi } = useBacklogFeedback();
   const { items, isLoading, error, loadItems } = useBacklogItems(session.user.id);
   const boardPageState = useBoardPageState({ isMobileLayout });
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<ReadonlySet<string>>(new Set());
 
   const dnd = useBacklogDnd({
     items,
+    pendingDeleteIds,
     isMobileLayout,
     onAfterDrop: loadItems,
     feedback,
@@ -27,6 +30,7 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
     items,
     localItems: dnd.localItems,
     setLocalItems: dnd.setLocalItems,
+    setPendingDeleteIds,
     session,
     loadItems,
     onItemDeleted: boardPageState.handleItemDeleted,

--- a/src/features/backlog/ui-feedback.ts
+++ b/src/features/backlog/ui-feedback.ts
@@ -1,6 +1,16 @@
+export type ToastOptions = {
+  undoLabel?: string;
+  timeoutMs?: number;
+};
+
+export type ToastResult = {
+  undone: boolean;
+};
+
 export type BacklogFeedback = {
   alert: (message: string) => void | Promise<void>;
   confirm: (message: string) => boolean | Promise<boolean>;
+  toast: (message: string, options?: ToastOptions) => Promise<ToastResult>;
 };
 
 export const browserBacklogFeedback: BacklogFeedback = {
@@ -8,4 +18,8 @@ export const browserBacklogFeedback: BacklogFeedback = {
     globalThis.alert(message);
   },
   confirm: (message) => globalThis.confirm(message),
+  toast: (_message, options) =>
+    new Promise<ToastResult>((resolve) => {
+      setTimeout(() => resolve({ undone: false }), options?.timeoutMs ?? 5000);
+    }),
 };


### PR DESCRIPTION
## 関連 Issue

Closes #181

## 変更内容

- 削除操作を楽観的 UI に変更：カードを即座に UI から除去し、詳細モーダルを閉じる
- 右下に Toast「削除しました／元に戻す」を 5 秒表示
- Undo クリック → タイマーキャンセル + `localItems` に復元（削除 API は呼ばない）
- Toast タイムアウト後に Supabase delete を実行。失敗時は alert + `loadItems` でロールバック
- `useBacklogDnd` から `setLocalItems` を公開し、`useBacklogActions` が `localItems` を操作できる構造に
- `BacklogFeedback` 型に `toast()` を追加（`useBacklogFeedback` と `browserBacklogFeedback` に実装）

楽観的追加は複雑さ過大と判断し今回スコープ外（Issue コメント参照）。