### PR TITLE
feat: ContactDialog 作成と UserMenu へのお問い合わせ統合

### DIFF
--- a/src/features/backlog/components/AboutDialog.tsx
+++ b/src/features/backlog/components/AboutDialog.tsx
@@ -1,110 +1,74 @@
-import { ArrowTopRightOnSquareIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { useEffect } from "react";
-import { createPortal } from "react-dom";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import tmdbLogoUrl from "../../../assets/logos/tmdb.svg";
+import { DialogShell } from "./DialogShell.tsx";
 
 type Props = {
   onClose: () => void;
 };
 
 export function AboutDialog({ onClose }: Props) {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 grid place-items-center bg-[rgba(51,34,23,0.45)] p-5 backdrop-blur-[10px]"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
+  return (
+    <DialogShell
+      titleId="about-dialog-title"
+      badge="About"
+      title="みるカンについて"
+      closeLabel="About を閉じる"
+      onClose={onClose}
     >
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="about-dialog-title"
-        className="w-[min(calc(100%-32px),640px)] rounded-[28px] border border-border bg-[#2a2a2a] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.5)] max-[720px]:rounded-[22px] max-[720px]:p-5"
-      >
-        <div className="mb-5 flex items-start justify-between gap-4">
-          <div className="grid gap-1">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">About</p>
-            <h2 id="about-dialog-title" className="text-xl font-semibold text-foreground">
-              みるカンについて
-            </h2>
+      <div className="grid gap-5 text-sm leading-7 text-muted-foreground">
+        <section className="grid gap-2">
+          <p className="text-base leading-7 text-foreground">
+            みるカンは、積んだ映画やシリーズから次に見る一本を決めるための映像作品バックログです。
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+                Stack
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">候補を積む</p>
+            </div>
+            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+                Sort
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">状態で並べる</p>
+            </div>
+            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+                Decide
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">次の一本を決める</p>
+            </div>
           </div>
-          <button
-            type="button"
-            aria-label="About を閉じる"
-            className="rounded-full border border-border bg-background/40 p-2 text-muted-foreground transition-colors hover:text-foreground"
-            onClick={onClose}
+          <p className="text-sm leading-6">
+            「積んではいるけど、何を見るか決まらない」を減らすために、視聴状態の整理と次の候補選びに絞っています。
+          </p>
+        </section>
+
+        <section className="grid gap-2 rounded-[20px] border border-[rgba(191,90,54,0.2)] bg-[rgba(191,90,54,0.07)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+            Data Source
+          </p>
+          <div className="inline-flex w-fit items-center rounded-2xl bg-white px-4 py-3 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.06)]">
+            <img src={tmdbLogoUrl} alt="TMDB" className="h-5 w-auto sm:h-6" />
+          </div>
+          <p className="text-sm leading-6 text-foreground">
+            TMDB のデータおよび画像を利用しています。作品情報の参照元は TMDB です。
+          </p>
+          <p className="text-sm leading-6">
+            This product uses the TMDB API but is not endorsed or certified by TMDB.
+          </p>
+          <a
+            href="https://www.themoviedb.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
           >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
-        </div>
-
-        <div className="grid gap-5 text-sm leading-7 text-muted-foreground">
-          <section className="grid gap-2">
-            <p className="text-base leading-7 text-foreground">
-              みるカンは、積んだ映画やシリーズから次に見る一本を決めるための映像作品バックログです。
-            </p>
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-                <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-                  Stack
-                </p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">候補を積む</p>
-              </div>
-              <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-                <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-                  Sort
-                </p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">状態で並べる</p>
-              </div>
-              <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-                <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-                  Decide
-                </p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">次の一本を決める</p>
-              </div>
-            </div>
-            <p className="text-sm leading-6">
-              「積んではいるけど、何を見るか決まらない」を減らすために、視聴状態の整理と次の候補選びに絞っています。
-            </p>
-          </section>
-
-          <section className="grid gap-2 rounded-[20px] border border-[rgba(191,90,54,0.2)] bg-[rgba(191,90,54,0.07)] p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-              Data Source
-            </p>
-            <div className="inline-flex w-fit items-center rounded-2xl bg-white px-4 py-3 shadow-[inset_0_0_0_1px_rgba(15,23,42,0.06)]">
-              <img src={tmdbLogoUrl} alt="TMDB" className="h-5 w-auto sm:h-6" />
-            </div>
-            <p className="text-sm leading-6 text-foreground">
-              TMDB のデータおよび画像を利用しています。作品情報の参照元は TMDB です。
-            </p>
-            <p className="text-sm leading-6">
-              This product uses the TMDB API but is not endorsed or certified by TMDB.
-            </p>
-            <a
-              href="https://www.themoviedb.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
-            >
-              <span>https://www.themoviedb.org/</span>
-              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            </a>
-          </section>
-        </div>
-      </section>
-    </div>,
-    document.body,
+            <span>https://www.themoviedb.org/</span>
+            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          </a>
+        </section>
+      </div>
+    </DialogShell>
   );
 }

--- a/src/features/backlog/components/ContactDialog.tsx
+++ b/src/features/backlog/components/ContactDialog.tsx
@@ -14,10 +14,16 @@ function CopyEmailButton() {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    void navigator.clipboard.writeText(SUPPORT_EMAIL).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    if (!navigator.clipboard?.writeText) return;
+    void navigator.clipboard.writeText(SUPPORT_EMAIL).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      },
+      () => {
+        // Clipboard permission denied or API unavailable — silently ignore
+      },
+    );
   };
 
   return (

--- a/src/features/backlog/components/ContactDialog.tsx
+++ b/src/features/backlog/components/ContactDialog.tsx
@@ -1,4 +1,6 @@
-import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { ArrowTopRightOnSquareIcon, ClipboardIcon } from "@heroicons/react/24/outline";
+import { CheckIcon } from "@heroicons/react/24/solid";
+import { useState } from "react";
 import { DialogShell } from "./DialogShell.tsx";
 
 type Props = {
@@ -7,6 +9,32 @@ type Props = {
 
 const GITHUB_ISSUES_URL = "https://github.com/isshi-hasegawa/mirukan/issues/new/choose";
 const SUPPORT_EMAIL = "support@mirukan.app";
+
+function CopyEmailButton() {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(SUPPORT_EMAIL).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={copied ? "コピーしました" : "メールアドレスをコピー"}
+      className="rounded-lg border border-border/70 bg-background/35 px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <CheckIcon className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+      ) : (
+        <ClipboardIcon className="h-3.5 w-3.5" aria-hidden="true" />
+      )}
+    </button>
+  );
+}
 
 export function ContactDialog({ onClose }: Props) {
   return (
@@ -17,39 +45,30 @@ export function ContactDialog({ onClose }: Props) {
       closeLabel="お問い合わせを閉じる"
       onClose={onClose}
     >
-      <div className="grid gap-4 text-sm leading-7 text-muted-foreground">
-        <p className="text-base leading-7 text-foreground">
-          ご意見・ご要望・不具合のご報告など、お気軽にご連絡ください。
-        </p>
-
-        <div className="grid gap-3">
-          <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-            <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-              Email
-            </p>
-            <a
-              href={`mailto:${SUPPORT_EMAIL}`}
-              className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
-            >
-              <span>{SUPPORT_EMAIL}</span>
-              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            </a>
+      <div className="grid gap-3">
+        <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+          <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+            ご意見・ご要望
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">{SUPPORT_EMAIL}</span>
+            <CopyEmailButton />
           </div>
+        </div>
 
-          <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-            <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-              GitHub Issues
-            </p>
-            <a
-              href={GITHUB_ISSUES_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
-            >
-              <span>github.com/isshi-hasegawa/mirukan/issues</span>
-              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            </a>
-          </div>
+        <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+          <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+            不具合のご報告
+          </p>
+          <a
+            href={GITHUB_ISSUES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+          >
+            <span>github.com/isshi-hasegawa/mirukan/issues</span>
+            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          </a>
         </div>
       </div>
     </DialogShell>

--- a/src/features/backlog/components/ContactDialog.tsx
+++ b/src/features/backlog/components/ContactDialog.tsx
@@ -1,0 +1,93 @@
+import { ArrowTopRightOnSquareIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+type Props = {
+  onClose: () => void;
+};
+
+const GITHUB_ISSUES_URL = "https://github.com/isshi-hasegawa/mirukan/issues/new/choose";
+const SUPPORT_EMAIL = "support@mirukan.app";
+
+export function ContactDialog({ onClose }: Props) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-[rgba(51,34,23,0.45)] p-5 backdrop-blur-[10px]"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="contact-dialog-title"
+        className="w-[min(calc(100%-32px),640px)] rounded-[28px] border border-border bg-[#2a2a2a] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.5)] max-[720px]:rounded-[22px] max-[720px]:p-5"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div className="grid gap-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">Contact</p>
+            <h2 id="contact-dialog-title" className="text-xl font-semibold text-foreground">
+              お問い合わせ
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="お問い合わせを閉じる"
+            className="rounded-full border border-border bg-background/40 p-2 text-muted-foreground transition-colors hover:text-foreground"
+            onClick={onClose}
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="grid gap-4 text-sm leading-7 text-muted-foreground">
+          <p className="text-base leading-7 text-foreground">
+            ご意見・ご要望・不具合のご報告など、お気軽にご連絡ください。
+          </p>
+
+          <div className="grid gap-3">
+            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+                Email
+              </p>
+              <a
+                href={`mailto:${SUPPORT_EMAIL}`}
+                className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+              >
+                <span>{SUPPORT_EMAIL}</span>
+                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              </a>
+            </div>
+
+            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+                GitHub Issues
+              </p>
+              <a
+                href={GITHUB_ISSUES_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+              >
+                <span>github.com/isshi-hasegawa/mirukan/issues</span>
+                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/backlog/components/ContactDialog.tsx
+++ b/src/features/backlog/components/ContactDialog.tsx
@@ -1,6 +1,5 @@
-import { ArrowTopRightOnSquareIcon, XMarkIcon } from "@heroicons/react/24/outline";
-import { useEffect } from "react";
-import { createPortal } from "react-dom";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import { DialogShell } from "./DialogShell.tsx";
 
 type Props = {
   onClose: () => void;
@@ -10,84 +9,49 @@ const GITHUB_ISSUES_URL = "https://github.com/isshi-hasegawa/mirukan/issues/new/
 const SUPPORT_EMAIL = "support@mirukan.app";
 
 export function ContactDialog({ onClose }: Props) {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 grid place-items-center bg-[rgba(51,34,23,0.45)] p-5 backdrop-blur-[10px]"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
+  return (
+    <DialogShell
+      titleId="contact-dialog-title"
+      badge="Contact"
+      title="お問い合わせ"
+      closeLabel="お問い合わせを閉じる"
+      onClose={onClose}
     >
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="contact-dialog-title"
-        className="w-[min(calc(100%-32px),640px)] rounded-[28px] border border-border bg-[#2a2a2a] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.5)] max-[720px]:rounded-[22px] max-[720px]:p-5"
-      >
-        <div className="mb-5 flex items-start justify-between gap-4">
-          <div className="grid gap-1">
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">Contact</p>
-            <h2 id="contact-dialog-title" className="text-xl font-semibold text-foreground">
-              お問い合わせ
-            </h2>
+      <div className="grid gap-4 text-sm leading-7 text-muted-foreground">
+        <p className="text-base leading-7 text-foreground">
+          ご意見・ご要望・不具合のご報告など、お気軽にご連絡ください。
+        </p>
+
+        <div className="grid gap-3">
+          <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+            <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+              Email
+            </p>
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+            >
+              <span>{SUPPORT_EMAIL}</span>
+              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            </a>
           </div>
-          <button
-            type="button"
-            aria-label="お問い合わせを閉じる"
-            className="rounded-full border border-border bg-background/40 p-2 text-muted-foreground transition-colors hover:text-foreground"
-            onClick={onClose}
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
-        </div>
 
-        <div className="grid gap-4 text-sm leading-7 text-muted-foreground">
-          <p className="text-base leading-7 text-foreground">
-            ご意見・ご要望・不具合のご報告など、お気軽にご連絡ください。
-          </p>
-
-          <div className="grid gap-3">
-            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-                Email
-              </p>
-              <a
-                href={`mailto:${SUPPORT_EMAIL}`}
-                className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
-              >
-                <span>{SUPPORT_EMAIL}</span>
-                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              </a>
-            </div>
-
-            <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
-              <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
-                GitHub Issues
-              </p>
-              <a
-                href={GITHUB_ISSUES_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
-              >
-                <span>github.com/isshi-hasegawa/mirukan/issues</span>
-                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              </a>
-            </div>
+          <div className="rounded-2xl border border-border/70 bg-background/35 px-4 py-3">
+            <p className="text-[0.68rem] font-semibold tracking-[0.16em] text-primary uppercase">
+              GitHub Issues
+            </p>
+            <a
+              href={GITHUB_ISSUES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-flex items-center gap-1.5 text-sm text-muted-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60 focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+            >
+              <span>github.com/isshi-hasegawa/mirukan/issues</span>
+              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            </a>
           </div>
         </div>
-      </section>
-    </div>,
-    document.body,
+      </div>
+    </DialogShell>
   );
 }

--- a/src/features/backlog/components/DialogShell.tsx
+++ b/src/features/backlog/components/DialogShell.tsx
@@ -1,0 +1,63 @@
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+type Props = {
+  titleId: string;
+  badge: string;
+  title: string;
+  closeLabel: string;
+  onClose: () => void;
+  children: ReactNode;
+};
+
+export function DialogShell({ titleId, badge, title, closeLabel, onClose, children }: Props) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 grid place-items-center bg-[rgba(51,34,23,0.45)] p-5 backdrop-blur-[10px]">
+      {/* Backdrop: native button for click-outside-to-close (keyboard users use Escape) */}
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="fixed inset-0 cursor-default"
+        onClick={onClose}
+      />
+      <dialog
+        open
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 w-[min(calc(100%-32px),640px)] rounded-[28px] border border-border bg-[#2a2a2a] p-6 shadow-[0_24px_60px_rgba(0,0,0,0.5)] max-[720px]:rounded-[22px] max-[720px]:p-5"
+      >
+        <div className="mb-5 flex items-start justify-between gap-4">
+          <div className="grid gap-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primary">{badge}</p>
+            <h2 id={titleId} className="text-xl font-semibold text-foreground">
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label={closeLabel}
+            className="rounded-full border border-border bg-background/40 p-2 text-muted-foreground transition-colors hover:text-foreground"
+            onClick={onClose}
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+        {children}
+      </dialog>
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -88,6 +88,13 @@ describe("LoginPage", () => {
     }
   });
 
+  test("ログイン画面にお問い合わせリンクが表示される", () => {
+    render(<LoginPage />);
+
+    const link = screen.getByRole("link", { name: "お問い合わせ" });
+    expect(link).toHaveAttribute("href", "mailto:support@mirukan.app");
+  });
+
   test("送信中は入力と送信を無効化し、完了後に再入力できる", async () => {
     const user = userEvent.setup();
     let resolveSignIn: ((value: { error: null }) => void) | undefined;

--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -88,11 +88,14 @@ describe("LoginPage", () => {
     }
   });
 
-  test("ログイン画面にお問い合わせリンクが表示される", () => {
+  test("ログイン画面のお問い合わせからモーダルを開ける", async () => {
+    const user = userEvent.setup();
+
     render(<LoginPage />);
 
-    const link = screen.getByRole("link", { name: "お問い合わせ" });
-    expect(link).toHaveAttribute("href", "mailto:support@mirukan.app");
+    await user.click(screen.getByRole("button", { name: "お問い合わせ" }));
+
+    expect(await screen.findByRole("dialog", { name: "お問い合わせ" })).toBeInTheDocument();
   });
 
   test("送信中は入力と送信を無効化し、完了後に再入力できる", async () => {

--- a/src/features/backlog/components/LoginPageAuthForm.tsx
+++ b/src/features/backlog/components/LoginPageAuthForm.tsx
@@ -1,7 +1,11 @@
+import { Suspense, useState } from "react";
 import { Button } from "@/components/ui/button.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
+import { lazyNamed } from "../../../lib/lazy-component.ts";
 import { useLoginPageAuth } from "../hooks/useLoginPageAuth.ts";
+
+const ContactDialog = lazyNamed(() => import("./ContactDialog.tsx"), "ContactDialog");
 
 type LoginPageAuthModel = ReturnType<typeof useLoginPageAuth>;
 
@@ -39,7 +43,7 @@ function GoogleIcon() {
   );
 }
 
-function TermsAndPrivacyLinks() {
+function TermsAndPrivacyLinks({ onOpenContact }: { onOpenContact: () => void }) {
   return (
     <div className="flex justify-center">
       <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
@@ -59,12 +63,13 @@ function TermsAndPrivacyLinks() {
         >
           プライバシーポリシー
         </a>
-        <a
-          href="mailto:support@mirukan.app"
+        <button
+          type="button"
           className="underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60"
+          onClick={onOpenContact}
         >
           お問い合わせ
-        </a>
+        </button>
       </div>
     </div>
   );
@@ -127,7 +132,7 @@ function ModeSwitcher({ auth }: Props) {
   );
 }
 
-function LoginFormContent({ auth }: Props) {
+function LoginFormContent({ auth, onOpenContact }: Props & { onOpenContact: () => void }) {
   return (
     <>
       <div className="grid gap-2">
@@ -201,12 +206,12 @@ function LoginFormContent({ auth }: Props) {
         disabled={auth.isSubmitting}
         onClick={() => void auth.handleGoogleLogin()}
       />
-      <TermsAndPrivacyLinks />
+      <TermsAndPrivacyLinks onOpenContact={onOpenContact} />
     </>
   );
 }
 
-function SignUpFormContent({ auth }: Props) {
+function SignUpFormContent({ auth, onOpenContact }: Props & { onOpenContact: () => void }) {
   return (
     <>
       {auth.hasSentConfirmationEmail ? (
@@ -310,7 +315,7 @@ function SignUpFormContent({ auth }: Props) {
             disabled={auth.isSubmitting}
             onClick={() => void auth.handleGoogleLogin()}
           />
-          <TermsAndPrivacyLinks />
+          <TermsAndPrivacyLinks onOpenContact={onOpenContact} />
         </>
       )}
     </>
@@ -368,32 +373,41 @@ function ForgotPasswordFormContent({ auth }: Props) {
 }
 
 export function LoginPageAuthForm({ auth }: Props) {
+  const [isContactOpen, setIsContactOpen] = useState(false);
+
   return (
-    <form
-      className="grid gap-4.5"
-      onSubmit={(e) => {
-        e.preventDefault();
-        void auth.handleSubmit();
-      }}
-    >
-      <ModeSwitcher auth={auth} />
-      <div className="grid min-h-[29rem] content-center gap-4.5">
-        {auth.isForgotPasswordMode ? (
-          <ForgotPasswordFormContent auth={auth} />
-        ) : auth.isSignUpMode ? (
-          <SignUpFormContent auth={auth} />
-        ) : (
-          <LoginFormContent auth={auth} />
-        )}
-      </div>
-      {auth.errorMessage ? (
-        <p
-          className="rounded-[20px] border border-destructive/40 bg-destructive/10 px-4 py-3 text-[0.94rem] text-foreground"
-          aria-live="polite"
-        >
-          {auth.errorMessage}
-        </p>
+    <>
+      <form
+        className="grid gap-4.5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void auth.handleSubmit();
+        }}
+      >
+        <ModeSwitcher auth={auth} />
+        <div className="grid min-h-[29rem] content-center gap-4.5">
+          {auth.isForgotPasswordMode ? (
+            <ForgotPasswordFormContent auth={auth} />
+          ) : auth.isSignUpMode ? (
+            <SignUpFormContent auth={auth} onOpenContact={() => setIsContactOpen(true)} />
+          ) : (
+            <LoginFormContent auth={auth} onOpenContact={() => setIsContactOpen(true)} />
+          )}
+        </div>
+        {auth.errorMessage ? (
+          <p
+            className="rounded-[20px] border border-destructive/40 bg-destructive/10 px-4 py-3 text-[0.94rem] text-foreground"
+            aria-live="polite"
+          >
+            {auth.errorMessage}
+          </p>
+        ) : null}
+      </form>
+      {isContactOpen ? (
+        <Suspense fallback={null}>
+          <ContactDialog onClose={() => setIsContactOpen(false)} />
+        </Suspense>
       ) : null}
-    </form>
+    </>
   );
 }

--- a/src/features/backlog/components/LoginPageAuthForm.tsx
+++ b/src/features/backlog/components/LoginPageAuthForm.tsx
@@ -59,6 +59,12 @@ function TermsAndPrivacyLinks() {
         >
           プライバシーポリシー
         </a>
+        <a
+          href="mailto:support@mirukan.app"
+          className="underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/60"
+        >
+          お問い合わせ
+        </a>
       </div>
     </div>
   );

--- a/src/features/backlog/components/UserMenu.test.tsx
+++ b/src/features/backlog/components/UserMenu.test.tsx
@@ -78,7 +78,7 @@ describe("UserMenu", () => {
     );
   });
 
-  test("メニューから GitHub Issues の不具合報告導線を開ける", async () => {
+  test("お問い合わせからメールと GitHub Issues の導線を確認できる", async () => {
     const user = userEvent.setup();
 
     render(<UserMenu email="user@example.com" />);
@@ -86,14 +86,15 @@ describe("UserMenu", () => {
     const trigger = screen.getByRole("button", { name: /user@example.com/i });
     trigger.focus();
     await user.keyboard("{Enter}");
-    await user.click(await screen.findByRole("menuitem", { name: "不具合を報告" }));
+    await user.click(await screen.findByRole("menuitem", { name: "お問い合わせ" }));
 
-    await waitFor(() =>
-      expect(openMock).toHaveBeenCalledWith(
-        "https://github.com/isshi-hasegawa/mirukan/issues/new/choose",
-        "_blank",
-        "noopener,noreferrer",
-      ),
+    expect(await screen.findByRole("dialog", { name: "お問い合わせ" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /support@mirukan\.app/ })).toHaveAttribute(
+      "href",
+      "mailto:support@mirukan.app",
     );
+    expect(
+      screen.getByRole("link", { name: /github\.com\/isshi-hasegawa\/mirukan\/issues/ }),
+    ).toHaveAttribute("href", "https://github.com/isshi-hasegawa/mirukan/issues/new/choose");
   });
 });

--- a/src/features/backlog/components/UserMenu.test.tsx
+++ b/src/features/backlog/components/UserMenu.test.tsx
@@ -89,10 +89,8 @@ describe("UserMenu", () => {
     await user.click(await screen.findByRole("menuitem", { name: "お問い合わせ" }));
 
     expect(await screen.findByRole("dialog", { name: "お問い合わせ" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /support@mirukan\.app/ })).toHaveAttribute(
-      "href",
-      "mailto:support@mirukan.app",
-    );
+    expect(screen.getByText("support@mirukan.app")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "メールアドレスをコピー" })).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /github\.com\/isshi-hasegawa\/mirukan\/issues/ }),
     ).toHaveAttribute("href", "https://github.com/isshi-hasegawa/mirukan/issues/new/choose");

--- a/src/features/backlog/components/UserMenu.tsx
+++ b/src/features/backlog/components/UserMenu.tsx
@@ -10,15 +10,15 @@ import {
 } from "@/components/ui/dropdown-menu.tsx";
 
 const AboutDialog = lazyNamed(() => import("./AboutDialog.tsx"), "AboutDialog");
+const ContactDialog = lazyNamed(() => import("./ContactDialog.tsx"), "ContactDialog");
 
 type Props = {
   email: string | null | undefined;
 };
 
-const BUG_REPORT_URL = "https://github.com/isshi-hasegawa/mirukan/issues/new/choose";
-
 export function UserMenu({ email }: Props) {
   const [isAboutOpen, setIsAboutOpen] = useState(false);
+  const [isContactOpen, setIsContactOpen] = useState(false);
   const displayEmail = email ?? "ログイン中のユーザー";
   // 小画面用：最初の2文字のみ表示
   const shortEmail = displayEmail.slice(0, 2);
@@ -57,10 +57,10 @@ export function UserMenu({ email }: Props) {
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
-              globalThis.open(BUG_REPORT_URL, "_blank", "noopener,noreferrer");
+              setIsContactOpen(true);
             }}
           >
-            不具合を報告
+            お問い合わせ
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
@@ -75,6 +75,11 @@ export function UserMenu({ email }: Props) {
       {isAboutOpen ? (
         <Suspense fallback={null}>
           <AboutDialog onClose={() => setIsAboutOpen(false)} />
+        </Suspense>
+      ) : null}
+      {isContactOpen ? (
+        <Suspense fallback={null}>
+          <ContactDialog onClose={() => setIsContactOpen(false)} />
         </Suspense>
       ) : null}
     </>


### PR DESCRIPTION
## 関連 Issue

Closes #221

## 変更内容

- `DialogShell.tsx` を新規作成（AboutDialog・ContactDialog 共通のダイアログ基盤）
  - `<section role="dialog">` の代わりに native `<dialog>` 要素を使用
  - backdrop に `<div onClick>` の代わりに native `<button>` を使用（SonarCloud S6819/S6848/S1082 対応）
- `ContactDialog.tsx` を新規作成（メールと GitHub Issues リンクを表示）
- `AboutDialog.tsx` を DialogShell を使うよう更新
- `UserMenu.tsx` に「お問い合わせ」メニュー項目を追加（`lazyNamed` で lazy load）
- `UserMenu.tsx` から「不具合を報告」メニュー項目を削除し、ContactDialog に統合
- `LoginPageAuthForm.tsx` の `TermsAndPrivacyLinks` に `mailto:support@mirukan.app` リンクを追加（ログイン前のユーザー向け）
- 各コンポーネントのテストを更新