### PR TITLE
feat: TanStack Router の導入（pathname 分岐を置き換え）

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@heroicons/react": "^2.2.0",
     "@supabase/supabase-js": "^2.100.1",
     "@tanstack/react-query": "^5.97.0",
+    "@tanstack/react-router": "^1.168.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "nuqs": "^2.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.97.0
         version: 5.99.0(react@19.2.5)
+      '@tanstack/react-router':
+        specifier: ^1.168.19
+        version: 1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -43,7 +46,7 @@ importers:
         version: 2.1.1
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(react@19.2.5)
+        version: 2.8.9(@tanstack/react-router@1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.4
         version: 19.2.5
@@ -1189,6 +1192,10 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/query-core@5.99.0':
     resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
 
@@ -1196,6 +1203,27 @@ packages:
     resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-router@1.168.19':
+    resolution: {integrity: sha512-0NCuwMPRlEpffDIF7OTSe3g4d8U93WsHxMi15YLJxjmNbng2of50wx+8UnT8IxKLbSdpFHSEDNTi4qnNyWn/Kw==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.168.14':
+    resolution: {integrity: sha512-UhCJtjNrd5wcTmhgB2HyUP0+Rj1M7BD4dS11YsF9x6VC2KH/eqxzs/vK+nN5f+cOhPOLZdmLkWMW+WGmacZ8HA==}
+    engines: {node: '>=20.19'}
+    hasBin: true
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1634,6 +1662,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -2139,6 +2170,10 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isbot@5.1.38:
+    resolution: {integrity: sha512-Cus2702JamTNMEY4zTP+TShgq/3qzjvGcBC4XMOV45BLaxD4iUFENkqu7ZhFeSzwNsCSZLjnGlihDQznnpnEEA==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2730,6 +2765,16 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+    engines: {node: '>=10'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -4041,12 +4086,39 @@ snapshots:
       postcss: 8.5.9
       tailwindcss: 4.2.2
 
+  '@tanstack/history@1.161.6': {}
+
   '@tanstack/query-core@5.99.0': {}
 
   '@tanstack/react-query@5.99.0(react@19.2.5)':
     dependencies:
       '@tanstack/query-core': 5.99.0
       react: 19.2.5
+
+  '@tanstack/react-router@1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.168.14
+      isbot: 5.1.38
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
+  '@tanstack/router-core@1.168.14':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 3.1.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  '@tanstack/store@0.9.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4426,6 +4498,8 @@ snapshots:
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie-signature@1.2.2: {}
 
@@ -4872,6 +4946,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isbot@5.1.38: {}
+
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
@@ -5135,10 +5211,12 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nuqs@2.8.9(react@19.2.5):
+  nuqs@2.8.9(@tanstack/react-router@1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.5
+    optionalDependencies:
+      '@tanstack/react-router': 1.168.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   object-assign@4.1.1: {}
 
@@ -5493,6 +5571,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
+  seroval@1.5.2: {}
 
   serve-static@2.2.1:
     dependencies:

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
+import { RouterProvider, createMemoryHistory, createRouter } from "@tanstack/react-router";
 import { setupTestLifecycle } from "./test/test-lifecycle.ts";
-import { App } from "./App.tsx";
+import { routeTree } from "./App.tsx";
 
 const authState = vi.hoisted(() => ({
   callback: null as ((event: string, session: unknown) => void) | null,
@@ -37,6 +38,14 @@ vi.mock("./features/backlog/components/TermsOfServicePage.tsx", () => ({
 
 setupTestLifecycle();
 
+function renderApp(path = "/") {
+  const testRouter = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  return render(<RouterProvider router={testRouter} />);
+}
+
 describe("App", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,7 +74,7 @@ describe("App", () => {
     });
     globalThis.history.replaceState({}, "", "/#type=recovery&access_token=token");
 
-    render(<App />);
+    renderApp("/");
 
     expect(await screen.findByText("RESET_PASSWORD_PAGE")).toBeInTheDocument();
     expect(screen.queryByText("BOARD_PAGE")).not.toBeInTheDocument();
@@ -74,7 +83,7 @@ describe("App", () => {
   test("recovery パラメータが残っていてもセッションがなければログイン画面を表示する", async () => {
     globalThis.history.replaceState({}, "", "/#type=recovery");
 
-    render(<App />);
+    renderApp("/");
 
     expect(await screen.findByText("LOGIN_PAGE")).toBeInTheDocument();
     expect(screen.queryByText("RESET_PASSWORD_PAGE")).not.toBeInTheDocument();
@@ -83,7 +92,7 @@ describe("App", () => {
   test("SIGNED_IN が先に来る recovery フローでも再設定画面を維持する", async () => {
     globalThis.history.replaceState({}, "", "/?type=recovery");
 
-    render(<App />);
+    renderApp("/");
     expect(await screen.findByText("LOGIN_PAGE")).toBeInTheDocument();
 
     act(() => {
@@ -99,7 +108,7 @@ describe("App", () => {
     });
     globalThis.history.replaceState({}, "", "/?type=recovery");
 
-    render(<App />);
+    renderApp("/");
     expect(await screen.findByText("RESET_PASSWORD_PAGE")).toBeInTheDocument();
 
     act(() => {
@@ -114,7 +123,7 @@ describe("App", () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     authRepositoryMock.getSession.mockRejectedValueOnce(new Error("network error"));
 
-    render(<App />);
+    renderApp("/");
 
     expect(await screen.findByText("LOGIN_PAGE")).toBeInTheDocument();
     expect(screen.queryByText("LOGIN_LOADING")).not.toBeInTheDocument();
@@ -123,21 +132,17 @@ describe("App", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  test("/privacy では認証処理を通さずプライバシーポリシーを表示する", () => {
-    globalThis.history.replaceState({}, "", "/privacy");
+  test("/privacy では認証処理を通さずプライバシーポリシーを表示する", async () => {
+    renderApp("/privacy");
 
-    render(<App />);
-
-    expect(screen.getByText("PRIVACY_POLICY_PAGE")).toBeInTheDocument();
+    expect(await screen.findByText("PRIVACY_POLICY_PAGE")).toBeInTheDocument();
     expect(authRepositoryMock.getSession).not.toHaveBeenCalled();
   });
 
-  test("/terms では認証処理を通さず利用規約を表示する", () => {
-    globalThis.history.replaceState({}, "", "/terms");
+  test("/terms では認証処理を通さず利用規約を表示する", async () => {
+    renderApp("/terms");
 
-    render(<App />);
-
-    expect(screen.getByText("TERMS_OF_SERVICE_PAGE")).toBeInTheDocument();
+    expect(await screen.findByText("TERMS_OF_SERVICE_PAGE")).toBeInTheDocument();
     expect(authRepositoryMock.getSession).not.toHaveBeenCalled();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,7 +166,7 @@ function AuthenticatedApp() {
   );
 }
 
-const rootRoute = createRootRoute({ component: Outlet });
+const rootRoute = createRootRoute({ component: Outlet, notFoundComponent: AuthenticatedApp });
 
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -188,7 +188,7 @@ const termsRoute = createRoute({
 
 export const routeTree = rootRoute.addChildren([indexRoute, privacyRoute, termsRoute]);
 
-export const router = createRouter({ routeTree });
+const router = createRouter({ routeTree });
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
+import {
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+} from "@tanstack/react-router";
 import { Button } from "@/components/ui/button.tsx";
 import { LazyViewBoundary } from "./components/LazyViewBoundary.tsx";
 import { getSession, onAuthStateChange } from "./lib/auth-repository.ts";
@@ -159,9 +166,36 @@ function AuthenticatedApp() {
   );
 }
 
+const rootRoute = createRootRoute({ component: Outlet });
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: AuthenticatedApp,
+});
+
+const privacyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/privacy",
+  component: PrivacyPolicyPage,
+});
+
+const termsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/terms",
+  component: TermsOfServicePage,
+});
+
+export const routeTree = rootRoute.addChildren([indexRoute, privacyRoute, termsRoute]);
+
+export const router = createRouter({ routeTree });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
 export function App() {
-  const pathname = globalThis.location.pathname;
-  if (pathname === "/privacy") return <PrivacyPolicyPage />;
-  if (pathname === "/terms") return <TermsOfServicePage />;
-  return <AuthenticatedApp />;
+  return <RouterProvider router={router} />;
 }


### PR DESCRIPTION
## 関連 Issue

Closes #220

## 変更内容

- `@tanstack/react-router` を導入し、`App.tsx` の `window.location.pathname` 手書き分岐をルーター定義に置き換え
- `/`・`/privacy`・`/terms` の宣言型ルート定義を追加（ファイルベースルーティングは不使用）
- 未マッチパスは `notFoundComponent: AuthenticatedApp` でフォールスルーし、旧実装の動作を維持
- 認証ガードは `AuthenticatedApp` 内の既存ロジックをそのまま流用（パスワードリセットフロー含む）
- テストを `createMemoryHistory` ベースの `renderApp()` ヘルパーに切り替え、各テストで独立したルーターインスタンスを生成