### PR TITLE
chore: Dependency Dashboard 無効化・major PR 自動作成・新 Issue への discovery ラベル自動付与

### DIFF
--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -1,0 +1,22 @@
+name: Label new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    if: github.actor != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['discovery']
+            })

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "dependencyDashboard": false,
   "automergeType": "pr",
   "separateMajorMinor": true,
   "separateMinorPatch": true,
@@ -9,10 +10,6 @@
     "automerge": true
   },
   "packageRules": [
-    {
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
-    },
     {
       "matchManagers": ["github-actions"],
       "groupName": "github actions"


### PR DESCRIPTION
## 関連 Issue

Refs #202

## 変更内容

- `renovate.json`: Dependency Dashboard を無効化（`dependencyDashboard: false`）
- `renovate.json`: major 更新の `dependencyDashboardApproval` を削除し、承認不要で PR 作成されるように変更
- `.github/workflows/label-new-issues.yml`: 新規 Issue に `discovery` ラベルを自動付与する workflow を追加（Renovate bot の Issue は除外）