### PR TITLE
refactor: テストの重複コードを共通化

### DIFF
--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -66,24 +66,16 @@ describe("LoginPage", () => {
     expect(screen.getByLabelText("パスワード")).toHaveValue("password123");
   });
 
-  test("ログイン画面に利用規約リンクが表示される", () => {
+  test.each([
+    ["利用規約", "/terms"],
+    ["プライバシーポリシー", "/privacy"],
+  ])("ログイン画面に %s リンクが表示される", (name, href) => {
     render(<LoginPage />);
 
-    const links = screen.getAllByRole("link", { name: "利用規約" });
+    const links = screen.getAllByRole("link", { name });
     expect(links.length).toBeGreaterThan(0);
     for (const link of links) {
-      expect(link).toHaveAttribute("href", "/terms");
-      expect(link).toHaveAttribute("target", "_blank");
-    }
-  });
-
-  test("ログイン画面にプライバシーポリシーリンクが表示される", () => {
-    render(<LoginPage />);
-
-    const links = screen.getAllByRole("link", { name: "プライバシーポリシー" });
-    expect(links.length).toBeGreaterThan(0);
-    for (const link of links) {
-      expect(link).toHaveAttribute("href", "/privacy");
+      expect(link).toHaveAttribute("href", href);
       expect(link).toHaveAttribute("target", "_blank");
     }
   });

--- a/src/features/backlog/components/UserMenu.test.tsx
+++ b/src/features/backlog/components/UserMenu.test.tsx
@@ -11,6 +11,13 @@ vi.mock("../../../lib/auth-repository.ts", () => authRepositoryMock);
 
 setupTestLifecycle();
 
+async function openMenuItem(user: ReturnType<typeof userEvent.setup>, name: string) {
+  const trigger = screen.getByRole("button", { name: /user@example.com/i });
+  trigger.focus();
+  await user.keyboard("{Enter}");
+  await user.click(await screen.findByRole("menuitem", { name }));
+}
+
 describe("UserMenu", () => {
   const openMock = vi.fn();
 
@@ -28,11 +35,7 @@ describe("UserMenu", () => {
     const user = userEvent.setup();
 
     render(<UserMenu email="user@example.com" />);
-
-    const trigger = screen.getByRole("button", { name: /user@example.com/i });
-    trigger.focus();
-    await user.keyboard("{Enter}");
-    await user.click(await screen.findByRole("menuitem", { name: "About" }));
+    await openMenuItem(user, "About");
 
     expect(await screen.findByRole("dialog", { name: "みるカンについて" })).toBeInTheDocument();
     expect(
@@ -52,11 +55,7 @@ describe("UserMenu", () => {
     const user = userEvent.setup();
 
     render(<UserMenu email="user@example.com" />);
-
-    const trigger = screen.getByRole("button", { name: /user@example.com/i });
-    trigger.focus();
-    await user.keyboard("{Enter}");
-    await user.click(await screen.findByRole("menuitem", { name: "利用規約" }));
+    await openMenuItem(user, "利用規約");
 
     await waitFor(() =>
       expect(openMock).toHaveBeenCalledWith("/terms", "_blank", "noopener,noreferrer"),
@@ -67,11 +66,7 @@ describe("UserMenu", () => {
     const user = userEvent.setup();
 
     render(<UserMenu email="user@example.com" />);
-
-    const trigger = screen.getByRole("button", { name: /user@example.com/i });
-    trigger.focus();
-    await user.keyboard("{Enter}");
-    await user.click(await screen.findByRole("menuitem", { name: "プライバシーポリシー" }));
+    await openMenuItem(user, "プライバシーポリシー");
 
     await waitFor(() =>
       expect(openMock).toHaveBeenCalledWith("/privacy", "_blank", "noopener,noreferrer"),
@@ -82,11 +77,7 @@ describe("UserMenu", () => {
     const user = userEvent.setup();
 
     render(<UserMenu email="user@example.com" />);
-
-    const trigger = screen.getByRole("button", { name: /user@example.com/i });
-    trigger.focus();
-    await user.keyboard("{Enter}");
-    await user.click(await screen.findByRole("menuitem", { name: "お問い合わせ" }));
+    await openMenuItem(user, "お問い合わせ");
 
     expect(await screen.findByRole("dialog", { name: "お問い合わせ" })).toBeInTheDocument();
     expect(screen.getByText("support@mirukan.app")).toBeInTheDocument();

--- a/src/features/backlog/work-repository.test.ts
+++ b/src/features/backlog/work-repository.test.ts
@@ -22,10 +22,14 @@ import type {
   TmdbSearchResult,
   TmdbSeasonOption,
   TmdbSeasonSelectionTarget,
-  TmdbWorkDetails,
 } from "../../lib/tmdb.ts";
 import { getMockWorks, setMockWorks } from "../../test/mocks/handlers";
 import { server } from "../../test/mocks/server";
+import {
+  createSeasonTmdbDetails,
+  createSeriesTmdbDetails,
+  createTmdbDetails,
+} from "../../test/backlog-fixtures.ts";
 import { setupTestLifecycle } from "../../test/test-lifecycle.ts";
 import {
   buildSelectedSeasonTargets,
@@ -40,26 +44,37 @@ const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || "http://localhost:5432
 
 setupTestLifecycle();
 
-function createTmdbDetails(overrides: Partial<TmdbWorkDetails> = {}): TmdbWorkDetails {
-  return {
-    tmdbId: 1,
-    tmdbMediaType: "movie",
-    workType: "movie",
-    title: "テスト作品",
-    originalTitle: "Test Work",
-    overview: "overview",
-    posterPath: "/poster.jpg",
-    releaseDate: "2024-01-01",
-    genres: ["ドラマ"],
-    runtimeMinutes: 120,
-    typicalEpisodeRuntimeMinutes: null,
-    episodeCount: null,
-    seasonCount: null,
-    seasonNumber: null,
-    imdbId: null,
-    ...overrides,
-  };
-}
+const sharedSeriesResult: TmdbSearchResult = {
+  tmdbId: 100,
+  tmdbMediaType: "tv",
+  workType: "series",
+  title: "テストシリーズ",
+  originalTitle: "Test Series",
+  overview: "overview",
+  posterPath: "/poster.jpg",
+  releaseDate: "2024-01-01",
+  jpWatchPlatforms: [],
+  hasJapaneseRelease: true,
+};
+
+const sharedSeasonOptions: TmdbSeasonOption[] = [
+  {
+    seasonNumber: 2,
+    title: "テストシリーズ シーズン2",
+    overview: "season 2",
+    posterPath: "/season2.jpg",
+    releaseDate: "2025-01-01",
+    episodeCount: 8,
+  },
+  {
+    seasonNumber: 3,
+    title: "テストシリーズ シーズン3",
+    overview: "season 3",
+    posterPath: "/season3.jpg",
+    releaseDate: "2026-01-01",
+    episodeCount: 10,
+  },
+];
 
 function createOmdbDetails() {
   return {
@@ -104,36 +119,6 @@ function failSeasonLookup(seasonNumber: number) {
   );
 }
 
-function createSeriesTmdbDetails(seriesResult: TmdbSearchResult, seasonCount: number) {
-  return createTmdbDetails({
-    tmdbId: seriesResult.tmdbId,
-    tmdbMediaType: "tv",
-    workType: "series",
-    title: seriesResult.title,
-    originalTitle: seriesResult.originalTitle,
-    runtimeMinutes: null,
-    typicalEpisodeRuntimeMinutes: 48,
-    seasonCount,
-  });
-}
-
-function createSeasonTmdbDetails(seriesResult: TmdbSearchResult, seasonOption: TmdbSeasonOption) {
-  return createTmdbDetails({
-    tmdbId: seriesResult.tmdbId,
-    tmdbMediaType: "tv",
-    workType: "season",
-    title: seasonOption.title,
-    originalTitle: seriesResult.originalTitle,
-    overview: seasonOption.overview,
-    posterPath: seasonOption.posterPath,
-    releaseDate: seasonOption.releaseDate,
-    runtimeMinutes: null,
-    typicalEpisodeRuntimeMinutes: 48,
-    episodeCount: seasonOption.episodeCount,
-    seasonNumber: seasonOption.seasonNumber,
-  });
-}
-
 beforeEach(() => {
   tmdbMocks.fetchTmdbWorkDetails.mockReset();
   omdbMocks.fetchOmdbWorkDetails.mockReset();
@@ -144,43 +129,15 @@ afterEach(() => {
 });
 
 describe("buildSelectedSeasonTargets", () => {
-  const seriesResult: TmdbSearchResult = {
-    tmdbId: 100,
-    tmdbMediaType: "tv",
-    workType: "series",
-    title: "テストシリーズ",
-    originalTitle: "Test Series",
-    overview: "overview",
-    posterPath: "/poster.jpg",
-    releaseDate: "2024-01-01",
-    jpWatchPlatforms: [],
-    hasJapaneseRelease: true,
-  };
-
-  const seasonOptions: TmdbSeasonOption[] = [
-    {
-      seasonNumber: 2,
-      title: "テストシリーズ シーズン2",
-      overview: "season 2",
-      posterPath: "/season2.jpg",
-      releaseDate: "2025-01-01",
-      episodeCount: 8,
-    },
-    {
-      seasonNumber: 3,
-      title: "テストシリーズ シーズン3",
-      overview: "season 3",
-      posterPath: "/season3.jpg",
-      releaseDate: "2026-01-01",
-      episodeCount: 10,
-    },
-  ];
-
   test("シーズン1はシリーズとして扱い、重複を除いて昇順で返す", () => {
-    const targets = buildSelectedSeasonTargets(seriesResult, seasonOptions, [3, 1, 3, 2]);
+    const targets = buildSelectedSeasonTargets(
+      sharedSeriesResult,
+      sharedSeasonOptions,
+      [3, 1, 3, 2],
+    );
 
     expect(targets).toHaveLength(3);
-    expect(targets[0]).toEqual(seriesResult);
+    expect(targets[0]).toEqual(sharedSeriesResult);
     expect(targets[1]).toMatchObject({
       workType: "season",
       seasonNumber: 2,
@@ -194,7 +151,7 @@ describe("buildSelectedSeasonTargets", () => {
   });
 
   test("不足しているシーズン情報を選ぶと例外を投げる", () => {
-    expect(() => buildSelectedSeasonTargets(seriesResult, seasonOptions, [4])).toThrow(
+    expect(() => buildSelectedSeasonTargets(sharedSeriesResult, sharedSeasonOptions, [4])).toThrow(
       "シーズン4の情報が見つかりません",
     );
   });
@@ -548,32 +505,27 @@ describe("upsertTmdbWork", () => {
   test("シーズン追加時は親 series を先に解決してから insert する", async () => {
     tmdbMocks.fetchTmdbWorkDetails
       .mockResolvedValueOnce(
-        createTmdbDetails({
-          tmdbId: seasonTarget.tmdbId,
-          tmdbMediaType: "tv",
-          workType: "series",
-          title: seasonTarget.seriesTitle,
-          originalTitle: seasonTarget.originalTitle,
-          runtimeMinutes: null,
-          typicalEpisodeRuntimeMinutes: 48,
-          seasonCount: 3,
-        }),
+        createSeriesTmdbDetails(
+          {
+            tmdbId: seasonTarget.tmdbId,
+            title: seasonTarget.seriesTitle,
+            originalTitle: seasonTarget.originalTitle,
+          },
+          3,
+        ),
       )
       .mockResolvedValueOnce(
-        createTmdbDetails({
-          tmdbId: seasonTarget.tmdbId,
-          tmdbMediaType: "tv",
-          workType: "season",
-          title: seasonTarget.title,
-          originalTitle: seasonTarget.originalTitle,
-          overview: seasonTarget.overview,
-          posterPath: seasonTarget.posterPath,
-          releaseDate: seasonTarget.releaseDate,
-          runtimeMinutes: null,
-          typicalEpisodeRuntimeMinutes: 48,
-          episodeCount: seasonTarget.episodeCount,
-          seasonNumber: seasonTarget.seasonNumber,
-        }),
+        createSeasonTmdbDetails(
+          { tmdbId: seasonTarget.tmdbId, originalTitle: seasonTarget.originalTitle },
+          {
+            seasonNumber: seasonTarget.seasonNumber,
+            title: seasonTarget.title,
+            overview: seasonTarget.overview,
+            posterPath: seasonTarget.posterPath,
+            releaseDate: seasonTarget.releaseDate,
+            episodeCount: seasonTarget.episodeCount,
+          },
+        ),
       );
 
     await expect(upsertTmdbWork(seasonTarget, "user-1")).resolves.toMatchObject({
@@ -603,41 +555,11 @@ describe("upsertTmdbWork", () => {
 });
 
 describe("resolveSelectedSeasonWorkIds", () => {
-  const seriesResult: TmdbSearchResult = {
-    tmdbId: 100,
-    tmdbMediaType: "tv",
-    workType: "series",
-    title: "テストシリーズ",
-    originalTitle: "Test Series",
-    overview: "overview",
-    posterPath: "/poster.jpg",
-    releaseDate: "2024-01-01",
-    jpWatchPlatforms: [],
-    hasJapaneseRelease: true,
-  };
-
-  const seasonOptions: TmdbSeasonOption[] = [
-    {
-      seasonNumber: 2,
-      title: "テストシリーズ シーズン2",
-      overview: "season 2",
-      posterPath: "/season2.jpg",
-      releaseDate: "2025-01-01",
-      episodeCount: 8,
-    },
-    {
-      seasonNumber: 3,
-      title: "テストシリーズ シーズン3",
-      overview: "season 3",
-      posterPath: "/season3.jpg",
-      releaseDate: "2026-01-01",
-      episodeCount: 10,
-    },
-  ];
-
   test("空入力時はエラーを返す", async () => {
     await expect(
-      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [], { seasonOptions }),
+      resolveSelectedSeasonWorkIds(sharedSeriesResult, "user-1", [], {
+        seasonOptions: sharedSeasonOptions,
+      }),
     ).resolves.toEqual({
       error: "追加するシーズンを1つ以上選択してください",
       workIds: [],
@@ -646,7 +568,9 @@ describe("resolveSelectedSeasonWorkIds", () => {
 
   test("シーズン情報組み立て失敗時はエラーを返す", async () => {
     await expect(
-      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [4], { seasonOptions }),
+      resolveSelectedSeasonWorkIds(sharedSeriesResult, "user-1", [4], {
+        seasonOptions: sharedSeasonOptions,
+      }),
     ).resolves.toEqual({
       error: "シーズン4の情報が見つかりません",
       workIds: [],
@@ -654,10 +578,14 @@ describe("resolveSelectedSeasonWorkIds", () => {
   });
 
   test("シーズン1のみ選択時は series を保存して返す", async () => {
-    tmdbMocks.fetchTmdbWorkDetails.mockResolvedValueOnce(createSeriesTmdbDetails(seriesResult, 3));
+    tmdbMocks.fetchTmdbWorkDetails.mockResolvedValueOnce(
+      createSeriesTmdbDetails(sharedSeriesResult, 3),
+    );
 
     await expect(
-      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1], { seasonOptions }),
+      resolveSelectedSeasonWorkIds(sharedSeriesResult, "user-1", [1], {
+        seasonOptions: sharedSeasonOptions,
+      }),
     ).resolves.toMatchObject({
       error: null,
       workIds: [expect.any(String)],
@@ -666,18 +594,18 @@ describe("resolveSelectedSeasonWorkIds", () => {
     expect(getMockWorks()).toContainEqual(
       expect.objectContaining({
         work_type: "series",
-        tmdb_id: seriesResult.tmdbId,
+        tmdb_id: sharedSeriesResult.tmdbId,
       }),
     );
   });
 
   test("複数シーズン追加時は親 series を一度だけ解決して workIds を順序どおり返す", async () => {
     tmdbMocks.fetchTmdbWorkDetails
-      .mockResolvedValueOnce(createSeriesTmdbDetails(seriesResult, 2))
-      .mockResolvedValueOnce(createSeasonTmdbDetails(seriesResult, seasonOptions[0]));
+      .mockResolvedValueOnce(createSeriesTmdbDetails(sharedSeriesResult, 2))
+      .mockResolvedValueOnce(createSeasonTmdbDetails(sharedSeriesResult, sharedSeasonOptions[0]));
 
-    const result = await resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1, 2], {
-      seasonOptions,
+    const result = await resolveSelectedSeasonWorkIds(sharedSeriesResult, "user-1", [1, 2], {
+      seasonOptions: sharedSeasonOptions,
     });
 
     expect(result.error).toBeNull();
@@ -689,13 +617,13 @@ describe("resolveSelectedSeasonWorkIds", () => {
 
     expect(seriesWork).toEqual(
       expect.objectContaining({
-        tmdb_id: seriesResult.tmdbId,
+        tmdb_id: sharedSeriesResult.tmdbId,
         parent_work_id: null,
       }),
     );
     expect(seasonWork).toEqual(
       expect.objectContaining({
-        tmdb_id: seriesResult.tmdbId,
+        tmdb_id: sharedSeriesResult.tmdbId,
         season_number: 2,
         parent_work_id: seriesWork?.id,
       }),
@@ -708,7 +636,9 @@ describe("resolveSelectedSeasonWorkIds", () => {
     failSeasonLookup(2);
 
     await expect(
-      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [1, 2], { seasonOptions }),
+      resolveSelectedSeasonWorkIds(sharedSeriesResult, "user-1", [1, 2], {
+        seasonOptions: sharedSeasonOptions,
+      }),
     ).resolves.toEqual({
       error: "season fetch failed",
       workIds: [],
@@ -720,11 +650,13 @@ describe("resolveSelectedSeasonWorkIds", () => {
     setExistingSeriesWork();
     failSeasonLookup(2);
     tmdbMocks.fetchTmdbWorkDetails.mockResolvedValue(
-      createSeasonTmdbDetails(seriesResult, seasonOptions[1]),
+      createSeasonTmdbDetails(sharedSeriesResult, sharedSeasonOptions[1]),
     );
 
     await expect(
-      resolveSelectedSeasonWorkIds(seriesResult, "user-1", [2, 3], { seasonOptions }),
+      resolveSelectedSeasonWorkIds(sharedSeriesResult, "user-1", [2, 3], {
+        seasonOptions: sharedSeasonOptions,
+      }),
     ).resolves.toEqual({
       error: "season fetch failed",
       workIds: [],

--- a/src/test/backlog-fixtures.ts
+++ b/src/test/backlog-fixtures.ts
@@ -1,3 +1,4 @@
+import type { TmdbSearchResult, TmdbSeasonOption, TmdbWorkDetails } from "../lib/tmdb.ts";
 import type { WorkSummary } from "../features/backlog/types.ts";
 
 export function createWorkSummary(overrides: Partial<WorkSummary> = {}): WorkSummary {
@@ -27,4 +28,61 @@ export function createWorkSummary(overrides: Partial<WorkSummary> = {}): WorkSum
     metacritic_score: null,
     ...overrides,
   };
+}
+
+export function createTmdbDetails(overrides: Partial<TmdbWorkDetails> = {}): TmdbWorkDetails {
+  return {
+    tmdbId: 1,
+    tmdbMediaType: "movie",
+    workType: "movie",
+    title: "テスト作品",
+    originalTitle: "Test Work",
+    overview: "overview",
+    posterPath: "/poster.jpg",
+    releaseDate: "2024-01-01",
+    genres: ["ドラマ"],
+    runtimeMinutes: 120,
+    typicalEpisodeRuntimeMinutes: null,
+    episodeCount: null,
+    seasonCount: null,
+    seasonNumber: null,
+    imdbId: null,
+    ...overrides,
+  };
+}
+
+export function createSeriesTmdbDetails(
+  seriesResult: Pick<TmdbSearchResult, "tmdbId" | "title" | "originalTitle">,
+  seasonCount: number,
+): TmdbWorkDetails {
+  return createTmdbDetails({
+    tmdbId: seriesResult.tmdbId,
+    tmdbMediaType: "tv",
+    workType: "series",
+    title: seriesResult.title,
+    originalTitle: seriesResult.originalTitle,
+    runtimeMinutes: null,
+    typicalEpisodeRuntimeMinutes: 48,
+    seasonCount,
+  });
+}
+
+export function createSeasonTmdbDetails(
+  seriesResult: Pick<TmdbSearchResult, "tmdbId" | "originalTitle">,
+  seasonOption: TmdbSeasonOption,
+): TmdbWorkDetails {
+  return createTmdbDetails({
+    tmdbId: seriesResult.tmdbId,
+    tmdbMediaType: "tv",
+    workType: "season",
+    title: seasonOption.title,
+    originalTitle: seriesResult.originalTitle,
+    overview: seasonOption.overview,
+    posterPath: seasonOption.posterPath,
+    releaseDate: seasonOption.releaseDate,
+    runtimeMinutes: null,
+    typicalEpisodeRuntimeMinutes: 48,
+    episodeCount: seasonOption.episodeCount,
+    seasonNumber: seasonOption.seasonNumber,
+  });
 }


### PR DESCRIPTION
## 関連 Issue

Refs #236

## 変更内容

SonarCloud で重複率が高いと指摘されたテストファイルを整理し、振る舞いを変えずに重複を削減しました。

### UserMenu.test.tsx（41.4% → 解消見込み）

メニュー開閉の 5 行シーケンス（`focus` → `keyboard` → `findByRole` → `click`）が 4 テストで完全重複していたため、`openMenuItem(user, name)` ヘルパーに集約しました。

### LoginPage.test.tsx（7.8% → 解消見込み）

「利用規約リンク」「プライバシーポリシーリンク」の 2 テストが同じ検証パターンだったため、`test.each` で name/href を表駆動化して 1 テストに統合しました。

### work-repository.test.ts（18.8% → 解消見込み）

- `createTmdbDetails` / `createSeriesTmdbDetails` / `createSeasonTmdbDetails` を `src/test/backlog-fixtures.ts` に移動（`createWorkSummary` と同じ位置付け）
- `buildSelectedSeasonTargets` と `resolveSelectedSeasonWorkIds` の 2 つの `describe` で同一の `seriesResult` / `seasonOptions` 定義が重複していたため、モジュールレベルの `sharedSeriesResult` / `sharedSeasonOptions` 定数に集約
- シーズン追加テストのインライン `createTmdbDetails` を共有ヘルパーに置き換え

### useBoardPageController.test.tsx（13.0%）

ファイル内に自明な重複が見当たらず（SonarCloud が他ファイルとの類似を検出している可能性あり）、今回は**見送り**としました。

## 検証

- `vp test` 全 37 ファイル 317 テスト通過
- `vp run knip` 未使用 export なし
- pre-commit (vp check --fix) 通過