### PR TITLE
fix: AddModal・DetailModal のバックドロップを button 要素に変更

### DIFF
--- a/src/features/backlog/components/AddModal.tsx
+++ b/src/features/backlog/components/AddModal.tsx
@@ -67,13 +67,15 @@ export function AddModal({ items, session, onClose, onAdded }: Props) {
   }, [onClose]);
 
   return (
-    <div
-      className="fixed inset-0 z-10 grid place-items-center p-5 bg-[rgba(51,34,23,0.4)] backdrop-blur-[10px]"
-      id="add-modal-backdrop"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
+    <div className="fixed inset-0 z-10 grid place-items-center p-5 bg-[rgba(51,34,23,0.4)] backdrop-blur-[10px]">
+      {/* Backdrop: native button for click-outside-to-close (keyboard users use Escape) */}
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="fixed inset-0 cursor-default"
+        onClick={onClose}
+      />
       <section
         className="w-[min(calc(100%_-_48px),960px)] h-[min(88svh,920px)] border border-border rounded-[28px] bg-[#2a2a2a] shadow-[0_24px_60px_rgba(0,0,0,0.5)] p-6 flex flex-col overflow-hidden max-[720px]:w-full max-[720px]:max-w-[560px] max-[720px]:p-5 max-[720px]:rounded-[22px] max-[720px]:h-[min(88svh,920px)]"
         role="dialog"

--- a/src/features/backlog/components/AddModal.tsx
+++ b/src/features/backlog/components/AddModal.tsx
@@ -77,7 +77,7 @@ export function AddModal({ items, session, onClose, onAdded }: Props) {
         onClick={onClose}
       />
       <section
-        className="w-[min(calc(100%_-_48px),960px)] h-[min(88svh,920px)] border border-border rounded-[28px] bg-[#2a2a2a] shadow-[0_24px_60px_rgba(0,0,0,0.5)] p-6 flex flex-col overflow-hidden max-[720px]:w-full max-[720px]:max-w-[560px] max-[720px]:p-5 max-[720px]:rounded-[22px] max-[720px]:h-[min(88svh,920px)]"
+        className="relative z-10 w-[min(calc(100%_-_48px),960px)] h-[min(88svh,920px)] border border-border rounded-[28px] bg-[#2a2a2a] shadow-[0_24px_60px_rgba(0,0,0,0.5)] p-6 flex flex-col overflow-hidden max-[720px]:w-full max-[720px]:max-w-[560px] max-[720px]:p-5 max-[720px]:rounded-[22px] max-[720px]:h-[min(88svh,920px)]"
         role="dialog"
         aria-modal="true"
         aria-label="作品を追加"

--- a/src/features/backlog/components/DetailModal.tsx
+++ b/src/features/backlog/components/DetailModal.tsx
@@ -71,13 +71,15 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
   const rtScore = work.rotten_tomatoes_score;
 
   return (
-    <div
-      className="fixed inset-0 z-10 grid place-items-center p-5 bg-[rgba(51,34,23,0.4)] backdrop-blur-[10px]"
-      id="detail-modal-backdrop"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
+    <div className="fixed inset-0 z-10 grid place-items-center p-5 bg-[rgba(51,34,23,0.4)] backdrop-blur-[10px]">
+      {/* Backdrop: native button for click-outside-to-close (keyboard users use Escape) */}
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="fixed inset-0 cursor-default"
+        onClick={onClose}
+      />
       <section
         className="relative w-full max-w-[860px] max-h-[min(88svh,920px)] border border-border rounded-[28px] bg-[#2a2a2a] shadow-[0_24px_60px_rgba(0,0,0,0.5)] p-6 flex flex-col overflow-hidden max-[720px]:p-5 max-[720px]:rounded-[22px]"
         role="dialog"


### PR DESCRIPTION
## 関連 Issue

Refs #225

## 変更内容

- `AddModal` と `DetailModal` のバックドロップ要素を `<div onClick>` から `<button aria-hidden tabIndex={-1}>` に変更
- `<div>` に click ハンドラを直接付ける代わりに、`DialogShell` と同じパターンへ統一
  - 外側の `<div>` はレイアウト（grid）専用に分離
  - クリック外しで閉じる処理は `fixed inset-0` の `<button>` が担う
  - `aria-hidden` / `tabIndex={-1}` でスクリーンリーダーからは隠し、キーボードユーザーは既存の Escape ハンドラで閉じる
- SonarCloud バグ指摘「Visible, non-interactive elements with click handlers must have at least one keyboard listener」を解消