### PR TITLE
fix: refactoring-backlog Issue への discovery ラベル自動付与を除外

### DIFF
--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label:
-    if: github.actor != 'renovate[bot]'
+    if: github.actor != 'renovate[bot]' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## 関連 Issue

Refs #202

## 変更内容

- `github-actions[bot]` 作成の Issue（refactoring-backlog 等）に `discovery` ラベルが付与されないよう除外条件を追加