### PR TITLE
feat: NuqsAdapter を RouterProvider 内の rootRoute component へ移動

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   createRouter,
   Outlet,
 } from "@tanstack/react-router";
+import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import { Button } from "@/components/ui/button.tsx";
 import { LazyViewBoundary } from "./components/LazyViewBoundary.tsx";
 import { getSession, onAuthStateChange } from "./lib/auth-repository.ts";
@@ -166,7 +167,14 @@ function AuthenticatedApp() {
   );
 }
 
-const rootRoute = createRootRoute({ component: Outlet, notFoundComponent: AuthenticatedApp });
+const rootRoute = createRootRoute({
+  component: () => (
+    <NuqsAdapter>
+      <Outlet />
+    </NuqsAdapter>
+  ),
+  notFoundComponent: AuthenticatedApp,
+});
 
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { NuqsAdapter } from "nuqs/adapters/react";
 import "@fontsource-variable/geist";
 import "./style.css";
 import { App } from "./App.tsx";
@@ -11,10 +10,8 @@ const queryClient = new QueryClient();
 
 createRoot(getAppRootElement()).render(
   <StrictMode>
-    <NuqsAdapter>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </NuqsAdapter>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## 関連 Issue

Closes #223

## 変更内容

- `main.tsx` から `nuqs/adapters/react` の `NuqsAdapter` を削除
- `App.tsx` の `rootRoute` component で `nuqs/adapters/tanstack-router` の `NuqsAdapter` を使って `<Outlet />` をラップ
- nuqs の URL 更新が TanStack Router のヒストリーを経由するようになる