### PR TITLE
fix: シーズン保存失敗時の fail-fast 維持

### DIFF
--- a/src/features/backlog/work-repository.test.ts
+++ b/src/features/backlog/work-repository.test.ts
@@ -70,6 +70,40 @@ function createOmdbDetails() {
   };
 }
 
+function setExistingSeriesWork() {
+  setMockWorks([
+    {
+      id: "series-work",
+      source_type: "tmdb",
+      work_type: "series",
+      tmdb_media_type: "tv",
+      tmdb_id: 100,
+      title: "テストシリーズ",
+      original_title: "Test Series",
+      search_text: "test series",
+      last_tmdb_synced_at: "2026-03-31T00:00:00.000Z",
+      omdb_fetched_at: "2026-04-08T00:00:00.000Z",
+      imdb_id: "tt0123456",
+      episode_count: null,
+      season_number: null,
+      series_title: null,
+    },
+  ]);
+}
+
+function failSeasonLookup(seasonNumber: number) {
+  server.use(
+    http.get(`${SUPABASE_URL}/rest/v1/works`, ({ request }) => {
+      const url = new URL(request.url);
+      if (url.searchParams.get("season_number") === `eq.${seasonNumber}`) {
+        return HttpResponse.json({ message: "season fetch failed" }, { status: 500 });
+      }
+
+      return undefined;
+    }),
+  );
+}
+
 beforeEach(() => {
   tmdbMocks.fetchTmdbWorkDetails.mockReset();
   omdbMocks.fetchOmdbWorkDetails.mockReset();
@@ -571,40 +605,6 @@ describe("resolveSelectedSeasonWorkIds", () => {
     },
   ];
 
-  function setExistingSeriesWork() {
-    setMockWorks([
-      {
-        id: "series-work",
-        source_type: "tmdb",
-        work_type: "series",
-        tmdb_media_type: "tv",
-        tmdb_id: 100,
-        title: "テストシリーズ",
-        original_title: "Test Series",
-        search_text: "test series",
-        last_tmdb_synced_at: "2026-03-31T00:00:00.000Z",
-        omdb_fetched_at: "2026-04-08T00:00:00.000Z",
-        imdb_id: "tt0123456",
-        episode_count: null,
-        season_number: null,
-        series_title: null,
-      },
-    ]);
-  }
-
-  function failSeasonLookup(seasonNumber: number) {
-    server.use(
-      http.get(`${SUPABASE_URL}/rest/v1/works`, ({ request }) => {
-        const url = new URL(request.url);
-        if (url.searchParams.get("season_number") === `eq.${seasonNumber}`) {
-          return HttpResponse.json({ message: "season fetch failed" }, { status: 500 });
-        }
-
-        return undefined;
-      }),
-    );
-  }
-
   test("空入力時はエラーを返す", async () => {
     await expect(
       resolveSelectedSeasonWorkIds(seriesResult, "user-1", [], { seasonOptions }),
@@ -621,6 +621,35 @@ describe("resolveSelectedSeasonWorkIds", () => {
       error: "シーズン4の情報が見つかりません",
       workIds: [],
     });
+  });
+
+  test("シーズン1のみ選択時は series を保存して返す", async () => {
+    tmdbMocks.fetchTmdbWorkDetails.mockResolvedValueOnce(
+      createTmdbDetails({
+        tmdbId: seriesResult.tmdbId,
+        tmdbMediaType: "tv",
+        workType: "series",
+        title: seriesResult.title,
+        originalTitle: seriesResult.originalTitle,
+        runtimeMinutes: null,
+        typicalEpisodeRuntimeMinutes: 48,
+        seasonCount: 3,
+      }),
+    );
+
+    await expect(
+      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1], { seasonOptions }),
+    ).resolves.toMatchObject({
+      error: null,
+      workIds: [expect.any(String)],
+    });
+    expect(tmdbMocks.fetchTmdbWorkDetails).toHaveBeenCalledTimes(1);
+    expect(getMockWorks()).toContainEqual(
+      expect.objectContaining({
+        work_type: "series",
+        tmdb_id: seriesResult.tmdbId,
+      }),
+    );
   });
 
   test("複数シーズン追加時は親 series を一度だけ解決して workIds を順序どおり返す", async () => {

--- a/src/features/backlog/work-repository.test.ts
+++ b/src/features/backlog/work-repository.test.ts
@@ -561,6 +561,14 @@ describe("resolveSelectedSeasonWorkIds", () => {
       releaseDate: "2025-01-01",
       episodeCount: 8,
     },
+    {
+      seasonNumber: 3,
+      title: "テストシリーズ シーズン3",
+      overview: "season 3",
+      posterPath: "/season3.jpg",
+      releaseDate: "2026-01-01",
+      episodeCount: 10,
+    },
   ];
 
   test("空入力時はエラーを返す", async () => {
@@ -574,9 +582,9 @@ describe("resolveSelectedSeasonWorkIds", () => {
 
   test("シーズン情報組み立て失敗時はエラーを返す", async () => {
     await expect(
-      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [3], { seasonOptions }),
+      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [4], { seasonOptions }),
     ).resolves.toEqual({
-      error: "シーズン3の情報が見つかりません",
+      error: "シーズン4の情報が見つかりません",
       workIds: [],
     });
   });
@@ -676,6 +684,63 @@ describe("resolveSelectedSeasonWorkIds", () => {
       workIds: [],
     });
     expect(tmdbMocks.fetchTmdbWorkDetails).not.toHaveBeenCalled();
+  });
+
+  test("途中の保存に失敗したら後続シーズンの保存を発行しない", async () => {
+    setMockWorks([
+      {
+        id: "series-work",
+        source_type: "tmdb",
+        work_type: "series",
+        tmdb_media_type: "tv",
+        tmdb_id: 100,
+        title: "テストシリーズ",
+        original_title: "Test Series",
+        search_text: "test series",
+        last_tmdb_synced_at: "2026-03-31T00:00:00.000Z",
+        omdb_fetched_at: "2026-04-08T00:00:00.000Z",
+        imdb_id: "tt0123456",
+        episode_count: null,
+        season_number: null,
+        series_title: null,
+      },
+    ]);
+    server.use(
+      http.get(`${SUPABASE_URL}/rest/v1/works`, ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("season_number") === "eq.2") {
+          return HttpResponse.json({ message: "season fetch failed" }, { status: 500 });
+        }
+
+        return undefined;
+      }),
+    );
+    tmdbMocks.fetchTmdbWorkDetails.mockResolvedValue(
+      createTmdbDetails({
+        tmdbId: seriesResult.tmdbId,
+        tmdbMediaType: "tv",
+        workType: "season",
+        title: seasonOptions[1].title,
+        originalTitle: seriesResult.originalTitle,
+        overview: seasonOptions[1].overview,
+        posterPath: seasonOptions[1].posterPath,
+        releaseDate: seasonOptions[1].releaseDate,
+        runtimeMinutes: null,
+        typicalEpisodeRuntimeMinutes: 48,
+        episodeCount: seasonOptions[1].episodeCount,
+        seasonNumber: seasonOptions[1].seasonNumber,
+      }),
+    );
+
+    await expect(
+      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [2, 3], { seasonOptions }),
+    ).resolves.toEqual({
+      error: "season fetch failed",
+      workIds: [],
+    });
+
+    expect(tmdbMocks.fetchTmdbWorkDetails).not.toHaveBeenCalled();
+    expect(getMockWorks()).not.toContainEqual(expect.objectContaining({ season_number: 3 }));
   });
 });
 

--- a/src/features/backlog/work-repository.test.ts
+++ b/src/features/backlog/work-repository.test.ts
@@ -104,6 +104,36 @@ function failSeasonLookup(seasonNumber: number) {
   );
 }
 
+function createSeriesTmdbDetails(seriesResult: TmdbSearchResult, seasonCount: number) {
+  return createTmdbDetails({
+    tmdbId: seriesResult.tmdbId,
+    tmdbMediaType: "tv",
+    workType: "series",
+    title: seriesResult.title,
+    originalTitle: seriesResult.originalTitle,
+    runtimeMinutes: null,
+    typicalEpisodeRuntimeMinutes: 48,
+    seasonCount,
+  });
+}
+
+function createSeasonTmdbDetails(seriesResult: TmdbSearchResult, seasonOption: TmdbSeasonOption) {
+  return createTmdbDetails({
+    tmdbId: seriesResult.tmdbId,
+    tmdbMediaType: "tv",
+    workType: "season",
+    title: seasonOption.title,
+    originalTitle: seriesResult.originalTitle,
+    overview: seasonOption.overview,
+    posterPath: seasonOption.posterPath,
+    releaseDate: seasonOption.releaseDate,
+    runtimeMinutes: null,
+    typicalEpisodeRuntimeMinutes: 48,
+    episodeCount: seasonOption.episodeCount,
+    seasonNumber: seasonOption.seasonNumber,
+  });
+}
+
 beforeEach(() => {
   tmdbMocks.fetchTmdbWorkDetails.mockReset();
   omdbMocks.fetchOmdbWorkDetails.mockReset();
@@ -624,18 +654,7 @@ describe("resolveSelectedSeasonWorkIds", () => {
   });
 
   test("シーズン1のみ選択時は series を保存して返す", async () => {
-    tmdbMocks.fetchTmdbWorkDetails.mockResolvedValueOnce(
-      createTmdbDetails({
-        tmdbId: seriesResult.tmdbId,
-        tmdbMediaType: "tv",
-        workType: "series",
-        title: seriesResult.title,
-        originalTitle: seriesResult.originalTitle,
-        runtimeMinutes: null,
-        typicalEpisodeRuntimeMinutes: 48,
-        seasonCount: 3,
-      }),
-    );
+    tmdbMocks.fetchTmdbWorkDetails.mockResolvedValueOnce(createSeriesTmdbDetails(seriesResult, 3));
 
     await expect(
       resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1], { seasonOptions }),
@@ -654,34 +673,8 @@ describe("resolveSelectedSeasonWorkIds", () => {
 
   test("複数シーズン追加時は親 series を一度だけ解決して workIds を順序どおり返す", async () => {
     tmdbMocks.fetchTmdbWorkDetails
-      .mockResolvedValueOnce(
-        createTmdbDetails({
-          tmdbId: seriesResult.tmdbId,
-          tmdbMediaType: "tv",
-          workType: "series",
-          title: seriesResult.title,
-          originalTitle: seriesResult.originalTitle,
-          runtimeMinutes: null,
-          typicalEpisodeRuntimeMinutes: 48,
-          seasonCount: 2,
-        }),
-      )
-      .mockResolvedValueOnce(
-        createTmdbDetails({
-          tmdbId: seriesResult.tmdbId,
-          tmdbMediaType: "tv",
-          workType: "season",
-          title: seasonOptions[0].title,
-          originalTitle: seriesResult.originalTitle,
-          overview: seasonOptions[0].overview,
-          posterPath: seasonOptions[0].posterPath,
-          releaseDate: seasonOptions[0].releaseDate,
-          runtimeMinutes: null,
-          typicalEpisodeRuntimeMinutes: 48,
-          episodeCount: seasonOptions[0].episodeCount,
-          seasonNumber: seasonOptions[0].seasonNumber,
-        }),
-      );
+      .mockResolvedValueOnce(createSeriesTmdbDetails(seriesResult, 2))
+      .mockResolvedValueOnce(createSeasonTmdbDetails(seriesResult, seasonOptions[0]));
 
     const result = await resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1, 2], {
       seasonOptions,
@@ -727,20 +720,7 @@ describe("resolveSelectedSeasonWorkIds", () => {
     setExistingSeriesWork();
     failSeasonLookup(2);
     tmdbMocks.fetchTmdbWorkDetails.mockResolvedValue(
-      createTmdbDetails({
-        tmdbId: seriesResult.tmdbId,
-        tmdbMediaType: "tv",
-        workType: "season",
-        title: seasonOptions[1].title,
-        originalTitle: seriesResult.originalTitle,
-        overview: seasonOptions[1].overview,
-        posterPath: seasonOptions[1].posterPath,
-        releaseDate: seasonOptions[1].releaseDate,
-        runtimeMinutes: null,
-        typicalEpisodeRuntimeMinutes: 48,
-        episodeCount: seasonOptions[1].episodeCount,
-        seasonNumber: seasonOptions[1].seasonNumber,
-      }),
+      createSeasonTmdbDetails(seriesResult, seasonOptions[1]),
     );
 
     await expect(

--- a/src/features/backlog/work-repository.test.ts
+++ b/src/features/backlog/work-repository.test.ts
@@ -571,6 +571,40 @@ describe("resolveSelectedSeasonWorkIds", () => {
     },
   ];
 
+  function setExistingSeriesWork() {
+    setMockWorks([
+      {
+        id: "series-work",
+        source_type: "tmdb",
+        work_type: "series",
+        tmdb_media_type: "tv",
+        tmdb_id: 100,
+        title: "テストシリーズ",
+        original_title: "Test Series",
+        search_text: "test series",
+        last_tmdb_synced_at: "2026-03-31T00:00:00.000Z",
+        omdb_fetched_at: "2026-04-08T00:00:00.000Z",
+        imdb_id: "tt0123456",
+        episode_count: null,
+        season_number: null,
+        series_title: null,
+      },
+    ]);
+  }
+
+  function failSeasonLookup(seasonNumber: number) {
+    server.use(
+      http.get(`${SUPABASE_URL}/rest/v1/works`, ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("season_number") === `eq.${seasonNumber}`) {
+          return HttpResponse.json({ message: "season fetch failed" }, { status: 500 });
+        }
+
+        return undefined;
+      }),
+    );
+  }
+
   test("空入力時はエラーを返す", async () => {
     await expect(
       resolveSelectedSeasonWorkIds(seriesResult, "user-1", [], { seasonOptions }),
@@ -648,34 +682,8 @@ describe("resolveSelectedSeasonWorkIds", () => {
   });
 
   test("途中の保存に失敗したら workIds を返さず打ち切る", async () => {
-    setMockWorks([
-      {
-        id: "series-work",
-        source_type: "tmdb",
-        work_type: "series",
-        tmdb_media_type: "tv",
-        tmdb_id: 100,
-        title: "テストシリーズ",
-        original_title: "Test Series",
-        search_text: "test series",
-        last_tmdb_synced_at: "2026-03-31T00:00:00.000Z",
-        omdb_fetched_at: "2026-04-08T00:00:00.000Z",
-        imdb_id: "tt0123456",
-        episode_count: null,
-        season_number: null,
-        series_title: null,
-      },
-    ]);
-    server.use(
-      http.get(`${SUPABASE_URL}/rest/v1/works`, ({ request }) => {
-        const url = new URL(request.url);
-        if (url.searchParams.get("season_number") === "eq.2") {
-          return HttpResponse.json({ message: "season fetch failed" }, { status: 500 });
-        }
-
-        return undefined;
-      }),
-    );
+    setExistingSeriesWork();
+    failSeasonLookup(2);
 
     await expect(
       resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1, 2], { seasonOptions }),
@@ -687,34 +695,8 @@ describe("resolveSelectedSeasonWorkIds", () => {
   });
 
   test("途中の保存に失敗したら後続シーズンの保存を発行しない", async () => {
-    setMockWorks([
-      {
-        id: "series-work",
-        source_type: "tmdb",
-        work_type: "series",
-        tmdb_media_type: "tv",
-        tmdb_id: 100,
-        title: "テストシリーズ",
-        original_title: "Test Series",
-        search_text: "test series",
-        last_tmdb_synced_at: "2026-03-31T00:00:00.000Z",
-        omdb_fetched_at: "2026-04-08T00:00:00.000Z",
-        imdb_id: "tt0123456",
-        episode_count: null,
-        season_number: null,
-        series_title: null,
-      },
-    ]);
-    server.use(
-      http.get(`${SUPABASE_URL}/rest/v1/works`, ({ request }) => {
-        const url = new URL(request.url);
-        if (url.searchParams.get("season_number") === "eq.2") {
-          return HttpResponse.json({ message: "season fetch failed" }, { status: 500 });
-        }
-
-        return undefined;
-      }),
-    );
+    setExistingSeriesWork();
+    failSeasonLookup(2);
     tmdbMocks.fetchTmdbWorkDetails.mockResolvedValue(
       createTmdbDetails({
         tmdbId: seriesResult.tmdbId,

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -140,9 +140,9 @@ export async function resolveSelectedSeasonWorkIds(
   }
 
   const sharedSeriesWork = await resolveSharedSeriesWork(targets, userId);
-  if (sharedSeriesWork?.error || !sharedSeriesWork?.data) {
+  if (sharedSeriesWork && (sharedSeriesWork.error || !sharedSeriesWork.data)) {
     return {
-      error: sharedSeriesWork?.error?.message ?? "シーズンの親シリーズ保存に失敗しました",
+      error: sharedSeriesWork.error?.message ?? "シーズンの親シリーズ保存に失敗しました",
       workIds: [],
     };
   }

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -139,36 +139,21 @@ export async function resolveSelectedSeasonWorkIds(
     };
   }
 
-  const firstSeasonTarget = targets.find(
-    (target): target is TmdbSeasonSelectionTarget => target.workType === "season",
-  );
-
-  let sharedSeriesWork: TmdbWorkIdResponse | null = null;
-  if (firstSeasonTarget) {
-    sharedSeriesWork = await upsertTmdbWork(buildTmdbSeriesTarget(firstSeasonTarget), userId);
-    if (sharedSeriesWork.error || !sharedSeriesWork.data) {
-      return {
-        error: sharedSeriesWork.error?.message ?? "シーズンの親シリーズ保存に失敗しました",
-        workIds: [],
-      };
-    }
+  const sharedSeriesWork = await resolveSharedSeriesWork(targets, userId);
+  if (sharedSeriesWork?.error || !sharedSeriesWork?.data) {
+    return {
+      error: sharedSeriesWork?.error?.message ?? "シーズンの親シリーズ保存に失敗しました",
+      workIds: [],
+    };
   }
 
   const workIds: string[] = [];
   for (const [index, target] of targets.entries()) {
-    const seasonWork =
-      target.workType !== "season"
-        ? (sharedSeriesWork ?? (await upsertTmdbWork(target, userId)))
-        : sharedSeriesWork?.data
-          ? await upsertFetchedTmdbWork(target, userId, {
-              parentWorkId: sharedSeriesWork.data.id,
-            })
-          : await upsertTmdbWork(target, userId);
+    const seasonWork = await resolveTargetWork(target, userId, sharedSeriesWork);
 
     if (seasonWork.error || !seasonWork.data) {
-      const label = target.workType === "season" ? `シーズン${target.seasonNumber}` : "シーズン1";
       return {
-        error: seasonWork.error?.message ?? `${label}の保存に失敗しました`,
+        error: seasonWork.error?.message ?? buildSeasonSaveErrorMessage(target),
         workIds: [],
       };
     }
@@ -177,6 +162,46 @@ export async function resolveSelectedSeasonWorkIds(
   }
 
   return { error: null, workIds };
+}
+
+async function resolveSharedSeriesWork(
+  targets: TmdbSelectionTarget[],
+  userId: string,
+): Promise<TmdbWorkIdResponse | null> {
+  const firstSeasonTarget = targets.find(isSeasonTarget);
+  if (!firstSeasonTarget) {
+    return null;
+  }
+
+  return upsertTmdbWork(buildTmdbSeriesTarget(firstSeasonTarget), userId);
+}
+
+async function resolveTargetWork(
+  target: TmdbSelectionTarget,
+  userId: string,
+  sharedSeriesWork: TmdbWorkIdResponse | null,
+): Promise<TmdbWorkIdResponse> {
+  if (!isSeasonTarget(target)) {
+    return sharedSeriesWork ?? upsertTmdbWork(target, userId);
+  }
+
+  if (!sharedSeriesWork?.data) {
+    return upsertTmdbWork(target, userId);
+  }
+
+  return upsertFetchedTmdbWork(target, userId, {
+    parentWorkId: sharedSeriesWork.data.id,
+  });
+}
+
+function isSeasonTarget(target: TmdbSelectionTarget): target is TmdbSeasonSelectionTarget {
+  return target.workType === "season";
+}
+
+function buildSeasonSaveErrorMessage(target: TmdbSelectionTarget) {
+  return isSeasonTarget(target)
+    ? `シーズン${target.seasonNumber}の保存に失敗しました`
+    : "シーズン1の保存に失敗しました";
 }
 
 async function upsertTmdbSeasonWork(

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -154,34 +154,29 @@ export async function resolveSelectedSeasonWorkIds(
     }
   }
 
-  const seasonWorks = await Promise.all(
-    targets.map(async (target) => {
-      if (target.workType !== "season") {
-        return sharedSeriesWork ?? upsertTmdbWork(target, userId);
-      }
+  const workIds: string[] = [];
+  for (const [index, target] of targets.entries()) {
+    const seasonWork =
+      target.workType !== "season"
+        ? (sharedSeriesWork ?? (await upsertTmdbWork(target, userId)))
+        : sharedSeriesWork?.data
+          ? await upsertFetchedTmdbWork(target, userId, {
+              parentWorkId: sharedSeriesWork.data.id,
+            })
+          : await upsertTmdbWork(target, userId);
 
-      if (sharedSeriesWork?.data) {
-        return upsertFetchedTmdbWork(target, userId, {
-          parentWorkId: sharedSeriesWork.data.id,
-        });
-      }
-
-      return upsertTmdbWork(target, userId);
-    }),
-  );
-
-  for (const [index, seasonWork] of seasonWorks.entries()) {
     if (seasonWork.error || !seasonWork.data) {
-      const target = targets[index];
       const label = target.workType === "season" ? `シーズン${target.seasonNumber}` : "シーズン1";
       return {
         error: seasonWork.error?.message ?? `${label}の保存に失敗しました`,
         workIds: [],
       };
     }
+
+    workIds[index] = seasonWork.data.id;
   }
 
-  return { error: null, workIds: seasonWorks.map((seasonWork) => seasonWork.data!.id) };
+  return { error: null, workIds };
 }
 
 async function upsertTmdbSeasonWork(


### PR DESCRIPTION
## 関連 Issue

Refs #195
Refs #210

## 変更内容

- `resolveSelectedSeasonWorkIds` で共有 series の先行解決は維持しつつ、season 保存自体は逐次実行に戻して fail-fast を維持
- これにより先行 season の保存失敗時に、後続 season の保存が発行されないよう修正
- `[2,3]` のようなケースで後続 season が保存されないことを確認する回帰テストを追加
