### PR TITLE
refactor: TMDB テストモック関連の backlog 指摘を解消

### DIFF
--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -48,7 +48,12 @@ describe("LoginPage", () => {
   test("開発時だけ補助導線から開発用アカウントを入力できる", async () => {
     const user = userEvent.setup();
 
-    render(<LoginPage showDevLoginHint />);
+    render(
+      <LoginPage
+        showDevLoginHint
+        devLoginCredentials={{ email: "akari@example.com", password: "password123" }}
+      />,
+    );
 
     expect(screen.getByText("開発用アカウント")).toBeInTheDocument();
     expect(screen.getByText("akari@example.com / password123")).toBeInTheDocument();

--- a/src/features/backlog/components/LoginPage.tsx
+++ b/src/features/backlog/components/LoginPage.tsx
@@ -1,20 +1,39 @@
 import { AuthScreen } from "./AuthScreen.tsx";
 import { BrandWordmark } from "./BrandWordmark.tsx";
 import { LoginPageAuthForm } from "./LoginPageAuthForm.tsx";
-import { getAuthRedirectUrl, useLoginPageAuth } from "../hooks/useLoginPageAuth.ts";
+import {
+  getAuthRedirectUrl,
+  useLoginPageAuth,
+  type DevLoginCredentials,
+} from "../hooks/useLoginPageAuth.ts";
 
 type Props = {
+  devLoginCredentials?: DevLoginCredentials | null;
   isSessionLoading?: boolean;
   showDevLoginHint?: boolean;
 };
 
 export { getAuthRedirectUrl };
 
+function getDevLoginCredentials(): DevLoginCredentials | null {
+  if (!import.meta.env.DEV || import.meta.env.MODE === "test") {
+    return null;
+  }
+
+  return {
+    // Seeded local-only account for development convenience, not a production secret.
+    email: import.meta.env.VITE_DEV_LOGIN_EMAIL || "akari@example.com",
+    password: import.meta.env.VITE_DEV_LOGIN_PASSWORD || "password123",
+  };
+}
+
 export function LoginPage({
+  devLoginCredentials = getDevLoginCredentials(),
   isSessionLoading = false,
   showDevLoginHint = import.meta.env.DEV && import.meta.env.MODE !== "test",
 }: Props) {
   const auth = useLoginPageAuth({
+    devLoginCredentials,
     showDevLoginHint: showDevLoginHint && !isSessionLoading,
   });
 

--- a/src/features/backlog/components/LoginPageAuthForm.tsx
+++ b/src/features/backlog/components/LoginPageAuthForm.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
-import { DEV_EMAIL, DEV_PASSWORD, useLoginPageAuth } from "../hooks/useLoginPageAuth.ts";
+import { useLoginPageAuth } from "../hooks/useLoginPageAuth.ts";
 
 type LoginPageAuthModel = ReturnType<typeof useLoginPageAuth>;
 
@@ -166,7 +166,7 @@ function LoginFormContent({ auth }: Props) {
             ローカル検証では seed 済みアカウントを入力して利用できます。
           </p>
           <p className="mt-2 text-xs leading-6 text-muted-foreground">
-            {DEV_EMAIL} / {DEV_PASSWORD}
+            {auth.devLoginCredentials?.email} / {auth.devLoginCredentials?.password}
           </p>
           <Button
             type="button"

--- a/src/features/backlog/hooks/useLoginPageAuth.ts
+++ b/src/features/backlog/hooks/useLoginPageAuth.ts
@@ -8,8 +8,10 @@ import {
 
 type AuthMode = "login" | "signUp" | "forgotPassword";
 
-export const DEV_EMAIL = "akari@example.com";
-export const DEV_PASSWORD = "password123";
+export type DevLoginCredentials = Readonly<{
+  email: string;
+  password: string;
+}>;
 
 export function getAuthRedirectUrl(location: Pick<Location, "origin" | "hostname">) {
   if (location.hostname === "www.mirukan.app") {
@@ -52,10 +54,14 @@ function getResetPasswordErrorMessage(errorMessage: string) {
 }
 
 type UseLoginPageAuthOptions = {
+  devLoginCredentials: DevLoginCredentials | null;
   showDevLoginHint: boolean;
 };
 
-export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) {
+export function useLoginPageAuth({
+  devLoginCredentials,
+  showDevLoginHint,
+}: UseLoginPageAuthOptions) {
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [loginEmail, setLoginEmail] = useState("");
   const [loginPassword, setLoginPassword] = useState("");
@@ -73,7 +79,8 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
   const email = isSignUpMode ? signUpEmail : loginEmail;
   const password = isSignUpMode ? signUpPassword : loginPassword;
   const authRedirectUrl = getAuthRedirectUrl(globalThis.location);
-  const shouldShowDevLoginHint = showDevLoginHint && !isSignUpMode && !isForgotPasswordMode;
+  const shouldShowDevLoginHint =
+    showDevLoginHint && devLoginCredentials !== null && !isSignUpMode && !isForgotPasswordMode;
 
   const resetStatusMessage = () => {
     setErrorMessage("");
@@ -113,8 +120,12 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
   };
 
   const fillDevAccount = () => {
-    setLoginEmail(DEV_EMAIL);
-    setLoginPassword(DEV_PASSWORD);
+    if (!devLoginCredentials) {
+      return;
+    }
+
+    setLoginEmail(devLoginCredentials.email);
+    setLoginPassword(devLoginCredentials.password);
     setErrorMessage("");
   };
 
@@ -207,6 +218,7 @@ export function useLoginPageAuth({ showDevLoginHint }: UseLoginPageAuthOptions) 
     errorMessage,
     hasSentConfirmationEmail,
     isSubmitting,
+    devLoginCredentials,
     shouldShowDevLoginHint,
     setLoginEmail,
     setLoginPassword,

--- a/src/lib/tmdb.test.ts
+++ b/src/lib/tmdb.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./tmdb.ts";
 import { setupTestLifecycle } from "../test/test-lifecycle.ts";
 import {
+  setMockTmdbSearchResults,
   setMockTmdbSeasonOptions,
   setMockTmdbSimilarResults,
   setMockTmdbTrendingResults,
@@ -260,10 +261,11 @@ describe("recommendation caches", () => {
 
     const results = await fetchTmdbTrending();
 
-    expect(results.map((result) => `${result.tmdbMediaType}-${result.tmdbId}`).sort()).toEqual([
-      "movie-10",
-      "tv-10",
-    ]);
+    expect(
+      results
+        .map((result) => `${result.tmdbMediaType}-${result.tmdbId}`)
+        .sort((left, right) => left.localeCompare(right)),
+    ).toEqual(["movie-10", "tv-10"]);
   });
 
   test("fetchTmdbTrending reuses an in-flight request", async () => {
@@ -320,28 +322,36 @@ describe("API boundary wrappers", () => {
     seriesTitle: "Series",
   };
 
-  test("searchTmdbWorks passes query and returns results", async () => {
+  test("searchTmdbWorks passes query", async () => {
     let receivedQuery = "";
     server.use(
       http.post(`${SUPABASE_URL}/functions/v1/search-tmdb-works`, async ({ request }) => {
         const body = (await request.json()) as { query: string };
         receivedQuery = body.query;
-        return HttpResponse.json([
-          {
-            tmdbId: 1,
-            tmdbMediaType: "movie",
-            workType: "movie",
-            title: "Search Result",
-            originalTitle: null,
-            overview: null,
-            posterPath: null,
-            releaseDate: "2025-01-01",
-            jpWatchPlatforms: [],
-            hasJapaneseRelease: true,
-          },
-        ]);
+        return HttpResponse.json([]);
       }),
     );
+
+    await searchTmdbWorks("query text");
+
+    expect(receivedQuery).toBe("query text");
+  });
+
+  test("searchTmdbWorks returns results configured in the default mock handler", async () => {
+    setMockTmdbSearchResults("query text", [
+      {
+        tmdbId: 1,
+        tmdbMediaType: "movie",
+        workType: "movie",
+        title: "Search Result",
+        originalTitle: null,
+        overview: null,
+        posterPath: null,
+        releaseDate: "2025-01-01",
+        jpWatchPlatforms: [],
+        hasJapaneseRelease: true,
+      },
+    ]);
 
     await expect(searchTmdbWorks("query text")).resolves.toEqual([
       expect.objectContaining({
@@ -349,7 +359,6 @@ describe("API boundary wrappers", () => {
         title: "Search Result",
       }),
     ]);
-    expect(receivedQuery).toBe("query text");
   });
 
   test("fetchTmdbSeasonOptions passes result and returns season options", async () => {

--- a/src/test/mocks/handlers/index.ts
+++ b/src/test/mocks/handlers/index.ts
@@ -3,6 +3,7 @@
  */
 
 export {
+  setMockTmdbSearchResults,
   resetMockTmdbData,
   setMockTmdbSeasonOptions,
   setMockTmdbSimilarResults,

--- a/src/test/mocks/handlers/supabase-functions.ts
+++ b/src/test/mocks/handlers/supabase-functions.ts
@@ -49,6 +49,10 @@ export function setMockTmdbTrendingResults(results: TmdbSearchResult[]) {
   trendingResults = results;
 }
 
+export function setMockTmdbSearchResults(query: string, results: TmdbSearchResult[]) {
+  searchResultsByQuery.set(query, results);
+}
+
 export function setMockTmdbSeasonOptions(
   result: { tmdbId: number; tmdbMediaType: "movie" | "tv" },
   options: TmdbSeasonOption[],
@@ -78,7 +82,7 @@ export const supabaseFunctionsHandlers = [
   http.post(`${SUPABASE_URL}/functions/v1/search-tmdb-works`, async ({ request }) => {
     const body = (await request.json()) as { query?: string };
 
-    return HttpResponse.json(searchResultsByQuery.get(body.query ?? "") ?? []);
+    return HttpResponse.json(body.query ? (searchResultsByQuery.get(body.query) ?? []) : []);
   }),
 
   http.post(`${SUPABASE_URL}/functions/v1/fetch-tmdb-season-options`, async ({ request }) => {


### PR DESCRIPTION
## 関連 Issue

Refs #199

## 変更内容

- `setMockTmdbSearchResults` を追加し、TMDB 検索のデフォルト MSW handler にテストデータを注入できるように変更
- `searchTmdbWorks` のテストを「query を送る確認」と「デフォルト handler が結果を返す確認」に分割し、mocks の責務を明確化
- `fetchTmdbTrending` のテストで `localeCompare` を使う比較関数を明示し、ソートの Sonar 指摘を解消
- 今回は優先度の高い bug 指摘のうち、テストと test mock に閉じた項目に限定して対応し、UI アクセシビリティ指摘は見送り
