### PR TITLE
refactor: 認知的複雑度が高いフック/ユーティリティの整理

### DIFF
--- a/src/features/backlog/backlog-item-utils.ts
+++ b/src/features/backlog/backlog-item-utils.ts
@@ -229,6 +229,23 @@ export function buildDetailFieldUpdate(
   };
 }
 
+function appendSortOrder(targetItems: BacklogItem[]) {
+  return targetItems.length > 0 ? targetItems.at(-1)!.sort_order + 1000 : 1000;
+}
+
+function interpolateSortOrder(previous: BacklogItem | null, next: BacklogItem | null) {
+  if (previous && next) {
+    return (previous.sort_order + next.sort_order) / 2;
+  }
+  if (previous) {
+    return previous.sort_order + 1000;
+  }
+  if (next) {
+    return next.sort_order - 1000;
+  }
+  return 1000;
+}
+
 export function getSortOrderForDrop(
   items: BacklogItem[],
   itemId: string,
@@ -241,30 +258,17 @@ export function getSortOrderForDrop(
     .sort((left, right) => left.sort_order - right.sort_order);
 
   if (!targetItemId) {
-    return targetItems.length > 0 ? targetItems.at(-1)!.sort_order + 1000 : 1000;
+    return appendSortOrder(targetItems);
   }
 
   const targetIndex = targetItems.findIndex((item) => item.id === targetItemId);
-
   if (targetIndex === -1) {
-    return targetItems.length > 0 ? targetItems.at(-1)!.sort_order + 1000 : 1000;
+    return appendSortOrder(targetItems);
   }
 
   const insertionIndex = side === "before" ? targetIndex : targetIndex + 1;
   const previous = insertionIndex > 0 ? targetItems[insertionIndex - 1] : null;
   const next = insertionIndex < targetItems.length ? targetItems[insertionIndex] : null;
 
-  if (!previous && !next) {
-    return 1000;
-  }
-
-  if (!previous && next) {
-    return next.sort_order - 1000;
-  }
-
-  if (previous && !next) {
-    return previous.sort_order + 1000;
-  }
-
-  return (previous!.sort_order + next!.sort_order) / 2;
+  return interpolateSortOrder(previous, next);
 }

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -105,6 +105,37 @@ function resolveDropSide(
   return getDropSideFromRect(rect, clientY);
 }
 
+function reorderWithinColumn(
+  prev: BacklogItem[],
+  overStatus: BacklogStatus,
+  activeId: string,
+  overId: string,
+  side: "before" | "after",
+) {
+  const colItems = prev.filter((i) => i.status === overStatus);
+  const others = prev.filter((i) => i.status !== overStatus);
+  return [...others, ...getReorderedColumnItems(colItems, activeId, overId, side)];
+}
+
+function moveToColumnEdge(prev: BacklogItem[], activeId: string, overStatus: BacklogStatus) {
+  return overStatus === "watched"
+    ? moveItemToColumnTop(prev, activeId, overStatus)
+    : moveItemToColumnEnd(prev, activeId, overStatus);
+}
+
+function moveAcrossColumns(
+  prev: BacklogItem[],
+  activeId: string,
+  overStatus: BacklogStatus,
+  overId: string,
+  side: "before" | "after",
+) {
+  const withUpdatedStatus = prev.map((i) => (i.id === activeId ? { ...i, status: overStatus } : i));
+  const newColItems = withUpdatedStatus.filter((i) => i.status === overStatus);
+  const others = withUpdatedStatus.filter((i) => i.status !== overStatus);
+  return [...others, ...getReorderedColumnItems(newColItems, activeId, overId, side)];
+}
+
 function calculateInsertedSortOrder(
   prevSortOrder: number | null,
   nextSortOrder: number | null,
@@ -177,27 +208,18 @@ export function useBacklogDnd({
       if (activeStatus === overStatus) {
         // 同列内での並び替え
         if (overId.startsWith("column:")) return prev;
-        const colItems = prev.filter((i) => i.status === overStatus);
-        const others = prev.filter((i) => i.status !== overStatus);
         const side = resolveDropSide(activatorEvent, over.rect);
-        return [...others, ...getReorderedColumnItems(colItems, activeId, overId, side)];
+        return reorderWithinColumn(prev, overStatus, activeId, overId, side);
       }
 
       // 列またぎ: ステータスを変更して over アイテムの位置に挿入
       // watched への列端ドロップは先頭挿入（handleMarkAsWatched と同じ並び順）
       if (overId.startsWith("column:")) {
-        return overStatus === "watched"
-          ? moveItemToColumnTop(prev, activeId, overStatus)
-          : moveItemToColumnEnd(prev, activeId, overStatus);
+        return moveToColumnEdge(prev, activeId, overStatus);
       }
 
-      const withUpdatedStatus = prev.map((i) =>
-        i.id === activeId ? { ...i, status: overStatus } : i,
-      );
-      const newColItems = withUpdatedStatus.filter((i) => i.status === overStatus);
-      const others = withUpdatedStatus.filter((i) => i.status !== overStatus);
       const side = resolveDropSide(activatorEvent, over.rect);
-      return [...others, ...getReorderedColumnItems(newColItems, activeId, overId, side)];
+      return moveAcrossColumns(prev, activeId, overStatus, overId, side);
     });
   };
 

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -356,6 +356,35 @@ type OmdbFields = {
   omdb_fetched_at?: string;
 };
 
+function buildOmdbNullImdbFields(
+  existing: ExistingTmdbWorkRow | null,
+  omdbFetchedAt: string,
+): OmdbFields {
+  if (shouldKeepExistingNullOmdbState(existing)) {
+    return {};
+  }
+  return {
+    rotten_tomatoes_score: null,
+    imdb_rating: null,
+    imdb_votes: null,
+    metacritic_score: null,
+    omdb_fetched_at: omdbFetchedAt,
+  };
+}
+
+function toOmdbFields(
+  omdb: Awaited<ReturnType<typeof fetchOmdbWorkDetails>>,
+  omdbFetchedAt: string,
+): OmdbFields {
+  return {
+    rotten_tomatoes_score: omdb.rottenTomatoesScore,
+    imdb_rating: omdb.imdbRating,
+    imdb_votes: omdb.imdbVotes,
+    metacritic_score: omdb.metacriticScore,
+    omdb_fetched_at: omdbFetchedAt,
+  };
+}
+
 async function buildOmdbFields(
   details: Awaited<ReturnType<typeof fetchTmdbWorkDetails>>,
   existing: ExistingTmdbWorkRow | null,
@@ -363,15 +392,7 @@ async function buildOmdbFields(
   const omdbFetchedAt = new Date().toISOString();
 
   if (details.imdbId === null) {
-    return shouldKeepExistingNullOmdbState(existing)
-      ? {}
-      : {
-          rotten_tomatoes_score: null,
-          imdb_rating: null,
-          imdb_votes: null,
-          metacritic_score: null,
-          omdb_fetched_at: omdbFetchedAt,
-        };
+    return buildOmdbNullImdbFields(existing, omdbFetchedAt);
   }
 
   if (!details.imdbId || shouldSkipOmdbRefresh(existing, details.imdbId)) {
@@ -380,13 +401,7 @@ async function buildOmdbFields(
 
   try {
     const omdb = await fetchOmdbWorkDetails(details.imdbId);
-    return {
-      rotten_tomatoes_score: omdb.rottenTomatoesScore,
-      imdb_rating: omdb.imdbRating,
-      imdb_votes: omdb.imdbVotes,
-      metacritic_score: omdb.metacriticScore,
-      omdb_fetched_at: omdbFetchedAt,
-    };
+    return toOmdbFields(omdb, omdbFetchedAt);
   } catch {
     return {};
   }


### PR DESCRIPTION
## 関連 Issue

Refs #241

## 変更内容

- `getSortOrderForDrop` から末尾追加の fallback と previous/next 補間を `appendSortOrder` / `interpolateSortOrder` ヘルパーに抽出
- `buildOmdbFields` の imdbId null 分岐と OMDB 成功ボディを `buildOmdbNullImdbFields` / `toOmdbFields` に抽出し早期 return に統一
- `handleDragOver` の同列並び替え・列端ドロップ・列またぎを `reorderWithinColumn` / `moveToColumnEdge` / `moveAcrossColumns` にそれぞれ抽出

いずれも挙動不変の純粋なリファクタで、SonarCloud の cognitive complexity を低減することが目的。

## 検証

- `vp test`（317 件）pass
- `vp build` 成功
- `vp run knip` 指摘なし