### PR TITLE
refactor: SonarCloud すぐ直す項目の一括修正

### DIFF
--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -48,8 +48,8 @@ export async function deleteCard(page: Page, status: string, title: string) {
 }
 
 export function buildUniqueTitle(testInfo: TestInfo, prefix = "e2e-manual") {
-  const projectSlug = testInfo.project.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  const testSlug = testInfo.title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const projectSlug = testInfo.project.name.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-");
+  const testSlug = testInfo.title.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-");
   return `${prefix}-${projectSlug}-${testInfo.workerIndex}-${Date.now()}-${testSlug}`;
 }
 

--- a/src/components/LazyViewBoundary.tsx
+++ b/src/components/LazyViewBoundary.tsx
@@ -36,12 +36,12 @@ class LazyErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
   }
 }
 
-type Props = {
+type Props = Readonly<{
   children: ReactNode;
   loadingFallback: ReactNode;
   errorFallback?: ReactNode;
   resetKey?: string;
-};
+}>;
 
 export function LazyViewBoundary({
   children,

--- a/src/features/backlog/components/AboutDialog.tsx
+++ b/src/features/backlog/components/AboutDialog.tsx
@@ -2,9 +2,9 @@ import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import tmdbLogoUrl from "../../../assets/logos/tmdb.svg";
 import { DialogShell } from "./DialogShell.tsx";
 
-type Props = {
+type Props = Readonly<{
   onClose: () => void;
-};
+}>;
 
 export function AboutDialog({ onClose }: Props) {
   return (

--- a/src/features/backlog/components/AddModal.tsx
+++ b/src/features/backlog/components/AddModal.tsx
@@ -5,12 +5,12 @@ import { useAddFlow } from "../hooks/useAddFlow.ts";
 import { AddModalDetailsPane } from "./AddModalDetailsPane.tsx";
 import { AddModalSearchPane } from "./AddModalSearchPane.tsx";
 
-type Props = {
+type Props = Readonly<{
   items: BacklogItem[];
   session: Session;
   onClose: () => void;
   onAdded: () => void | Promise<void>;
-};
+}>;
 
 export function AddModal({ items, session, onClose, onAdded }: Props) {
   const {

--- a/src/features/backlog/components/AddModalDetailsPane.tsx
+++ b/src/features/backlog/components/AddModalDetailsPane.tsx
@@ -6,7 +6,7 @@ import type { PrimaryPlatform } from "../types.ts";
 import { PendingSaveNotice } from "./PendingSaveNotice.tsx";
 import { PlatformPicker } from "./PlatformPicker.tsx";
 
-type Props = {
+type Props = Readonly<{
   selectedTmdbResult: { title: string } | null;
   resolvedTitle: string;
   resolvedWorkType: "movie" | "series";
@@ -20,7 +20,7 @@ type Props = {
   onChangeNote: (note: string) => void;
   onConfirmPendingSave: () => void;
   onCancelPendingSave: () => void;
-};
+}>;
 
 export function AddModalDetailsPane({
   selectedTmdbResult,

--- a/src/features/backlog/components/AddModalSearchPane.tsx
+++ b/src/features/backlog/components/AddModalSearchPane.tsx
@@ -6,7 +6,7 @@ import { PendingSaveNotice } from "./PendingSaveNotice.tsx";
 import { SeasonPicker } from "./SeasonPicker.tsx";
 import { TmdbWorkCard } from "./TmdbWorkCard.tsx";
 
-type Props = {
+type Props = Readonly<{
   searchInputRef: RefObject<HTMLInputElement | null>;
   isComposingRef: MutableRefObject<boolean>;
   searchQuery: string;
@@ -33,7 +33,7 @@ type Props = {
   onToggleAllSeasons: () => void;
   onConfirmPendingSave: () => void;
   onCancelPendingSave: () => void;
-};
+}>;
 
 type SelectedResultFooterProps = Omit<
   Props,

--- a/src/features/backlog/components/AuthScreen.tsx
+++ b/src/features/backlog/components/AuthScreen.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
 
-type Props = {
+type Props = Readonly<{
   badge?: string;
   title?: string;
   description?: string;
   sideContent?: ReactNode;
   children: ReactNode;
-};
+}>;
 
 export function AuthScreen({ badge, title, description, sideContent, children }: Props) {
   return (

--- a/src/features/backlog/components/BacklogCard.tsx
+++ b/src/features/backlog/components/BacklogCard.tsx
@@ -31,13 +31,13 @@ const ModeIcon: Record<
   background: SpeakerWaveIcon,
 };
 
-type Props = {
+type Props = Readonly<{
   item: BacklogItem;
   showModeBadge?: boolean;
   onOpenDetail: () => void;
   onDeleteItem: (itemId: string) => void;
   onMarkAsWatched: (itemId: string) => void;
-};
+}>;
 
 export function BacklogCard({
   item,

--- a/src/features/backlog/components/BoardPage.tsx
+++ b/src/features/backlog/components/BoardPage.tsx
@@ -13,7 +13,7 @@ import { DraggedBacklogCardOverlay } from "./DraggedBacklogCardOverlay.tsx";
 const AddModal = lazyNamed(() => import("./AddModal.tsx"), "AddModal");
 const DetailModal = lazyNamed(() => import("./DetailModal.tsx"), "DetailModal");
 
-type Props = { session: Session };
+type Props = Readonly<{ session: Session }>;
 
 const shellBase =
   "w-full min-w-0 max-w-[1680px] mx-auto px-3 max-[720px]:px-2.5 max-[500px]:px-2 max-[400px]:px-1.5";

--- a/src/features/backlog/components/BrandWordmark.tsx
+++ b/src/features/backlog/components/BrandWordmark.tsx
@@ -1,9 +1,9 @@
-type Props = {
+type Props = Readonly<{
   className?: string;
   titleClassName?: string;
   subtitleClassName?: string;
   symbolClassName?: string;
-};
+}>;
 
 export function BrandWordmark({
   className,

--- a/src/features/backlog/components/ContactDialog.tsx
+++ b/src/features/backlog/components/ContactDialog.tsx
@@ -3,9 +3,9 @@ import { CheckIcon } from "@heroicons/react/24/solid";
 import { useState } from "react";
 import { DialogShell } from "./DialogShell.tsx";
 
-type Props = {
+type Props = Readonly<{
   onClose: () => void;
-};
+}>;
 
 const GITHUB_ISSUES_URL = "https://github.com/isshi-hasegawa/mirukan/issues/new/choose";
 const SUPPORT_EMAIL = "support@mirukan.app";

--- a/src/features/backlog/components/DesktopKanbanBoard.tsx
+++ b/src/features/backlog/components/DesktopKanbanBoard.tsx
@@ -3,10 +3,10 @@ import { statusOrder } from "../constants.ts";
 import { KanbanColumn } from "./KanbanColumn.tsx";
 import type { KanbanColumnProps } from "./kanban-board-shared.ts";
 
-type Props = {
+type Props = Readonly<{
   getColumnProps: (status: BacklogStatus) => KanbanColumnProps;
   columnRef: (status: BacklogStatus, el: HTMLElement | null) => void;
-};
+}>;
 
 export function DesktopKanbanBoard({ getColumnProps, columnRef }: Props) {
   return (

--- a/src/features/backlog/components/DetailModal.tsx
+++ b/src/features/backlog/components/DetailModal.tsx
@@ -10,14 +10,14 @@ import { DetailModalNoteField } from "./DetailModalNoteField.tsx";
 import { DetailModalPlatformField } from "./DetailModalPlatformField.tsx";
 import type { BacklogItem, DetailModalState } from "../types.ts";
 
-type Props = {
+type Props = Readonly<{
   item: BacklogItem | null;
   state: DetailModalState;
   items: BacklogItem[];
   onStateChange: Dispatch<SetStateAction<DetailModalState>>;
   onClose: () => void;
   onReload: () => Promise<void>;
-};
+}>;
 
 export function DetailModal({ item, state, items, onStateChange, onClose, onReload }: Props) {
   const inputRef = useRef<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null>(null);
@@ -54,7 +54,7 @@ export function DetailModal({ item, state, items, onStateChange, onClose, onRelo
     }
   }, [state.editingField]);
 
-  if (!item || !item.works) {
+  if (!item?.works) {
     return null;
   }
 

--- a/src/features/backlog/components/DetailModalNoteField.tsx
+++ b/src/features/backlog/components/DetailModalNoteField.tsx
@@ -2,7 +2,7 @@ import type { MutableRefObject } from "react";
 import { DocumentTextIcon } from "@heroicons/react/24/outline";
 import type { DetailModalState } from "../types.ts";
 
-type Props = {
+type Props = Readonly<{
   note: string | null;
   state: DetailModalState;
   inputRef: MutableRefObject<HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement | null>;
@@ -10,7 +10,7 @@ type Props = {
   onCancelEditing: () => void;
   onChangeDraft: (value: string) => void;
   onSave: () => Promise<void>;
-};
+}>;
 
 export function DetailModalNoteField({
   note,

--- a/src/features/backlog/components/DetailModalPlatformField.tsx
+++ b/src/features/backlog/components/DetailModalPlatformField.tsx
@@ -1,10 +1,10 @@
 import type { PrimaryPlatform } from "../types.ts";
 import { PlatformPicker } from "./PlatformPicker.tsx";
 
-type Props = {
+type Props = Readonly<{
   value: PrimaryPlatform;
   onSelect: (value: PrimaryPlatform) => Promise<void>;
-};
+}>;
 
 export function DetailModalPlatformField({ value, onSelect }: Props) {
   return <PlatformPicker value={value} onChange={(nextValue) => void onSelect(nextValue)} />;

--- a/src/features/backlog/components/DialogShell.tsx
+++ b/src/features/backlog/components/DialogShell.tsx
@@ -2,14 +2,14 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
-type Props = {
+type Props = Readonly<{
   titleId: string;
   badge: string;
   title: string;
   closeLabel: string;
   onClose: () => void;
   children: ReactNode;
-};
+}>;
 
 export function DialogShell({ titleId, badge, title, closeLabel, onClose, children }: Props) {
   useEffect(() => {

--- a/src/features/backlog/components/DraggedBacklogCardOverlay.tsx
+++ b/src/features/backlog/components/DraggedBacklogCardOverlay.tsx
@@ -1,8 +1,8 @@
 import type { BacklogItem } from "../types.ts";
 
-type Props = {
+type Props = Readonly<{
   item: BacklogItem | null;
-};
+}>;
 
 export function DraggedBacklogCardOverlay({ item }: Props) {
   if (!item?.works) {

--- a/src/features/backlog/components/Header.tsx
+++ b/src/features/backlog/components/Header.tsx
@@ -2,9 +2,9 @@ import type { Session } from "@supabase/supabase-js";
 import { BrandWordmark } from "./BrandWordmark.tsx";
 import { UserMenu } from "./UserMenu.tsx";
 
-type Props = {
+type Props = Readonly<{
   session: Session;
-};
+}>;
 
 export function Header({ session }: Props) {
   return (

--- a/src/features/backlog/components/KanbanBoard.test.tsx
+++ b/src/features/backlog/components/KanbanBoard.test.tsx
@@ -65,7 +65,7 @@ function createItem(
     works: createWorkSummaryFromFixtures({
       id: `work-${id}`,
       title,
-      tmdb_id: Number(id.replace(/\D/g, "")) || 1,
+      tmdb_id: Number(id.replaceAll(/\D/g, "")) || 1,
     }),
     ...overrides,
   };

--- a/src/features/backlog/components/KanbanBoard.tsx
+++ b/src/features/backlog/components/KanbanBoard.tsx
@@ -6,7 +6,7 @@ import { sortStackedItemsByViewingMode } from "../viewing-mode.ts";
 import { DesktopKanbanBoard } from "./DesktopKanbanBoard.tsx";
 import { MobileKanbanBoard } from "./MobileKanbanBoard.tsx";
 
-type Props = {
+type Props = Readonly<{
   items: BacklogItem[];
   isDragging: boolean;
   isMobileLayout: boolean;
@@ -18,7 +18,7 @@ type Props = {
   onDeleteItem: (itemId: string) => void;
   onMarkAsWatched: (itemId: string) => void;
   columnRef: (status: BacklogStatus, el: HTMLElement | null) => void;
-};
+}>;
 
 export function KanbanBoard({
   items,

--- a/src/features/backlog/components/KanbanColumnHeader.tsx
+++ b/src/features/backlog/components/KanbanColumnHeader.tsx
@@ -2,12 +2,12 @@ import { Button } from "@/components/ui/button.tsx";
 import { statusLabels } from "../constants.ts";
 import type { BacklogStatus } from "../types.ts";
 
-type Props = {
+type Props = Readonly<{
   status: BacklogStatus;
   itemCount: number;
   isMobileLayout: boolean;
   onOpenAddModal: () => void;
-};
+}>;
 
 export function KanbanColumnHeader({ status, itemCount, isMobileLayout, onOpenAddModal }: Props) {
   return (

--- a/src/features/backlog/components/LoginPage.tsx
+++ b/src/features/backlog/components/LoginPage.tsx
@@ -1,19 +1,15 @@
 import { AuthScreen } from "./AuthScreen.tsx";
 import { BrandWordmark } from "./BrandWordmark.tsx";
 import { LoginPageAuthForm } from "./LoginPageAuthForm.tsx";
-import {
-  getAuthRedirectUrl,
-  useLoginPageAuth,
-  type DevLoginCredentials,
-} from "../hooks/useLoginPageAuth.ts";
+import { useLoginPageAuth, type DevLoginCredentials } from "../hooks/useLoginPageAuth.ts";
 
-type Props = {
+type Props = Readonly<{
   devLoginCredentials?: DevLoginCredentials | null;
   isSessionLoading?: boolean;
   showDevLoginHint?: boolean;
-};
+}>;
 
-export { getAuthRedirectUrl };
+export { getAuthRedirectUrl } from "../hooks/useLoginPageAuth.ts";
 
 function getDevLoginCredentials(): DevLoginCredentials | null {
   if (!import.meta.env.DEV || import.meta.env.MODE === "test") {

--- a/src/features/backlog/components/LoginPageAuthForm.tsx
+++ b/src/features/backlog/components/LoginPageAuthForm.tsx
@@ -9,9 +9,9 @@ const ContactDialog = lazyNamed(() => import("./ContactDialog.tsx"), "ContactDia
 
 type LoginPageAuthModel = ReturnType<typeof useLoginPageAuth>;
 
-type Props = {
+type Props = Readonly<{
   auth: LoginPageAuthModel;
-};
+}>;
 
 function GoogleIcon() {
   return (

--- a/src/features/backlog/components/MobileKanbanBoard.tsx
+++ b/src/features/backlog/components/MobileKanbanBoard.tsx
@@ -6,13 +6,13 @@ import type { KanbanColumnProps } from "./kanban-board-shared.ts";
 
 const SWIPE_THRESHOLD_PX = 50;
 
-type Props = {
+type Props = Readonly<{
   selectedTabStatus: BacklogStatus;
   isMobileDragging: boolean;
   onTabChange: (status: BacklogStatus) => void;
   getColumnProps: (status: BacklogStatus) => KanbanColumnProps;
   columnRef: (status: BacklogStatus, el: HTMLElement | null) => void;
-};
+}>;
 
 export function MobileKanbanBoard({
   selectedTabStatus,

--- a/src/features/backlog/components/PendingSaveNotice.tsx
+++ b/src/features/backlog/components/PendingSaveNotice.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@/components/ui/button.tsx";
 
-type Props = {
+type Props = Readonly<{
   message: string;
   onConfirm: () => void;
   onCancel: () => void;
-};
+}>;
 
 export function PendingSaveNotice({ message, onConfirm, onCancel }: Props) {
   return (

--- a/src/features/backlog/components/PlatformIcon.tsx
+++ b/src/features/backlog/components/PlatformIcon.tsx
@@ -1,9 +1,9 @@
 import type { PrimaryPlatform } from "../types.ts";
 import { platformBackgrounds, platformIcons, platformLabels } from "../constants.ts";
 
-type Props = {
+type Props = Readonly<{
   platform: Exclude<PrimaryPlatform, null>;
-};
+}>;
 
 export function PlatformIcon({ platform }: Props) {
   return (

--- a/src/features/backlog/components/PlatformPicker.tsx
+++ b/src/features/backlog/components/PlatformPicker.tsx
@@ -1,10 +1,10 @@
 import type { PrimaryPlatform } from "../types.ts";
 import { platformBackgrounds, platformIcons, platformKeys, platformLabels } from "../constants.ts";
 
-type Props = {
+type Props = Readonly<{
   value: PrimaryPlatform;
   onChange: (value: PrimaryPlatform) => void;
-};
+}>;
 
 export function PlatformPicker({ value, onChange }: Props) {
   const handlePlatformClick = (platform: Exclude<PrimaryPlatform, null>) => {

--- a/src/features/backlog/components/PosterImage.tsx
+++ b/src/features/backlog/components/PosterImage.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 
-type Props = {
+type Props = Readonly<{
   posterPath: string | null;
   alt: string;
   size?: "w92" | "w185" | "w500";
   fallback?: string;
   className?: string;
   fallbackClassName?: string;
-};
+}>;
 
 export function PosterImage({
   posterPath,

--- a/src/features/backlog/components/RottenTomatoesBadge.tsx
+++ b/src/features/backlog/components/RottenTomatoesBadge.tsx
@@ -2,12 +2,12 @@ import { cn } from "../../../lib/utils.ts";
 
 type RottenTomatoesBadgeVariant = "fresh" | "rotten";
 
-type Props = {
+type Props = Readonly<{
   score: number;
   variant: RottenTomatoesBadgeVariant;
   appearance?: "pill" | "plain";
   className?: string;
-};
+}>;
 
 function FreshIcon() {
   return (

--- a/src/features/backlog/components/SeasonPicker.tsx
+++ b/src/features/backlog/components/SeasonPicker.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon } from "@heroicons/react/24/outline";
 import type { TmdbSeasonOption } from "../../../lib/tmdb.ts";
 
-type Props = {
+type Props = Readonly<{
   seasonOptions: TmdbSeasonOption[];
   selectedSeasonNumbers: number[];
   stackedSeasonNumbers: number[];
@@ -10,7 +10,7 @@ type Props = {
   hasAllSeasonsSelected: boolean;
   onToggleSeason: (seasonNumber: number) => void;
   onToggleAll: () => void;
-};
+}>;
 
 const seasonBtnClass = (active: boolean, locked: boolean) =>
   `inline-flex items-center gap-2 px-3.5 py-2.5 border rounded-full text-[0.88rem] cursor-pointer transition-[background,color,border-color,box-shadow] duration-150${

--- a/src/features/backlog/components/TmdbLink.tsx
+++ b/src/features/backlog/components/TmdbLink.tsx
@@ -1,14 +1,14 @@
 import { siThemoviedatabase } from "simple-icons";
 import { cn } from "../../../lib/utils.ts";
 
-type Props = {
+type Props = Readonly<{
   href: string;
   className?: string;
   iconClassName?: string;
   ariaLabel?: string;
   title?: string;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-};
+}>;
 
 export function TmdbLink({
   href,

--- a/src/features/backlog/components/TmdbWorkCard.tsx
+++ b/src/features/backlog/components/TmdbWorkCard.tsx
@@ -6,7 +6,7 @@ import { getTmdbSearchResultMetadataLabels } from "../helpers.ts";
 import { RottenTomatoesBadge } from "./RottenTomatoesBadge.tsx";
 import { TmdbLink } from "./TmdbLink.tsx";
 
-type Props = {
+type Props = Readonly<{
   result: TmdbSearchResult;
   isSelected?: boolean;
   onSelect?: () => void;
@@ -14,7 +14,7 @@ type Props = {
   isChecked?: boolean;
   footer?: ReactNode;
   footerLayout?: "panel" | "inline";
-};
+}>;
 
 export function TmdbWorkCard({
   result,

--- a/src/features/backlog/components/UserMenu.tsx
+++ b/src/features/backlog/components/UserMenu.tsx
@@ -12,9 +12,9 @@ import {
 const AboutDialog = lazyNamed(() => import("./AboutDialog.tsx"), "AboutDialog");
 const ContactDialog = lazyNamed(() => import("./ContactDialog.tsx"), "ContactDialog");
 
-type Props = {
+type Props = Readonly<{
   email: string | null | undefined;
-};
+}>;
 
 export function UserMenu({ email }: Props) {
   const [isAboutOpen, setIsAboutOpen] = useState(false);

--- a/src/features/backlog/components/ViewingModeFilter.tsx
+++ b/src/features/backlog/components/ViewingModeFilter.tsx
@@ -13,10 +13,10 @@ const viewingModeIcons: Record<
   background: SpeakerWaveIcon,
 };
 
-type Props = {
+type Props = Readonly<{
   activeViewingMode: ViewingMode | null;
   onViewingModeToggle: (mode: ViewingMode) => void;
-};
+}>;
 
 export function ViewingModeFilter({ activeViewingMode, onViewingModeToggle }: Props) {
   return (

--- a/src/features/backlog/constants.ts
+++ b/src/features/backlog/constants.ts
@@ -66,7 +66,7 @@ export const platformBackgrounds: Record<PlatformKey, string> = {
 };
 
 export function isPrimaryPlatformValue(value: unknown): value is PlatformKey {
-  return typeof value === "string" && platformKeys.includes(value);
+  return typeof value === "string" && (platformKeys as ReadonlyArray<string>).includes(value);
 }
 
 export const viewingModeOrder = [

--- a/src/features/backlog/constants.ts
+++ b/src/features/backlog/constants.ts
@@ -66,7 +66,7 @@ export const platformBackgrounds: Record<PlatformKey, string> = {
 };
 
 export function isPrimaryPlatformValue(value: unknown): value is PlatformKey {
-  return typeof value === "string" && platformKeys.some((platform) => platform === value);
+  return typeof value === "string" && platformKeys.includes(value);
 }
 
 export const viewingModeOrder = [

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -16,7 +16,7 @@ export function getStringField(formData: FormData, key: string) {
 
 export function getNullableStringField(formData: FormData, key: string) {
   const value = getStringField(formData, key).trim();
-  return value ? value : null;
+  return value || null;
 }
 
 export function isPrimaryPlatform(value: unknown): value is PrimaryPlatform {

--- a/src/features/backlog/hooks/useBacklogActions.ts
+++ b/src/features/backlog/hooks/useBacklogActions.ts
@@ -15,7 +15,7 @@ import { upsertTmdbWork } from "../work-repository.ts";
 import type { BacklogItem } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
 
-type Props = {
+type Props = Readonly<{
   items: BacklogItem[];
   localItems: BacklogItem[];
   setLocalItems: Dispatch<SetStateAction<BacklogItem[]>>;
@@ -25,7 +25,7 @@ type Props = {
   onItemDeleted: (itemId: string) => void;
   onWorksAdded: () => void;
   feedback?: BacklogFeedback;
-};
+}>;
 
 function buildWorkFailureMessage(failedTitles: string[], prefix: string) {
   if (failedTitles.length === 0) {

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -14,13 +14,13 @@ import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts"
 
 const EMPTY_PENDING_DELETES: ReadonlySet<string> = new Set();
 
-type Props = {
+type Props = Readonly<{
   items: BacklogItem[];
   pendingDeleteIds?: ReadonlySet<string>;
   isMobileLayout: boolean;
   onAfterDrop: () => Promise<void>;
   feedback?: BacklogFeedback;
-};
+}>;
 
 type RectLike = Pick<DOMRect, "top" | "height">;
 type TouchListKey = "touches" | "changedTouches";

--- a/src/features/backlog/hooks/useBoardPageState.ts
+++ b/src/features/backlog/hooks/useBoardPageState.ts
@@ -2,9 +2,9 @@ import { useRef, useState } from "react";
 import { createDetailModalState } from "../helpers.ts";
 import type { BacklogStatus, DetailModalState } from "../types.ts";
 
-type Props = {
+type Props = Readonly<{
   isMobileLayout: boolean;
-};
+}>;
 
 export function useBoardPageState({ isMobileLayout }: Props) {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);

--- a/src/features/backlog/hooks/useTmdbSearch.ts
+++ b/src/features/backlog/hooks/useTmdbSearch.ts
@@ -107,7 +107,7 @@ export function useTmdbSearch({ items }: UseTmdbSearchOptions) {
   };
 
   const toggleSeasonSelection = (seasonNumber: number) => {
-    if (!selectedTmdbResult || selectedTmdbResult.tmdbMediaType !== "tv") return;
+    if (selectedTmdbResult?.tmdbMediaType !== "tv") return;
     if (stackedSeasonNumbers.includes(seasonNumber)) return;
 
     const nextSelectedSeasonNumbers = selectedSeasonNumbersState.includes(seasonNumber)
@@ -126,7 +126,7 @@ export function useTmdbSearch({ items }: UseTmdbSearchOptions) {
   };
 
   const toggleAllSeasons = () => {
-    if (!selectedTmdbResult || selectedTmdbResult.tmdbMediaType !== "tv") return;
+    if (selectedTmdbResult?.tmdbMediaType !== "tv") return;
     if (!canToggleAllSeasons) return;
 
     const toggleableSeasonNumbers = allSeasonNumbers.filter(

--- a/src/features/backlog/work-metadata.ts
+++ b/src/features/backlog/work-metadata.ts
@@ -79,9 +79,11 @@ function isHighlyRated({ imdbRating, rottenTomatoesScore }: RatingInfo): boolean
   );
 }
 
+const DEFAULT_RATING_INFO: RatingInfo = { imdbRating: null, rottenTomatoesScore: null };
+
 export function calcBackgroundFitScore(
   genres: string[],
-  ratings: RatingInfo = { imdbRating: null, rottenTomatoesScore: null },
+  ratings: RatingInfo = DEFAULT_RATING_INFO,
 ): number {
   if (genres.some((genre) => BG_LOW_GENRES.has(genre))) return 0;
   const genreScore = genres.some((genre) => BG_HIGH_GENRES.has(genre))

--- a/src/lib/refactoring-backlog-paths.ts
+++ b/src/lib/refactoring-backlog-paths.ts
@@ -38,9 +38,9 @@ function matchesGlobPattern(path: string, pattern: string) {
   const normalizedPattern = normalizePathForMatch(pattern);
   const source = normalizedPattern
     .replaceAll(/[|\\{}()[\]^$+?.]/g, String.raw`\$&`)
-    .replaceAll(/\*\*/g, "__DOUBLE_STAR__")
-    .replaceAll(/\*/g, "[^/]*")
-    .replaceAll(/__DOUBLE_STAR__/g, ".*");
+    .replaceAll("**", "__DOUBLE_STAR__")
+    .replaceAll("*", "[^/]*")
+    .replaceAll("__DOUBLE_STAR__", ".*");
   return new RegExp(`^${source}$`).test(normalizedPath);
 }
 

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -9,7 +9,6 @@ import {
   fetchCachedTrendingResults,
   mergeRecommendationResults,
   normalizeRecommendationSources,
-  resetTmdbRecommendationCachesForTest,
 } from "./tmdb-recommendation-cache.ts";
 
 export type TmdbWatchPlatform = {
@@ -281,7 +280,7 @@ export async function fetchTmdbTrending(): Promise<TmdbSearchResult[]> {
   });
 }
 
-export { resetTmdbRecommendationCachesForTest };
+export { resetTmdbRecommendationCachesForTest } from "./tmdb-recommendation-cache.ts";
 
 export function searchTmdbWorks(query: string) {
   return invokeTmdbFunction<TmdbSearchResult[]>(

--- a/supabase/functions/_shared/omdb.ts
+++ b/supabase/functions/_shared/omdb.ts
@@ -24,27 +24,27 @@ function getOmdbApiKey(): string {
 }
 
 function parseRottenTomatoesScore(value: string): number | null {
-  const match = value.match(/^(\d+)%$/);
+  const match = /^(\d+)%$/.exec(value);
   if (!match) return null;
   const score = Number.parseInt(match[1], 10);
   return score >= 0 && score <= 100 ? score : null;
 }
 
 function parseImdbRating(value: string): number | null {
-  const match = value.match(/^(\d+(?:\.\d+)?)\/10$/);
+  const match = /^(\d+(?:\.\d+)?)\/10$/.exec(value);
   if (!match) return null;
   const rating = Number.parseFloat(match[1]);
   return rating >= 0 && rating <= 10 ? rating : null;
 }
 
 function parseImdbVotes(value: string): number | null {
-  const cleaned = value.replace(/,/g, "");
+  const cleaned = value.replaceAll(",", "");
   const votes = Number.parseInt(cleaned, 10);
   return Number.isNaN(votes) ? null : votes;
 }
 
 function parseMetacriticScore(value: string): number | null {
-  const match = value.match(/^(\d+)\/100$/);
+  const match = /^(\d+)\/100$/.exec(value);
   if (!match) return null;
   const score = Number.parseInt(match[1], 10);
   return score >= 0 && score <= 100 ? score : null;

--- a/supabase/functions/_shared/tmdb.ts
+++ b/supabase/functions/_shared/tmdb.ts
@@ -680,11 +680,11 @@ function buildFallbackQueries(query: string): string[] {
   const variants: string[] = [];
 
   // ・をスペースに置換（例: "インディ・ジョーンズ" → "インディ ジョーンズ"）
-  const withSpace = query.replace(/・/g, " ").replace(/\s+/g, " ").trim();
+  const withSpace = query.replaceAll("・", " ").replaceAll(/\s+/g, " ").trim();
   if (withSpace !== query) variants.push(withSpace);
 
   // ・を除去（例: "インディ・ジョーンズ" → "インディジョーンズ"）
-  const withoutDot = query.replace(/・/g, "").trim();
+  const withoutDot = query.replaceAll("・", "").trim();
   if (withoutDot !== query && withoutDot !== withSpace) variants.push(withoutDot);
 
   return variants;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath, URL } from "url";
+import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vite-plus";
 import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";


### PR DESCRIPTION
## 関連 Issue

Refs #225

## 変更内容

Issue #225 (Refactoring Backlog) の「すぐ直す」カテゴリの項目を可能な限り対応した。

- `node:url` インポートへの変更（`vite.config.ts`）
- `.some(x => x === v)` → `.includes(v)` への置き換え（`constants.ts`）
- 三項演算子 `v ? v : null` → `v || null` への簡略化（`helpers.ts`）
- 関数パラメータのオブジェクトリテラルデフォルト値を定数化（`work-metadata.ts`）
- glob パターン変換の正規表現を文字列リテラルに変更（`refactoring-backlog-paths.ts`）
- `export { x }` → `export { x } from "..."` の re-export 形式に変更（`LoginPage.tsx`, `tmdb.ts`）
- `String#match()` → `RegExp#exec()` に変更（`omdb.ts`）
- `String#replace(/pattern/g, ...)` → `String#replaceAll(...)` に変更（`omdb.ts`, `e2e/app.ts`, `KanbanBoard.test.tsx`, `tmdb.ts`）
- optional chain 式の適用（`useTmdbSearch.ts`, `DetailModal.tsx`）
- コンポーネント・フックの Props 型に `Readonly<>` を適用（35 ファイル）

### 見送った「すぐ直す」項目

- **`void` 演算子の除去 (6件)**: `no-floating-promises` lint ルールとの兼ね合いがあり、単純除去でリグレッションのおそれがあるため保留
- **ネストされた三項演算子の展開 (9件)**: JSX 内の表現で展開方針が可読性に影響するため、別 PR で検討
- **`<dialog>` 要素への置き換え (4件)**: `<section role="dialog">` → `<dialog>` の変更は DOM API の変更を伴い影響範囲が大きいため保留
- **`role="group"` → ネイティブ要素への変更 (3件)**: 視覚的影響を確認した上で別 PR で対応