### PR TITLE
ci: refactoring backlog issue を snapshot 運用に変更

### DIFF
--- a/.github/scripts/refactoring-backlog.ts
+++ b/.github/scripts/refactoring-backlog.ts
@@ -19,8 +19,6 @@ import {
 
 const REQUIRED_ENV_KEYS = ["SONAR_PROJECT_KEY", "SONAR_TOKEN"] as const;
 const SONAR_BASE_URL = "https://sonarcloud.io";
-const WORKFLOW_URL =
-  "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml";
 const PROJECT_METRICS: SonarMeasureKey[] = [
   "code_smells",
   "sqale_index",
@@ -103,7 +101,6 @@ async function main() {
     observedAt,
     sonarBaseUrl: SONAR_BASE_URL,
     branchName,
-    workflowUrl: WORKFLOW_URL,
     projectMeasures,
     bugIssues,
     vulnerabilityIssues,

--- a/.github/workflows/refactoring-backlog.yml
+++ b/.github/workflows/refactoring-backlog.yml
@@ -2,7 +2,8 @@ name: Refactoring Backlog
 
 on:
   schedule:
-    - cron: "17 2 * * 2,6"
+    # Tue/Thu/Sat 11:17 JST
+    - cron: "17 2 * * 2,4,6"
   workflow_dispatch:
 
 env:
@@ -61,7 +62,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: node --experimental-strip-types .github/scripts/refactoring-backlog.ts
 
-      - name: Create or update backlog issue
+      - name: Create backlog issue and close superseded snapshots
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -74,22 +75,29 @@ jobs:
             --color "0969da" \
             || true
 
-          issue_number=$(
+          issue_title="$(<"$REFACTORING_BACKLOG_OUTPUT_DIR/title.txt")"
+          new_issue_url=$(
+            gh issue create \
+              --title "${issue_title:-$REFACTORING_BACKLOG_TITLE}" \
+              --body-file "$REFACTORING_BACKLOG_OUTPUT_DIR/body.md" \
+              --label "$REFACTORING_BACKLOG_LABEL"
+          )
+          new_issue_number="${new_issue_url##*/}"
+
+          mapfile -t backlog_issue_numbers < <(
             gh issue list \
               --label "$REFACTORING_BACKLOG_LABEL" \
               --state open \
               --limit 100 \
-              --json number,title,body \
-              --jq 'map(select(.body | contains(env.REFACTORING_BACKLOG_MARKER))) | first | .number // empty'
+              --json number,body \
+              --jq '.[] | select(.body | contains(env.REFACTORING_BACKLOG_MARKER)) | .number'
           )
 
-          if [[ -n "${issue_number}" ]]; then
-            gh issue edit "$issue_number" \
-              --title "$REFACTORING_BACKLOG_TITLE" \
-              --body-file "$REFACTORING_BACKLOG_OUTPUT_DIR/body.md"
-          else
-            gh issue create \
-              --title "$REFACTORING_BACKLOG_TITLE" \
-              --body-file "$REFACTORING_BACKLOG_OUTPUT_DIR/body.md" \
-              --label "$REFACTORING_BACKLOG_LABEL"
-          fi
+          for issue_number in "${backlog_issue_numbers[@]}"; do
+            if [[ "$issue_number" == "$new_issue_number" ]]; then
+              continue
+            fi
+
+            gh issue comment "$issue_number" --body "Superseded by #$new_issue_number" || true
+            gh issue close "$issue_number"
+          done

--- a/.github/workflows/refactoring-backlog.yml
+++ b/.github/workflows/refactoring-backlog.yml
@@ -2,8 +2,8 @@ name: Refactoring Backlog
 
 on:
   schedule:
-    # Tue/Thu/Sat 11:17 JST
-    - cron: "17 2 * * 2,4,6"
+    # Tue/Thu/Sat 00:00 JST
+    - cron: "0 15 * * 1,3,5"
   workflow_dispatch:
 
 env:

--- a/src/lib/refactoring-backlog.test.ts
+++ b/src/lib/refactoring-backlog.test.ts
@@ -240,8 +240,6 @@ describe("buildRefactoringBacklogIssue", () => {
       observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
-      workflowUrl:
-        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {
         code_smells: 12,
         sqale_index: 135,
@@ -288,7 +286,16 @@ describe("buildRefactoringBacklogIssue", () => {
 
     expect(result.title).toBe("refactoring backlog");
     expect(result.body).toContain("<!-- refactoring-backlog:sonarcloud -->");
+    expect(result.body).toContain(
+      "この Issue は定期生成される refactoring backlog snapshot です。",
+    );
+    expect(result.body).toContain("- まず `バグ`、次に `脆弱性`、その次に `すぐ直す` を優先");
+    expect(result.body).toContain("- PR では原則 `Closes` を使わず、必要なら `Refs` に留める");
+    expect(result.body).not.toContain("workflow:");
     expect(result.body).toContain("maintainability debt: 2 h 15 min");
+    expect(result.body).toContain("## バグ (0件)");
+    expect(result.body).toContain("## 脆弱性 (0件)");
+    expect(result.body).toContain("- 該当なし");
     expect(result.body).toContain(
       "- This assertion is unnecessary since it does not change the type of the expression. - 2件 (最短 1 min)",
     );
@@ -307,8 +314,6 @@ describe("buildRefactoringBacklogIssue", () => {
       observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
-      workflowUrl:
-        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
       bugIssues: [],
       vulnerabilityIssues: [],
@@ -369,8 +374,6 @@ describe("buildRefactoringBacklogIssue", () => {
       observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
-      workflowUrl:
-        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
       bugIssues: [],
       vulnerabilityIssues: [],
@@ -399,8 +402,6 @@ describe("buildRefactoringBacklogIssue", () => {
       observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
-      workflowUrl:
-        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
       bugIssues: [
         {
@@ -429,17 +430,15 @@ describe("buildRefactoringBacklogIssue", () => {
     expect(result.body).toContain("[src/lib/example.ts:10]");
     expect(result.body).toContain("Null pointer dereference.");
     expect(result.body).toContain("[src/features/backlog/types.ts:5]");
-    expect(result.body).not.toContain("## 脆弱性");
+    expect(result.body).toContain("## 脆弱性 (0件)");
   });
 
-  test("bugs / vulnerabilities が 0 件の場合はセクションを出力しない", () => {
+  test("bugs / vulnerabilities が 0 件の場合も空セクションを出力する", () => {
     const result = buildRefactoringBacklogIssue({
       projectKey: "mirukan",
       observedAt: "2026-04-11 10:00 JST",
       sonarBaseUrl: "https://sonarcloud.io",
       branchName: "main",
-      workflowUrl:
-        "https://github.com/isshi-hasegawa/mirukan/actions/workflows/refactoring-backlog.yml",
       projectMeasures: {},
       bugIssues: [],
       vulnerabilityIssues: [],
@@ -449,7 +448,8 @@ describe("buildRefactoringBacklogIssue", () => {
       duplicateFiles: [],
     });
 
-    expect(result.body).not.toContain("## バグ");
-    expect(result.body).not.toContain("## 脆弱性");
+    expect(result.body).toContain("## バグ (0件)");
+    expect(result.body).toContain("## 脆弱性 (0件)");
+    expect(result.body).toContain("- 該当なし");
   });
 });

--- a/src/lib/refactoring-backlog.ts
+++ b/src/lib/refactoring-backlog.ts
@@ -52,7 +52,6 @@ type RefactoringBacklogInput = {
   observedAt: string;
   sonarBaseUrl: string;
   branchName: string;
-  workflowUrl: string;
   projectMeasures: SonarMeasureMap;
   bugIssues: SonarIssue[];
   vulnerabilityIssues: SonarIssue[];
@@ -201,7 +200,6 @@ export function buildRefactoringBacklogIssue({
   observedAt,
   sonarBaseUrl,
   branchName,
-  workflowUrl,
   projectMeasures,
   bugIssues,
   vulnerabilityIssues,
@@ -219,10 +217,19 @@ export function buildRefactoringBacklogIssue({
     "",
     "# Refactoring backlog",
     "",
+    "この Issue は定期生成される refactoring backlog snapshot です。最新の観測結果をもとに、今回対応する項目を自分で選んで進めてください。",
+    "",
+    "- まず `バグ`、次に `脆弱性`、その次に `すぐ直す` を優先",
+    "- 余力があれば `構造改善が必要` から安全に触れられるものを追加",
+    "- 振る舞いを変えないリファクタを優先",
+    "- 実行手順・検証・コミット・PR の進め方は `AGENTS.md` と各 skill に従う",
+    "- PR / 最終報告では、対応した項目・見送った項目・実施した検証を整理する",
+    "- PR では原則 `Closes` を使わず、必要なら `Refs` に留める",
+    "- 大きすぎる変更を 1 PR に詰め込みすぎない",
+    "",
     `- 観測日時: ${observedAt}`,
     `- 対象ブランチ: \`${branchName}\``,
     `- SonarCloud: [overall dashboard](${overallDashboardUrl})`,
-    `- workflow: [refactoring-backlog.yml](${workflowUrl})`,
     "",
     "## 今回のサマリー",
     "",
@@ -234,22 +241,14 @@ export function buildRefactoringBacklogIssue({
     `- complexity: ${formatNumber(projectMeasures.complexity)}`,
     `- ncloc: ${formatNumber(projectMeasures.ncloc)}`,
     "",
-    ...(bugIssues.length > 0
-      ? [
-          `## バグ (${bugIssues.length}件)`,
-          "",
-          ...renderIssueList(projectKey, sonarBaseUrl, bugIssues),
-          "",
-        ]
-      : []),
-    ...(vulnerabilityIssues.length > 0
-      ? [
-          `## 脆弱性 (${vulnerabilityIssues.length}件)`,
-          "",
-          ...renderIssueList(projectKey, sonarBaseUrl, vulnerabilityIssues),
-          "",
-        ]
-      : []),
+    `## バグ (${bugIssues.length}件)`,
+    "",
+    ...renderIssueSection(projectKey, sonarBaseUrl, bugIssues),
+    "",
+    `## 脆弱性 (${vulnerabilityIssues.length}件)`,
+    "",
+    ...renderIssueSection(projectKey, sonarBaseUrl, vulnerabilityIssues),
+    "",
     "## すぐ直す",
     "",
     ...renderQuickWinIssues(projectKey, sonarBaseUrl, quickWinIssues),
@@ -278,4 +277,12 @@ export function buildRefactoringBacklogIssue({
 
 function trimTrailingSlash(value: string) {
   return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function renderIssueSection(projectKey: string, sonarBaseUrl: string, issues: SonarIssue[]) {
+  if (issues.length === 0) {
+    return ["- 該当なし"];
+  }
+
+  return renderIssueList(projectKey, sonarBaseUrl, issues);
 }


### PR DESCRIPTION
## 関連 Issue

-

## 変更内容

- `refactoring backlog` workflow を既存 issue の更新方式から、毎回新規 issue を作成して旧 snapshot を close する方式に変更
- 新しく作成した backlog issue 以外の open backlog issue を探索し、close 前に `Superseded by #...` コメントを試行するように変更
- schedule を火・木・土の 0:00 JST 相当である `15:00 UTC` に変更
- backlog issue 本文を self-contained 化し、固定のエージェント向け指示を本文へ移動して workflow リンクとコメント依存を削除
