### PR TITLE
fix: search-tmdb-works の verify_jwt を false に修正

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,7 +56,7 @@ subject = "みるカン - メールアドレス変更の確認"
 content_path = "./supabase/templates/email_change.html"
 
 [functions.search-tmdb-works]
-verify_jwt = true
+verify_jwt = false
 
 [functions.fetch-tmdb-trending]
 verify_jwt = false


### PR DESCRIPTION
## 関連 Issue

<!-- なし -->

## 変更内容

- `supabase/config.toml` の `[functions.search-tmdb-works]` で `verify_jwt = true` になっていたのを `false` に修正
- 他の TMDB 系 Edge Function（`fetch-tmdb-trending` 等）はすべて `verify_jwt = false` であり、`search-tmdb-works` だけ誤って `true` が設定されていた
- 本番で検索実行時に `Invalid JWT` エラーが発生していた原因