### PR TITLE
fix: カード追加時の複数シーズン保存を並列化

### DIFF
--- a/src/features/backlog/work-repository.test.ts
+++ b/src/features/backlog/work-repository.test.ts
@@ -581,6 +581,64 @@ describe("resolveSelectedSeasonWorkIds", () => {
     });
   });
 
+  test("複数シーズン追加時は親 series を一度だけ解決して workIds を順序どおり返す", async () => {
+    tmdbMocks.fetchTmdbWorkDetails
+      .mockResolvedValueOnce(
+        createTmdbDetails({
+          tmdbId: seriesResult.tmdbId,
+          tmdbMediaType: "tv",
+          workType: "series",
+          title: seriesResult.title,
+          originalTitle: seriesResult.originalTitle,
+          runtimeMinutes: null,
+          typicalEpisodeRuntimeMinutes: 48,
+          seasonCount: 2,
+        }),
+      )
+      .mockResolvedValueOnce(
+        createTmdbDetails({
+          tmdbId: seriesResult.tmdbId,
+          tmdbMediaType: "tv",
+          workType: "season",
+          title: seasonOptions[0].title,
+          originalTitle: seriesResult.originalTitle,
+          overview: seasonOptions[0].overview,
+          posterPath: seasonOptions[0].posterPath,
+          releaseDate: seasonOptions[0].releaseDate,
+          runtimeMinutes: null,
+          typicalEpisodeRuntimeMinutes: 48,
+          episodeCount: seasonOptions[0].episodeCount,
+          seasonNumber: seasonOptions[0].seasonNumber,
+        }),
+      );
+
+    const result = await resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1, 2], {
+      seasonOptions,
+    });
+
+    expect(result.error).toBeNull();
+    expect(tmdbMocks.fetchTmdbWorkDetails).toHaveBeenCalledTimes(2);
+
+    const works = getMockWorks();
+    const seriesWork = works.find((work) => work.work_type === "series");
+    const seasonWork = works.find((work) => work.work_type === "season");
+
+    expect(seriesWork).toEqual(
+      expect.objectContaining({
+        tmdb_id: seriesResult.tmdbId,
+        parent_work_id: null,
+      }),
+    );
+    expect(seasonWork).toEqual(
+      expect.objectContaining({
+        tmdb_id: seriesResult.tmdbId,
+        season_number: 2,
+        parent_work_id: seriesWork?.id,
+      }),
+    );
+    expect(result.workIds).toEqual([seriesWork?.id, seasonWork?.id]);
+  });
+
   test("途中の保存に失敗したら workIds を返さず打ち切る", async () => {
     setMockWorks([
       {

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -139,20 +139,49 @@ export async function resolveSelectedSeasonWorkIds(
     };
   }
 
-  const workIds: string[] = [];
-  for (const target of targets) {
-    const seasonWork = await upsertTmdbWork(target, userId);
+  const firstSeasonTarget = targets.find(
+    (target): target is TmdbSeasonSelectionTarget => target.workType === "season",
+  );
+
+  let sharedSeriesWork: TmdbWorkIdResponse | null = null;
+  if (firstSeasonTarget) {
+    sharedSeriesWork = await upsertTmdbWork(buildTmdbSeriesTarget(firstSeasonTarget), userId);
+    if (sharedSeriesWork.error || !sharedSeriesWork.data) {
+      return {
+        error: sharedSeriesWork.error?.message ?? "シーズンの親シリーズ保存に失敗しました",
+        workIds: [],
+      };
+    }
+  }
+
+  const seasonWorks = await Promise.all(
+    targets.map(async (target) => {
+      if (target.workType !== "season") {
+        return sharedSeriesWork ?? upsertTmdbWork(target, userId);
+      }
+
+      if (sharedSeriesWork?.data) {
+        return upsertFetchedTmdbWork(target, userId, {
+          parentWorkId: sharedSeriesWork.data.id,
+        });
+      }
+
+      return upsertTmdbWork(target, userId);
+    }),
+  );
+
+  for (const [index, seasonWork] of seasonWorks.entries()) {
     if (seasonWork.error || !seasonWork.data) {
+      const target = targets[index];
       const label = target.workType === "season" ? `シーズン${target.seasonNumber}` : "シーズン1";
       return {
         error: seasonWork.error?.message ?? `${label}の保存に失敗しました`,
         workIds: [],
       };
     }
-    workIds.push(seasonWork.data.id);
   }
 
-  return { error: null, workIds };
+  return { error: null, workIds: seasonWorks.map((seasonWork) => seasonWork.data!.id) };
 }
 
 async function upsertTmdbSeasonWork(


### PR DESCRIPTION
## 関連 Issue

Closes #195

## 変更内容

- `resolveSelectedSeasonWorkIds` で複数シーズン追加時に共有する series を先に 1 回だけ解決し、その後の season 保存を `Promise.all` で並行実行するよう変更
- `season 1` を含む追加でも parent series の解決が競合しないようにしつつ、戻り値の `workIds` 順序を維持
- 複数シーズン追加時に parent series が 1 回だけ解決されることと、戻り値・親子関係が維持されることをテストで追加
