### PR TITLE
ci: refactoring backlog の Issue 生成内容の改善

### DIFF
--- a/.github/scripts/refactoring-backlog.ts
+++ b/.github/scripts/refactoring-backlog.ts
@@ -19,6 +19,8 @@ import {
 
 const REQUIRED_ENV_KEYS = ["SONAR_PROJECT_KEY", "SONAR_TOKEN"] as const;
 const SONAR_BASE_URL = "https://sonarcloud.io";
+const WORKFLOW_URL =
+  "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml";
 const PROJECT_METRICS: SonarMeasureKey[] = [
   "code_smells",
   "sqale_index",
@@ -27,6 +29,10 @@ const PROJECT_METRICS: SonarMeasureKey[] = [
   "complexity",
   "cognitive_complexity",
   "ncloc",
+  "reliability_rating",
+  "bugs",
+  "security_rating",
+  "vulnerabilities",
 ];
 const FILE_METRICS: SonarMeasureKey[] = [
   "code_smells",
@@ -82,10 +88,10 @@ async function main() {
 
   const observedAt =
     new Intl.DateTimeFormat("sv-SE", {
-      timeZone: "UTC",
+      timeZone: "Asia/Tokyo",
       dateStyle: "short",
       timeStyle: "short",
-    }).format(new Date()) + " UTC";
+    }).format(new Date()) + " JST";
 
   const quickWinIssues = selectQuickWinIssues(filterBacklogIssues(issues, projectKey));
   const filteredFileSignals = filterBacklogSignals(fileSignals);
@@ -97,6 +103,7 @@ async function main() {
     observedAt,
     sonarBaseUrl: SONAR_BASE_URL,
     branchName,
+    workflowUrl: WORKFLOW_URL,
     projectMeasures,
     quickWinIssues,
     longFiles,

--- a/.github/scripts/refactoring-backlog.ts
+++ b/.github/scripts/refactoring-backlog.ts
@@ -29,10 +29,6 @@ const PROJECT_METRICS: SonarMeasureKey[] = [
   "complexity",
   "cognitive_complexity",
   "ncloc",
-  "reliability_rating",
-  "bugs",
-  "security_rating",
-  "vulnerabilities",
 ];
 const FILE_METRICS: SonarMeasureKey[] = [
   "code_smells",
@@ -80,10 +76,12 @@ async function main() {
     process.env.REFACTORING_BACKLOG_OUTPUT_DIR || "artifacts/refactoring-backlog",
   );
 
-  const [projectMeasures, fileSignals, issues] = await Promise.all([
+  const [projectMeasures, fileSignals, codeSmells, bugs, vulnerabilities] = await Promise.all([
     fetchProjectMeasures({ projectKey, branchName }),
     fetchFileSignals({ projectKey, branchName }),
-    fetchCodeSmells({ projectKey, branchName }),
+    fetchIssuesByType({ projectKey, branchName, type: "CODE_SMELL" }),
+    fetchIssuesByType({ projectKey, branchName, type: "BUG" }),
+    fetchIssuesByType({ projectKey, branchName, type: "VULNERABILITY" }),
   ]);
 
   const observedAt =
@@ -93,7 +91,9 @@ async function main() {
       timeStyle: "short",
     }).format(new Date()) + " JST";
 
-  const quickWinIssues = selectQuickWinIssues(filterBacklogIssues(issues, projectKey));
+  const bugIssues = filterBacklogIssues(bugs, projectKey);
+  const vulnerabilityIssues = filterBacklogIssues(vulnerabilities, projectKey);
+  const quickWinIssues = selectQuickWinIssues(filterBacklogIssues(codeSmells, projectKey));
   const filteredFileSignals = filterBacklogSignals(fileSignals);
   const longFiles = rankLongFiles(filteredFileSignals);
   const complexFiles = rankComplexFiles(filteredFileSignals);
@@ -105,6 +105,8 @@ async function main() {
     branchName,
     workflowUrl: WORKFLOW_URL,
     projectMeasures,
+    bugIssues,
+    vulnerabilityIssues,
     quickWinIssues,
     longFiles,
     complexFiles,
@@ -165,12 +167,12 @@ async function fetchFileSignals(input: { projectKey: string; branchName: string 
   })) satisfies SonarFileSignal[];
 }
 
-async function fetchCodeSmells(input: { projectKey: string; branchName: string }) {
+async function fetchIssuesByType(input: { projectKey: string; branchName: string; type: string }) {
   const issues = await paginate<SonarIssuesResponse["issues"][number]>(async (page) => {
     const response = await sonarApi<SonarIssuesResponse>("/api/issues/search", {
       componentKeys: input.projectKey,
       branch: input.branchName,
-      types: "CODE_SMELL",
+      types: input.type,
       statuses: "OPEN,CONFIRMED",
       ps: "100",
       p: String(page),

--- a/src/lib/refactoring-backlog-render.ts
+++ b/src/lib/refactoring-backlog-render.ts
@@ -23,6 +23,19 @@ type QuickWinGroup = {
   minEffortMinutes?: number;
 };
 
+export function renderIssueList(
+  projectKey: string,
+  sonarBaseUrl: string,
+  issues: SonarIssueLike[],
+) {
+  return issues.map((issue) => {
+    const path = toDisplayPath(normalizeComponentPath(issue.component, projectKey));
+    const line = issue.line ? `:${issue.line}` : "";
+    const issueUrl = `${trimTrailingSlash(sonarBaseUrl)}/project/issues?id=${encodeURIComponent(projectKey)}&open=${encodeURIComponent(issue.key)}`;
+    return `- [${path}${line}](${issueUrl}) — ${sanitizeAbsolutePaths(issue.message)}`;
+  });
+}
+
 export function renderQuickWinIssues(
   projectKey: string,
   sonarBaseUrl: string,

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -237,9 +237,11 @@ describe("buildRefactoringBacklogIssue", () => {
   test("issue 本文に summary と候補一覧を含める", () => {
     const result = buildRefactoringBacklogIssue({
       projectKey: "mirukan",
-      observedAt: "2026-04-11 10:00 UTC",
+      observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
+      workflowUrl:
+        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {
         code_smells: 12,
         sqale_index: 135,
@@ -300,9 +302,11 @@ describe("buildRefactoringBacklogIssue", () => {
   test("絶対パスだけを repo 相対に正規化し、相対パスの quick win label は壊さない", () => {
     const result = buildRefactoringBacklogIssue({
       projectKey: "mirukan",
-      observedAt: "2026-04-11 10:00 UTC",
+      observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
+      workflowUrl:
+        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
       quickWinIssues: [
         {
@@ -358,9 +362,11 @@ describe("buildRefactoringBacklogIssue", () => {
   test("通常の slash を含むだけのメッセージは変更しない", () => {
     const result = buildRefactoringBacklogIssue({
       projectKey: "mirukan",
-      observedAt: "2026-04-11 10:00 UTC",
+      observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
+      workflowUrl:
+        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
       quickWinIssues: [
         {

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -251,6 +251,8 @@ describe("buildRefactoringBacklogIssue", () => {
         complexity: 90,
         ncloc: 1500,
       },
+      bugIssues: [],
+      vulnerabilityIssues: [],
       quickWinIssues: [
         {
           key: "issue-1",
@@ -308,6 +310,8 @@ describe("buildRefactoringBacklogIssue", () => {
       workflowUrl:
         "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
+      bugIssues: [],
+      vulnerabilityIssues: [],
       quickWinIssues: [
         {
           key: "issue-1",
@@ -368,6 +372,8 @@ describe("buildRefactoringBacklogIssue", () => {
       workflowUrl:
         "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
+      bugIssues: [],
+      vulnerabilityIssues: [],
       quickWinIssues: [
         {
           key: "issue-1",
@@ -385,5 +391,65 @@ describe("buildRefactoringBacklogIssue", () => {
     expect(result.body).toContain(
       "- See docs/ui.md and keep src/lib/example.ts as-is. - 1件 (最短 1 min)",
     );
+  });
+
+  test("bugs が存在する場合にセクションと issue リンクを出力する", () => {
+    const result = buildRefactoringBacklogIssue({
+      projectKey: "mirukan",
+      observedAt: "2026-04-11 10:00 JST",
+      sonarBaseUrl: "https://sonarcloud.io",
+      branchName: "main",
+      workflowUrl:
+        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
+      projectMeasures: {},
+      bugIssues: [
+        {
+          key: "bug-1",
+          message: "Null pointer dereference.",
+          component: "mirukan:src/lib/example.ts",
+          line: 10,
+          rule: "typescript:S2259",
+        },
+        {
+          key: "bug-2",
+          message: "This condition always evaluates to true.",
+          component: "mirukan:src/features/backlog/types.ts",
+          line: 5,
+          rule: "typescript:S2589",
+        },
+      ],
+      vulnerabilityIssues: [],
+      quickWinIssues: [],
+      longFiles: [],
+      complexFiles: [],
+      duplicateFiles: [],
+    });
+
+    expect(result.body).toContain("## バグ (2件)");
+    expect(result.body).toContain("[src/lib/example.ts:10]");
+    expect(result.body).toContain("Null pointer dereference.");
+    expect(result.body).toContain("[src/features/backlog/types.ts:5]");
+    expect(result.body).not.toContain("## 脆弱性");
+  });
+
+  test("bugs / vulnerabilities が 0 件の場合はセクションを出力しない", () => {
+    const result = buildRefactoringBacklogIssue({
+      projectKey: "mirukan",
+      observedAt: "2026-04-11 10:00 JST",
+      sonarBaseUrl: "https://sonarcloud.io",
+      branchName: "main",
+      workflowUrl:
+        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
+      projectMeasures: {},
+      bugIssues: [],
+      vulnerabilityIssues: [],
+      quickWinIssues: [],
+      longFiles: [],
+      complexFiles: [],
+      duplicateFiles: [],
+    });
+
+    expect(result.body).not.toContain("## バグ");
+    expect(result.body).not.toContain("## 脆弱性");
   });
 });

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -22,7 +22,11 @@ export type SonarMeasureKey =
   | "duplicated_blocks"
   | "complexity"
   | "cognitive_complexity"
-  | "ncloc";
+  | "ncloc"
+  | "reliability_rating"
+  | "bugs"
+  | "security_rating"
+  | "vulnerabilities";
 
 export type SonarMeasureMap = Partial<Record<SonarMeasureKey, number>>;
 
@@ -51,6 +55,7 @@ type RefactoringBacklogInput = {
   observedAt: string;
   sonarBaseUrl: string;
   branchName: string;
+  workflowUrl: string;
   projectMeasures: SonarMeasureMap;
   quickWinIssues: SonarIssue[];
   longFiles: RankedSignal[];
@@ -197,13 +202,16 @@ export function buildRefactoringBacklogIssue({
   observedAt,
   sonarBaseUrl,
   branchName,
+  workflowUrl,
   projectMeasures,
   quickWinIssues,
   longFiles,
   complexFiles,
   duplicateFiles,
 }: RefactoringBacklogInput) {
-  const dashboardUrl = `${trimTrailingSlash(sonarBaseUrl)}/summary/new_code?id=${encodeURIComponent(projectKey)}`;
+  const base = trimTrailingSlash(sonarBaseUrl);
+  const encodedKey = encodeURIComponent(projectKey);
+  const overallDashboardUrl = `${base}/summary/overall?id=${encodedKey}&branch=${encodeURIComponent(branchName)}`;
   const issueTitle = "refactoring backlog";
   const issueBody = [
     REFACTORING_BACKLOG_MARKER,
@@ -212,7 +220,8 @@ export function buildRefactoringBacklogIssue({
     "",
     `- 観測日時: ${observedAt}`,
     `- 対象ブランチ: \`${branchName}\``,
-    `- SonarCloud: [dashboard](${dashboardUrl})`,
+    `- SonarCloud: [overall dashboard](${overallDashboardUrl})`,
+    `- workflow: [refactoring-backlog.yml](${workflowUrl})`,
     "",
     "## 今回のサマリー",
     "",
@@ -223,6 +232,8 @@ export function buildRefactoringBacklogIssue({
     `- cognitive complexity: ${formatNumber(projectMeasures.cognitive_complexity)}`,
     `- complexity: ${formatNumber(projectMeasures.complexity)}`,
     `- ncloc: ${formatNumber(projectMeasures.ncloc)}`,
+    `- reliability: ${formatRating(projectMeasures.reliability_rating)} (bugs: ${formatNumber(projectMeasures.bugs)})`,
+    `- security: ${formatRating(projectMeasures.security_rating)} (vulnerabilities: ${formatNumber(projectMeasures.vulnerabilities)})`,
     "",
     "## すぐ直す",
     "",
@@ -242,23 +253,21 @@ export function buildRefactoringBacklogIssue({
     "",
     ...renderRankedSignals(duplicateFiles, "duplicated lines density", "関連メモ"),
     "",
-    "## 今は保留",
-    "",
-    "- coverage / knip / lint はまだ棚卸し対象に含めていない",
-    "- issue 分割や自動 PR は行わず、この issue に集約する",
-    "",
-    "## メモ",
-    "",
-    "- `すぐ直す` は修正コストが低い code smell を優先表示",
-    "- `構造改善が必要` は局所修正では片付きにくいファイル単位のシグナル",
-    "- 最終的な優先度判断は人間が行う",
-    "",
   ].join("\n");
 
   return {
     title: issueTitle,
     body: issueBody,
   };
+}
+
+function formatRating(value: number | undefined): string {
+  if (value == null) {
+    return "-";
+  }
+
+  const grade = ["A", "B", "C", "D", "E"][Math.round(value) - 1];
+  return grade ?? "-";
 }
 
 function trimTrailingSlash(value: string) {

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -3,6 +3,7 @@ import {
   formatMinutes,
   formatNumber,
   formatPercent,
+  renderIssueList,
   renderQuickWinIssues,
   renderRankedSignals,
 } from "./refactoring-backlog-render.ts";
@@ -22,11 +23,7 @@ export type SonarMeasureKey =
   | "duplicated_blocks"
   | "complexity"
   | "cognitive_complexity"
-  | "ncloc"
-  | "reliability_rating"
-  | "bugs"
-  | "security_rating"
-  | "vulnerabilities";
+  | "ncloc";
 
 export type SonarMeasureMap = Partial<Record<SonarMeasureKey, number>>;
 
@@ -57,6 +54,8 @@ type RefactoringBacklogInput = {
   branchName: string;
   workflowUrl: string;
   projectMeasures: SonarMeasureMap;
+  bugIssues: SonarIssue[];
+  vulnerabilityIssues: SonarIssue[];
   quickWinIssues: SonarIssue[];
   longFiles: RankedSignal[];
   complexFiles: RankedSignal[];
@@ -204,6 +203,8 @@ export function buildRefactoringBacklogIssue({
   branchName,
   workflowUrl,
   projectMeasures,
+  bugIssues,
+  vulnerabilityIssues,
   quickWinIssues,
   longFiles,
   complexFiles,
@@ -232,9 +233,23 @@ export function buildRefactoringBacklogIssue({
     `- cognitive complexity: ${formatNumber(projectMeasures.cognitive_complexity)}`,
     `- complexity: ${formatNumber(projectMeasures.complexity)}`,
     `- ncloc: ${formatNumber(projectMeasures.ncloc)}`,
-    `- reliability: ${formatRating(projectMeasures.reliability_rating)} (bugs: ${formatNumber(projectMeasures.bugs)})`,
-    `- security: ${formatRating(projectMeasures.security_rating)} (vulnerabilities: ${formatNumber(projectMeasures.vulnerabilities)})`,
     "",
+    ...(bugIssues.length > 0
+      ? [
+          `## バグ (${bugIssues.length}件)`,
+          "",
+          ...renderIssueList(projectKey, sonarBaseUrl, bugIssues),
+          "",
+        ]
+      : []),
+    ...(vulnerabilityIssues.length > 0
+      ? [
+          `## 脆弱性 (${vulnerabilityIssues.length}件)`,
+          "",
+          ...renderIssueList(projectKey, sonarBaseUrl, vulnerabilityIssues),
+          "",
+        ]
+      : []),
     "## すぐ直す",
     "",
     ...renderQuickWinIssues(projectKey, sonarBaseUrl, quickWinIssues),
@@ -259,15 +274,6 @@ export function buildRefactoringBacklogIssue({
     title: issueTitle,
     body: issueBody,
   };
-}
-
-function formatRating(value: number | undefined): string {
-  if (value == null) {
-    return "-";
-  }
-
-  const grade = ["A", "B", "C", "D", "E"][Math.round(value) - 1];
-  return grade ?? "-";
 }
 
 function trimTrailingSlash(value: string) {


### PR DESCRIPTION
## 関連 Issue

Refs #167

## 変更内容

- 観測日時を JST 表示に変更（`UTC` → `Asia/Tokyo`）
- Issue 本文メタに workflow リンクを追加（`refactoring-backlog.yml`）
- SonarCloud リンクを `new_code` dashboard から `overall` dashboard に変更（branch パラメータ付き）
- サマリーに reliability / security を追加（`reliability: A (bugs: 0)` / `security: A (vulnerabilities: 0)` 形式）
- `今は保留` / `メモ` セクションを削除
- 上記に合わせてテストを更新（`workflowUrl` 追加、`observedAt` を JST 形式に統一）