### PR TITLE
ci: PR E2E と deploy 統合 E2E を分離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run unit tests
         run: vp test
 
-  e2e:
+  e2e-browser:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,7 +79,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('playwright.config.ts', 'playwright.integration.config.ts', 'package.json') }}
 
       - name: Install Playwright browsers
         run: playwright install --with-deps chromium
@@ -89,24 +89,14 @@ jobs:
         run: playwright install-deps chromium
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
-        with:
-          version: latest
-
-      - name: Start Supabase local stack
-        run: >-
-          supabase start
-          --exclude studio,mailpit,imgproxy,storage-api,realtime,postgres-meta,logflare,vector,supavisor,edge-runtime
-
-      - name: Run E2E tests (chromium)
-        run: playwright test --project chromium
+      - name: Run browser E2E tests (chromium)
+        run: vp exec playwright test --project chromium
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: playwright-report
+          name: playwright-report-browser
           path: playwright-report/
           retention-days: 7
 

--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -1,0 +1,71 @@
+name: Deploy E2E
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  VITE_SUPABASE_URL: http://127.0.0.1:54321
+  VITE_SUPABASE_PUBLISHABLE_KEY: ci-publishable-key
+  VP_BOOTSTRAP_VERSION: 0.1.14
+
+concurrency:
+  group: deploy-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-integration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('playwright.config.ts', 'playwright.integration.config.ts', 'package.json') }}
+
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Install Playwright system deps only
+        run: playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        with:
+          version: latest
+
+      - name: Start Supabase local stack
+        run: >-
+          supabase start
+          --exclude studio,mailpit,imgproxy,storage-api,realtime,postgres-meta,logflare,vector,supavisor,edge-runtime
+
+      - name: Run deploy integration E2E tests
+        run: >-
+          vp exec playwright test
+          --config=playwright.integration.config.ts
+          --project chromium
+          e2e/spec/auth.spec.ts
+          e2e/spec/regression-flow.spec.ts
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: playwright-report-integration
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/global-setup-mock.ts
+++ b/e2e/global-setup-mock.ts
@@ -1,0 +1,53 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const AUTH_FILE = path.resolve("e2e/.auth/user.json");
+
+export default async function globalSetup() {
+  const expiresAt = Math.floor(Date.now() / 1000) + 60 * 60;
+
+  fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
+  fs.writeFileSync(
+    AUTH_FILE,
+    JSON.stringify(
+      {
+        cookies: [],
+        origins: [
+          {
+            origin: "http://localhost:5173",
+            localStorage: [
+              {
+                name: "sb-127-auth-token",
+                value: JSON.stringify({
+                  access_token: "mock-access-token",
+                  token_type: "bearer",
+                  expires_in: 3600,
+                  expires_at: expiresAt,
+                  refresh_token: "mock-refresh-token",
+                  user: {
+                    id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1",
+                    aud: "authenticated",
+                    role: "authenticated",
+                    email: "akari@example.com",
+                    email_confirmed_at: "2026-04-01T00:00:00.000Z",
+                    phone: "",
+                    confirmed_at: "2026-04-01T00:00:00.000Z",
+                    last_sign_in_at: "2026-04-01T00:00:00.000Z",
+                    app_metadata: { provider: "email", providers: ["email"] },
+                    user_metadata: { name: "Akari" },
+                    identities: [],
+                    created_at: "2026-04-01T00:00:00.000Z",
+                    updated_at: "2026-04-01T00:00:00.000Z",
+                    is_anonymous: false,
+                  },
+                }),
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || "akari@example.com";
-const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD || "password123";
+const TEST_USER_SECRET = process.env.TEST_USER_SECRET || "password123";
 const AUTH_FILE = path.resolve("e2e/.auth/user.json");
 
 export default async function globalSetup() {
@@ -15,7 +15,7 @@ export default async function globalSetup() {
 
   await page.goto("/");
   await page.getByLabel("メールアドレス").fill(TEST_USER_EMAIL);
-  await page.getByLabel("パスワード").fill(TEST_USER_PASSWORD);
+  await page.getByLabel("パスワード").fill(TEST_USER_SECRET);
   await page.locator('form button[type="submit"]').click();
   await page.getByRole("button", { name: "作品を検索してストックに追加" }).waitFor();
 

--- a/e2e/mock-supabase-server.ts
+++ b/e2e/mock-supabase-server.ts
@@ -3,8 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 const HOST = "127.0.0.1";
 const PORT = Number(process.env.MOCK_SUPABASE_PORT || "55432");
 const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || "akari@example.com";
-const TEST_USER_SECRET =
-  process.env.TEST_USER_PASSWORD || process.env.TEST_USER_SECRET || "ci-login-token";
+const TEST_USER_SECRET = process.env.TEST_USER_SECRET || "ci-login-token";
 const TEST_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
 const ACCESS_TOKEN = "mock-access-token";
 const REFRESH_TOKEN = "mock-refresh-token";
@@ -572,7 +571,7 @@ function resolveTmdbWorkType(target: Record<string, unknown>) {
 }
 
 function readStringValue(target: Record<string, unknown>, key: string, fallback: string) {
-  return typeof target[key] === "string" ? (target[key] as string) : fallback;
+  return typeof target[key] === "string" ? target[key] : fallback;
 }
 
 function readNullableStringValue(
@@ -585,7 +584,7 @@ function readNullableStringValue(
 }
 
 function readNullableNumberValue(target: Record<string, unknown>, key: string) {
-  return typeof target[key] === "number" ? (target[key] as number) : null;
+  return typeof target[key] === "number" ? target[key] : null;
 }
 
 function createTmdbWorkDetails(target: Record<string, unknown>) {

--- a/e2e/mock-supabase-server.ts
+++ b/e2e/mock-supabase-server.ts
@@ -1,0 +1,896 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+const HOST = "127.0.0.1";
+const PORT = Number(process.env.MOCK_SUPABASE_PORT || "55432");
+const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || "akari@example.com";
+const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD || "password123";
+const TEST_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
+const ACCESS_TOKEN = "mock-access-token";
+const REFRESH_TOKEN = "mock-refresh-token";
+const TOKEN_EXPIRES_IN = 60 * 60;
+
+type Work = {
+  id: string;
+  created_by: string;
+  source_type: "tmdb" | "manual";
+  tmdb_media_type: "movie" | "tv" | null;
+  tmdb_id: number | null;
+  work_type: "movie" | "series" | "season";
+  parent_work_id: string | null;
+  title: string;
+  original_title: string | null;
+  search_text: string;
+  overview: string | null;
+  poster_path: string | null;
+  release_date: string | null;
+  runtime_minutes: number | null;
+  typical_episode_runtime_minutes: number | null;
+  duration_bucket: "short" | "medium" | "long" | "very_long" | null;
+  episode_count: number | null;
+  season_count: number | null;
+  season_number: number | null;
+  genres: string[];
+  focus_required_score: number | null;
+  background_fit_score: number | null;
+  completion_load_score: number | null;
+  imdb_id: string | null;
+  omdb_fetched_at: string | null;
+  rotten_tomatoes_score: number | null;
+  imdb_rating: number | null;
+  imdb_votes: number | null;
+  metacritic_score: number | null;
+  last_tmdb_synced_at: string | null;
+  series_title: string | null;
+};
+
+type BacklogItem = {
+  id: string;
+  user_id: string;
+  work_id: string;
+  status: "stacked" | "want_to_watch" | "watching" | "interrupted" | "watched";
+  primary_platform:
+    | "netflix"
+    | "prime_video"
+    | "u_next"
+    | "disney_plus"
+    | "hulu"
+    | "apple_tv_plus"
+    | "apple_tv"
+    | null;
+  note: string | null;
+  sort_order: number;
+  display_title: string | null;
+  created_at: string;
+};
+
+type SessionUser = {
+  id: string;
+  aud: "authenticated";
+  role: "authenticated";
+  email: string;
+  email_confirmed_at: string;
+  phone: string;
+  confirmed_at: string;
+  last_sign_in_at: string;
+  app_metadata: { provider: "email"; providers: ["email"] };
+  user_metadata: { name: string };
+  identities: [];
+  created_at: string;
+  updated_at: string;
+  is_anonymous: false;
+};
+
+const sessionUser: SessionUser = {
+  id: TEST_USER_ID,
+  aud: "authenticated",
+  role: "authenticated",
+  email: TEST_USER_EMAIL,
+  email_confirmed_at: "2026-04-01T00:00:00.000Z",
+  phone: "",
+  confirmed_at: "2026-04-01T00:00:00.000Z",
+  last_sign_in_at: "2026-04-01T00:00:00.000Z",
+  app_metadata: { provider: "email", providers: ["email"] },
+  user_metadata: { name: "Akari" },
+  identities: [],
+  created_at: "2026-04-01T00:00:00.000Z",
+  updated_at: "2026-04-01T00:00:00.000Z",
+  is_anonymous: false,
+};
+
+const corsHeaders = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers":
+    "authorization, x-client-info, apikey, content-type, prefer, x-supabase-api-version, accept-profile, content-profile",
+  "access-control-allow-methods": "GET,POST,PATCH,DELETE,OPTIONS",
+  "access-control-expose-headers": "content-range, x-supabase-api-version",
+};
+
+const works = new Map<string, Work>([
+  [
+    "work-manual-movie",
+    {
+      id: "work-manual-movie",
+      created_by: TEST_USER_ID,
+      source_type: "manual",
+      tmdb_media_type: null,
+      tmdb_id: null,
+      work_type: "movie",
+      parent_work_id: null,
+      title: "遠い街の休日",
+      original_title: null,
+      search_text: "遠い街の休日",
+      overview: "配信では見つからなかったので手動で積んだ、しっとり系のヒューマンドラマ。",
+      poster_path: null,
+      release_date: "2018-04-13",
+      runtime_minutes: 95,
+      typical_episode_runtime_minutes: null,
+      duration_bucket: "long",
+      episode_count: null,
+      season_count: null,
+      season_number: null,
+      genres: ["Drama", "Family"],
+      focus_required_score: 50,
+      background_fit_score: 25,
+      completion_load_score: 25,
+      imdb_id: null,
+      omdb_fetched_at: null,
+      rotten_tomatoes_score: null,
+      imdb_rating: null,
+      imdb_votes: null,
+      metacritic_score: null,
+      last_tmdb_synced_at: null,
+      series_title: null,
+    },
+  ],
+  [
+    "work-manual-series",
+    {
+      id: "work-manual-series",
+      created_by: TEST_USER_ID,
+      source_type: "manual",
+      tmdb_media_type: null,
+      tmdb_id: null,
+      work_type: "series",
+      parent_work_id: null,
+      title: "週末メモリーズ",
+      original_title: null,
+      search_text: "週末メモリーズ",
+      overview: "あとで配信先を調べたい、雑談向きの軽めシリーズ。",
+      poster_path: null,
+      release_date: "2021-10-08",
+      runtime_minutes: null,
+      typical_episode_runtime_minutes: 24,
+      duration_bucket: "short",
+      episode_count: null,
+      season_count: 10,
+      season_number: null,
+      genres: ["Comedy"],
+      focus_required_score: 25,
+      background_fit_score: 75,
+      completion_load_score: 25,
+      imdb_id: null,
+      omdb_fetched_at: null,
+      rotten_tomatoes_score: null,
+      imdb_rating: null,
+      imdb_votes: null,
+      metacritic_score: null,
+      last_tmdb_synced_at: null,
+      series_title: null,
+    },
+  ],
+  [
+    "work-breaking-bad",
+    {
+      id: "work-breaking-bad",
+      created_by: TEST_USER_ID,
+      source_type: "tmdb",
+      tmdb_media_type: "tv",
+      tmdb_id: 1396,
+      work_type: "series",
+      parent_work_id: null,
+      title: "ブレイキング・バッド",
+      original_title: "Breaking Bad",
+      search_text: "ブレイキング・バッド breaking bad",
+      overview:
+        "A high school chemistry teacher turned meth producer navigates danger, pride, and family collapse.",
+      poster_path: "/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg",
+      release_date: "2008-01-20",
+      runtime_minutes: null,
+      typical_episode_runtime_minutes: 47,
+      duration_bucket: "medium",
+      episode_count: null,
+      season_count: 5,
+      season_number: null,
+      genres: ["Drama", "Crime"],
+      focus_required_score: 75,
+      background_fit_score: 0,
+      completion_load_score: 100,
+      imdb_id: "tt0903747",
+      omdb_fetched_at: "2026-04-01T00:00:00.000Z",
+      rotten_tomatoes_score: 96,
+      imdb_rating: 9.5,
+      imdb_votes: 2300000,
+      metacritic_score: 87,
+      last_tmdb_synced_at: "2026-04-01T00:00:00.000Z",
+      series_title: null,
+    },
+  ],
+  [
+    "work-breaking-bad-season2",
+    {
+      id: "work-breaking-bad-season2",
+      created_by: TEST_USER_ID,
+      source_type: "tmdb",
+      tmdb_media_type: "tv",
+      tmdb_id: 1396,
+      work_type: "season",
+      parent_work_id: "work-breaking-bad",
+      title: "ブレイキング・バッド シーズン2",
+      original_title: "Breaking Bad Season 2",
+      search_text: "ブレイキング・バッド season 2",
+      overview: "ウォルターとジェシーの選択がさらに重くなっていく第二シーズン。",
+      poster_path: "/eSzpy96DwBujGFj0xMbXBcGcfxX.jpg",
+      release_date: "2009-03-08",
+      runtime_minutes: null,
+      typical_episode_runtime_minutes: 47,
+      duration_bucket: "medium",
+      episode_count: 13,
+      season_count: null,
+      season_number: 2,
+      genres: ["Drama", "Crime"],
+      focus_required_score: 75,
+      background_fit_score: 0,
+      completion_load_score: 100,
+      imdb_id: "tt0903747",
+      omdb_fetched_at: "2026-04-01T00:00:00.000Z",
+      rotten_tomatoes_score: 100,
+      imdb_rating: 9.4,
+      imdb_votes: 500000,
+      metacritic_score: 90,
+      last_tmdb_synced_at: "2026-04-01T00:00:00.000Z",
+      series_title: "ブレイキング・バッド",
+    },
+  ],
+  [
+    "work-matrix",
+    {
+      id: "work-matrix",
+      created_by: TEST_USER_ID,
+      source_type: "tmdb",
+      tmdb_media_type: "movie",
+      tmdb_id: 603,
+      work_type: "movie",
+      parent_work_id: null,
+      title: "マトリックス",
+      original_title: "The Matrix",
+      search_text: "マトリックス the matrix",
+      overview:
+        "A computer hacker learns about the true nature of reality and his role in the war against its controllers.",
+      poster_path: "/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg",
+      release_date: "1999-03-31",
+      runtime_minutes: 136,
+      typical_episode_runtime_minutes: null,
+      duration_bucket: "very_long",
+      episode_count: null,
+      season_count: null,
+      season_number: null,
+      genres: ["Action", "Science Fiction"],
+      focus_required_score: 75,
+      background_fit_score: 25,
+      completion_load_score: 50,
+      imdb_id: "tt0133093",
+      omdb_fetched_at: "2026-04-01T00:00:00.000Z",
+      rotten_tomatoes_score: 83,
+      imdb_rating: 8.7,
+      imdb_votes: 2200000,
+      metacritic_score: 73,
+      last_tmdb_synced_at: "2026-04-01T00:00:00.000Z",
+      series_title: null,
+    },
+  ],
+]);
+
+const backlogItems = new Map<string, BacklogItem>([
+  [
+    "backlog-stacked",
+    {
+      id: "backlog-stacked",
+      user_id: TEST_USER_ID,
+      work_id: "work-manual-movie",
+      status: "stacked",
+      primary_platform: null,
+      note: "配信先不明。週末に腰を据えて観たい。",
+      sort_order: 1000,
+      display_title: null,
+      created_at: "2026-04-10T00:00:00.000Z",
+    },
+  ],
+  [
+    "backlog-want",
+    {
+      id: "backlog-want",
+      user_id: TEST_USER_ID,
+      work_id: "work-manual-series",
+      status: "want_to_watch",
+      primary_platform: null,
+      note: "軽い気分の日に候補へ回しておく。",
+      sort_order: 1000,
+      display_title: null,
+      created_at: "2026-04-11T00:00:00.000Z",
+    },
+  ],
+  [
+    "backlog-watching",
+    {
+      id: "backlog-watching",
+      user_id: TEST_USER_ID,
+      work_id: "work-breaking-bad",
+      status: "watching",
+      primary_platform: "netflix",
+      note: "今月の平日夜に少しずつ進める。",
+      sort_order: 1000,
+      display_title: null,
+      created_at: "2026-04-12T00:00:00.000Z",
+    },
+  ],
+  [
+    "backlog-interrupted",
+    {
+      id: "backlog-interrupted",
+      user_id: TEST_USER_ID,
+      work_id: "work-breaking-bad-season2",
+      status: "interrupted",
+      primary_platform: "netflix",
+      note: "再開ポイント確認待ち。",
+      sort_order: 1000,
+      display_title: null,
+      created_at: "2026-04-13T00:00:00.000Z",
+    },
+  ],
+  [
+    "backlog-watched",
+    {
+      id: "backlog-watched",
+      user_id: TEST_USER_ID,
+      work_id: "work-matrix",
+      status: "watched",
+      primary_platform: "prime_video",
+      note: "視聴済みだけど比較用に残しているカード。",
+      sort_order: 1000,
+      display_title: null,
+      created_at: "2026-04-14T00:00:00.000Z",
+    },
+  ],
+]);
+
+let nextWorkId = 1;
+let nextBacklogItemId = 1;
+
+function json(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  extraHeaders: Record<string, string> = {},
+) {
+  res.writeHead(status, {
+    "content-type": "application/json",
+    ...corsHeaders,
+    ...extraHeaders,
+  });
+  res.end(JSON.stringify(body));
+}
+
+function noContent(res: ServerResponse, status = 204, extraHeaders: Record<string, string> = {}) {
+  res.writeHead(status, {
+    ...corsHeaders,
+    ...extraHeaders,
+  });
+  res.end();
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  if (chunks.length === 0) {
+    return null;
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function matchesFilters(row: Record<string, unknown>, url: URL) {
+  for (const [key, value] of url.searchParams.entries()) {
+    if (["select", "order", "limit", "offset", "columns", "on_conflict"].includes(key)) {
+      continue;
+    }
+
+    if (!value.startsWith("eq.")) {
+      continue;
+    }
+
+    if (String(row[key]) !== value.slice(3)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function selectedFields(selectValue: string | null) {
+  return (selectValue ?? "")
+    .split(",")
+    .map((field) => field.trim())
+    .filter((field) => field && !field.includes("("));
+}
+
+function pickSelectedFields<T extends Record<string, unknown>>(row: T, selectValue: string | null) {
+  const fields = selectedFields(selectValue);
+  if (fields.length === 0) {
+    return row;
+  }
+
+  return Object.fromEntries(
+    fields.filter((field) => field in row).map((field) => [field, row[field]]),
+  );
+}
+
+function sortRows<T extends Record<string, unknown>>(rows: T[], url: URL) {
+  const orderParams = url.searchParams.getAll("order");
+  if (orderParams.length === 0) {
+    return rows;
+  }
+
+  return [...rows].sort((left, right) => {
+    for (const orderParam of orderParams) {
+      const [column, direction = "asc"] = orderParam.split(".");
+      const leftValue = left[column];
+      const rightValue = right[column];
+      if (leftValue === rightValue) {
+        continue;
+      }
+
+      if (leftValue === null || leftValue === undefined) return direction === "desc" ? 1 : -1;
+      if (rightValue === null || rightValue === undefined) return direction === "desc" ? -1 : 1;
+      if (leftValue < rightValue) return direction === "desc" ? 1 : -1;
+      if (leftValue > rightValue) return direction === "desc" ? -1 : 1;
+    }
+
+    return 0;
+  });
+}
+
+function buildJsonResponseRows(
+  request: IncomingMessage,
+  rows: Record<string, unknown>[],
+  status = 200,
+) {
+  const accept = request.headers.accept ?? "";
+  if (accept.includes("application/vnd.pgrst.object+json")) {
+    if (rows.length !== 1) {
+      return {
+        status: 406,
+        body: { message: "JSON object requested, multiple (or no) rows returned" },
+      };
+    }
+
+    return { status, body: rows[0] };
+  }
+
+  return { status, body: rows };
+}
+
+function shouldReturnRepresentation(request: IncomingMessage) {
+  return (request.headers.prefer ?? "").includes("return=representation");
+}
+
+function createSessionResponse() {
+  const expiresAt = Math.floor(Date.now() / 1000) + TOKEN_EXPIRES_IN;
+
+  return {
+    access_token: ACCESS_TOKEN,
+    token_type: "bearer",
+    expires_in: TOKEN_EXPIRES_IN,
+    expires_at: expiresAt,
+    refresh_token: REFRESH_TOKEN,
+    user: sessionUser,
+  };
+}
+
+function materializeBacklogRows(url: URL) {
+  return sortRows(
+    Array.from(backlogItems.values())
+      .filter((item) => item.user_id === TEST_USER_ID)
+      .map((item) => ({
+        id: item.id,
+        status: item.status,
+        display_title: item.display_title,
+        primary_platform: item.primary_platform,
+        note: item.note,
+        sort_order: item.sort_order,
+        created_at: item.created_at,
+        works: works.get(item.work_id) ?? null,
+      })),
+    url,
+  );
+}
+
+function createSearchText(title: string) {
+  return title.trim().toLowerCase();
+}
+
+function createTmdbWorkDetails(target: Record<string, unknown>) {
+  const workType =
+    target.workType === "season" ? "season" : target.workType === "series" ? "series" : "movie";
+  const releaseDate = typeof target.releaseDate === "string" ? target.releaseDate : "2025-02-02";
+  const title = typeof target.title === "string" ? target.title : "テスト作品";
+  const originalTitle =
+    typeof target.originalTitle === "string" || target.originalTitle === null
+      ? target.originalTitle
+      : "Test Work";
+
+  return {
+    tmdbId: typeof target.tmdbId === "number" ? target.tmdbId : 777002,
+    tmdbMediaType: target.tmdbMediaType === "tv" ? "tv" : "movie",
+    workType,
+    title,
+    originalTitle,
+    overview:
+      typeof target.overview === "string" || target.overview === null
+        ? target.overview
+        : "overview",
+    posterPath:
+      typeof target.posterPath === "string" || target.posterPath === null
+        ? target.posterPath
+        : null,
+    releaseDate,
+    genres: workType === "movie" ? ["Drama"] : ["Drama", "Crime"],
+    runtimeMinutes: workType === "movie" ? 110 : null,
+    typicalEpisodeRuntimeMinutes: workType === "movie" ? null : 47,
+    episodeCount: typeof target.episodeCount === "number" ? target.episodeCount : null,
+    seasonCount: workType === "series" ? 3 : null,
+    seasonNumber: typeof target.seasonNumber === "number" ? target.seasonNumber : null,
+    imdbId: "tt7654321",
+  };
+}
+
+async function handleAuth(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method === "POST" && url.pathname === "/auth/v1/token") {
+    const body = (await readJson(req)) as { email?: string; password?: string } | null;
+    if (body?.email !== TEST_USER_EMAIL || body?.password !== TEST_USER_PASSWORD) {
+      json(res, 400, { error: "invalid_grant", error_description: "Invalid login credentials" });
+      return true;
+    }
+
+    json(res, 200, createSessionResponse());
+    return true;
+  }
+
+  if (req.method === "GET" && url.pathname === "/auth/v1/user") {
+    json(res, 200, sessionUser);
+    return true;
+  }
+
+  if (req.method === "POST" && url.pathname === "/auth/v1/logout") {
+    noContent(res);
+    return true;
+  }
+
+  return false;
+}
+
+async function handleRest(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method === "GET" && url.pathname === "/rest/v1/backlog_items") {
+    const rows = materializeBacklogRows(url);
+    const response = buildJsonResponseRows(req, rows);
+    json(res, response.status, response.body, {
+      "content-range": `0-${Math.max(rows.length - 1, 0)}/${rows.length}`,
+    });
+    return true;
+  }
+
+  if (req.method === "GET" && url.pathname === "/rest/v1/works") {
+    const rows = Array.from(works.values())
+      .filter((work) => matchesFilters(work, url))
+      .map((work) => pickSelectedFields(work, url.searchParams.get("select")));
+    const response = buildJsonResponseRows(req, rows);
+    json(res, response.status, response.body, {
+      "content-range": `0-${Math.max(rows.length - 1, 0)}/${rows.length}`,
+    });
+    return true;
+  }
+
+  if (req.method === "POST" && url.pathname === "/rest/v1/works") {
+    const payload = (await readJson(req)) as Partial<Work> | Array<Partial<Work>>;
+    const rows = (Array.isArray(payload) ? payload : [payload]).map((row) => {
+      const id = row.id ?? `mock-work-${nextWorkId++}`;
+      const createdBy = row.created_by ?? TEST_USER_ID;
+      return {
+        id,
+        created_by: createdBy,
+        source_type: row.source_type ?? "manual",
+        tmdb_media_type: row.tmdb_media_type ?? null,
+        tmdb_id: row.tmdb_id ?? null,
+        work_type: row.work_type ?? "movie",
+        parent_work_id: row.parent_work_id ?? null,
+        title: row.title ?? "",
+        original_title: row.original_title ?? null,
+        search_text: row.search_text ?? createSearchText(row.title ?? ""),
+        overview: row.overview ?? null,
+        poster_path: row.poster_path ?? null,
+        release_date: row.release_date ?? null,
+        runtime_minutes: row.runtime_minutes ?? null,
+        typical_episode_runtime_minutes: row.typical_episode_runtime_minutes ?? null,
+        duration_bucket: row.duration_bucket ?? null,
+        episode_count: row.episode_count ?? null,
+        season_count: row.season_count ?? null,
+        season_number: row.season_number ?? null,
+        genres: row.genres ?? [],
+        focus_required_score: row.focus_required_score ?? null,
+        background_fit_score: row.background_fit_score ?? null,
+        completion_load_score: row.completion_load_score ?? null,
+        imdb_id: row.imdb_id ?? null,
+        omdb_fetched_at: row.omdb_fetched_at ?? null,
+        rotten_tomatoes_score: row.rotten_tomatoes_score ?? null,
+        imdb_rating: row.imdb_rating ?? null,
+        imdb_votes: row.imdb_votes ?? null,
+        metacritic_score: row.metacritic_score ?? null,
+        last_tmdb_synced_at: row.last_tmdb_synced_at ?? null,
+        series_title: row.series_title ?? null,
+      } satisfies Work;
+    });
+
+    const hasConflict = rows.some((row) =>
+      Array.from(works.values()).some(
+        (work) =>
+          work.created_by === row.created_by &&
+          work.source_type === row.source_type &&
+          work.work_type === row.work_type &&
+          work.search_text === row.search_text,
+      ),
+    );
+
+    if (!url.searchParams.get("on_conflict") && hasConflict) {
+      json(res, 409, { message: "duplicate key value", code: "23505" });
+      return true;
+    }
+
+    rows.forEach((row) => {
+      works.set(row.id, row);
+    });
+
+    if (!shouldReturnRepresentation(req)) {
+      noContent(res, 201);
+      return true;
+    }
+
+    const response = buildJsonResponseRows(
+      req,
+      rows.map((row) => pickSelectedFields(row, url.searchParams.get("select"))),
+      201,
+    );
+    json(res, response.status, response.body);
+    return true;
+  }
+
+  if (req.method === "PATCH" && url.pathname === "/rest/v1/works") {
+    const body = (await readJson(req)) as Partial<Work>;
+    const target = Array.from(works.values()).find((work) => matchesFilters(work, url));
+
+    if (!target) {
+      json(res, 404, { message: "Work not found" });
+      return true;
+    }
+
+    const updated = { ...target, ...body };
+    works.set(updated.id, updated);
+
+    if (!shouldReturnRepresentation(req)) {
+      noContent(res);
+      return true;
+    }
+
+    json(res, 200, [pickSelectedFields(updated, url.searchParams.get("select"))]);
+    return true;
+  }
+
+  if (req.method === "POST" && url.pathname === "/rest/v1/backlog_items") {
+    const payload = (await readJson(req)) as Partial<BacklogItem> | Array<Partial<BacklogItem>>;
+    const rows = (Array.isArray(payload) ? payload : [payload]).map(
+      (row) =>
+        ({
+          id: row.id ?? `mock-backlog-item-${nextBacklogItemId++}`,
+          user_id: row.user_id ?? TEST_USER_ID,
+          work_id: row.work_id ?? "work-manual-movie",
+          status: row.status ?? "stacked",
+          primary_platform: row.primary_platform ?? null,
+          note: row.note ?? null,
+          sort_order: row.sort_order ?? 1000,
+          display_title: row.display_title ?? null,
+          created_at: row.created_at ?? new Date().toISOString(),
+        }) satisfies BacklogItem,
+    );
+
+    if (url.searchParams.get("on_conflict") === "user_id,work_id") {
+      rows.forEach((row) => {
+        const existing = Array.from(backlogItems.values()).find(
+          (item) => item.user_id === row.user_id && item.work_id === row.work_id,
+        );
+        backlogItems.set(existing?.id ?? row.id, {
+          ...existing,
+          ...row,
+          id: existing?.id ?? row.id,
+          created_at: existing?.created_at ?? row.created_at,
+        });
+      });
+    } else {
+      rows.forEach((row) => {
+        backlogItems.set(row.id, row);
+      });
+    }
+
+    if (!shouldReturnRepresentation(req)) {
+      noContent(res, 201);
+      return true;
+    }
+
+    const response = buildJsonResponseRows(req, rows, 201);
+    json(res, response.status, response.body);
+    return true;
+  }
+
+  if (req.method === "PATCH" && url.pathname === "/rest/v1/backlog_items") {
+    const body = (await readJson(req)) as Partial<BacklogItem>;
+    const target = Array.from(backlogItems.values()).find((item) => matchesFilters(item, url));
+
+    if (!target) {
+      json(res, 404, { message: "Backlog item not found" });
+      return true;
+    }
+
+    const updated = { ...target, ...body };
+    backlogItems.set(updated.id, updated);
+
+    if (!shouldReturnRepresentation(req)) {
+      noContent(res);
+      return true;
+    }
+
+    json(res, 200, [updated]);
+    return true;
+  }
+
+  if (req.method === "DELETE" && url.pathname === "/rest/v1/backlog_items") {
+    const target = Array.from(backlogItems.values()).find((item) => matchesFilters(item, url));
+
+    if (!target) {
+      noContent(res);
+      return true;
+    }
+
+    backlogItems.delete(target.id);
+    noContent(res);
+    return true;
+  }
+
+  return false;
+}
+
+async function handleFunctions(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "POST" || !url.pathname.startsWith("/functions/v1/")) {
+    return false;
+  }
+
+  const body = ((await readJson(req)) ?? {}) as Record<string, unknown>;
+  const functionName = url.pathname.replace("/functions/v1/", "");
+
+  if (functionName === "fetch-tmdb-trending") {
+    json(res, 200, [
+      {
+        tmdbId: 777001,
+        tmdbMediaType: "movie",
+        workType: "movie",
+        title: "おすすめ作品",
+        originalTitle: "Recommended Work",
+        overview: "initial recommendation",
+        posterPath: null,
+        releaseDate: "2024-01-01",
+        jpWatchPlatforms: [],
+        hasJapaneseRelease: true,
+      },
+    ]);
+    return true;
+  }
+
+  if (functionName === "fetch-tmdb-similar") {
+    json(res, 200, []);
+    return true;
+  }
+
+  if (functionName === "search-tmdb-works") {
+    const query = typeof body.query === "string" ? body.query.trim() : "";
+    json(
+      res,
+      200,
+      query
+        ? [
+            {
+              tmdbId: 777002,
+              tmdbMediaType: "movie",
+              workType: "movie",
+              title: `検索結果 ${query}`.trim(),
+              originalTitle: "Search Result",
+              overview: "search result overview",
+              posterPath: null,
+              releaseDate: "2025-02-02",
+              jpWatchPlatforms: [],
+              hasJapaneseRelease: true,
+            },
+          ]
+        : [],
+    );
+    return true;
+  }
+
+  if (functionName === "fetch-tmdb-season-options") {
+    json(res, 200, []);
+    return true;
+  }
+
+  if (functionName === "fetch-tmdb-work-details") {
+    json(res, 200, createTmdbWorkDetails((body.target as Record<string, unknown>) ?? {}));
+    return true;
+  }
+
+  if (functionName === "suggest-display-title") {
+    json(res, 200, { title: null });
+    return true;
+  }
+
+  if (functionName === "fetch-omdb-work-details") {
+    json(res, 200, {
+      rottenTomatoesScore: 96,
+      imdbRating: 9.5,
+      imdbVotes: 2300000,
+      metacriticScore: 87,
+    });
+    return true;
+  }
+
+  json(res, 404, { error: `Unknown function: ${functionName}` });
+  return true;
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", `http://${HOST}:${PORT}`);
+
+  if (req.method === "OPTIONS") {
+    noContent(res);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    json(res, 200, { ok: true });
+    return;
+  }
+
+  if (await handleAuth(req, res, url)) {
+    return;
+  }
+
+  if (await handleRest(req, res, url)) {
+    return;
+  }
+
+  if (await handleFunctions(req, res, url)) {
+    return;
+  }
+
+  json(res, 404, { error: `Not found: ${req.method} ${url.pathname}` });
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`Mock Supabase server listening on http://${HOST}:${PORT}`);
+});

--- a/e2e/mock-supabase-server.ts
+++ b/e2e/mock-supabase-server.ts
@@ -3,11 +3,17 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 const HOST = "127.0.0.1";
 const PORT = Number(process.env.MOCK_SUPABASE_PORT || "55432");
 const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || "akari@example.com";
-const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD || "password123";
+const TEST_USER_SECRET =
+  process.env.TEST_USER_PASSWORD || process.env.TEST_USER_SECRET || "ci-login-token";
 const TEST_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
 const ACCESS_TOKEN = "mock-access-token";
 const REFRESH_TOKEN = "mock-refresh-token";
 const TOKEN_EXPIRES_IN = 60 * 60;
+const DEFAULT_RELEASE_DATE = "2025-02-02";
+const DEFAULT_WORK_TITLE = "テスト作品";
+const DEFAULT_WORK_ORIGINAL_TITLE = "Test Work";
+const DEFAULT_WORK_OVERVIEW = "overview";
+const DEFAULT_IMDB_ID = "tt7654321";
 
 type Work = {
   id: string;
@@ -80,6 +86,12 @@ type SessionUser = {
   is_anonymous: false;
 };
 
+type RouteHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+) => Promise<boolean> | boolean;
+
 const sessionUser: SessionUser = {
   id: TEST_USER_ID,
   aud: "authenticated",
@@ -105,102 +117,121 @@ const corsHeaders = {
   "access-control-expose-headers": "content-range, x-supabase-api-version",
 };
 
+let nextWorkId = 1;
+let nextBacklogItemId = 1;
+
+function createSearchText(title: string) {
+  return title.trim().toLowerCase();
+}
+
+function createWork(
+  overrides: Partial<Work> & Pick<Work, "id" | "title" | "source_type" | "work_type">,
+): Work {
+  return {
+    id: overrides.id,
+    created_by: overrides.created_by ?? TEST_USER_ID,
+    source_type: overrides.source_type,
+    tmdb_media_type: overrides.tmdb_media_type ?? null,
+    tmdb_id: overrides.tmdb_id ?? null,
+    work_type: overrides.work_type,
+    parent_work_id: overrides.parent_work_id ?? null,
+    title: overrides.title,
+    original_title: overrides.original_title ?? null,
+    search_text: overrides.search_text ?? createSearchText(overrides.title),
+    overview: overrides.overview ?? null,
+    poster_path: overrides.poster_path ?? null,
+    release_date: overrides.release_date ?? null,
+    runtime_minutes: overrides.runtime_minutes ?? null,
+    typical_episode_runtime_minutes: overrides.typical_episode_runtime_minutes ?? null,
+    duration_bucket: overrides.duration_bucket ?? null,
+    episode_count: overrides.episode_count ?? null,
+    season_count: overrides.season_count ?? null,
+    season_number: overrides.season_number ?? null,
+    genres: overrides.genres ?? [],
+    focus_required_score: overrides.focus_required_score ?? null,
+    background_fit_score: overrides.background_fit_score ?? null,
+    completion_load_score: overrides.completion_load_score ?? null,
+    imdb_id: overrides.imdb_id ?? null,
+    omdb_fetched_at: overrides.omdb_fetched_at ?? null,
+    rotten_tomatoes_score: overrides.rotten_tomatoes_score ?? null,
+    imdb_rating: overrides.imdb_rating ?? null,
+    imdb_votes: overrides.imdb_votes ?? null,
+    metacritic_score: overrides.metacritic_score ?? null,
+    last_tmdb_synced_at: overrides.last_tmdb_synced_at ?? null,
+    series_title: overrides.series_title ?? null,
+  };
+}
+
+function createBacklogItem(
+  overrides: Partial<BacklogItem> & Pick<BacklogItem, "id" | "work_id" | "status" | "created_at">,
+): BacklogItem {
+  return {
+    id: overrides.id,
+    user_id: overrides.user_id ?? TEST_USER_ID,
+    work_id: overrides.work_id,
+    status: overrides.status,
+    primary_platform: overrides.primary_platform ?? null,
+    note: overrides.note ?? null,
+    sort_order: overrides.sort_order ?? 1000,
+    display_title: overrides.display_title ?? null,
+    created_at: overrides.created_at,
+  };
+}
+
 const works = new Map<string, Work>([
   [
     "work-manual-movie",
-    {
+    createWork({
       id: "work-manual-movie",
-      created_by: TEST_USER_ID,
-      source_type: "manual",
-      tmdb_media_type: null,
-      tmdb_id: null,
-      work_type: "movie",
-      parent_work_id: null,
       title: "遠い街の休日",
-      original_title: null,
-      search_text: "遠い街の休日",
+      source_type: "manual",
+      work_type: "movie",
       overview: "配信では見つからなかったので手動で積んだ、しっとり系のヒューマンドラマ。",
-      poster_path: null,
       release_date: "2018-04-13",
       runtime_minutes: 95,
-      typical_episode_runtime_minutes: null,
       duration_bucket: "long",
-      episode_count: null,
-      season_count: null,
-      season_number: null,
       genres: ["Drama", "Family"],
       focus_required_score: 50,
       background_fit_score: 25,
       completion_load_score: 25,
-      imdb_id: null,
-      omdb_fetched_at: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-      last_tmdb_synced_at: null,
-      series_title: null,
-    },
+    }),
   ],
   [
     "work-manual-series",
-    {
+    createWork({
       id: "work-manual-series",
-      created_by: TEST_USER_ID,
-      source_type: "manual",
-      tmdb_media_type: null,
-      tmdb_id: null,
-      work_type: "series",
-      parent_work_id: null,
       title: "週末メモリーズ",
-      original_title: null,
-      search_text: "週末メモリーズ",
+      source_type: "manual",
+      work_type: "series",
       overview: "あとで配信先を調べたい、雑談向きの軽めシリーズ。",
-      poster_path: null,
       release_date: "2021-10-08",
-      runtime_minutes: null,
       typical_episode_runtime_minutes: 24,
       duration_bucket: "short",
-      episode_count: null,
       season_count: 10,
-      season_number: null,
       genres: ["Comedy"],
       focus_required_score: 25,
       background_fit_score: 75,
       completion_load_score: 25,
-      imdb_id: null,
-      omdb_fetched_at: null,
-      rotten_tomatoes_score: null,
-      imdb_rating: null,
-      imdb_votes: null,
-      metacritic_score: null,
-      last_tmdb_synced_at: null,
-      series_title: null,
-    },
+    }),
   ],
   [
     "work-breaking-bad",
-    {
+    createWork({
       id: "work-breaking-bad",
-      created_by: TEST_USER_ID,
+      title: "ブレイキング・バッド",
       source_type: "tmdb",
+      work_type: "series",
       tmdb_media_type: "tv",
       tmdb_id: 1396,
-      work_type: "series",
-      parent_work_id: null,
-      title: "ブレイキング・バッド",
       original_title: "Breaking Bad",
       search_text: "ブレイキング・バッド breaking bad",
       overview:
         "A high school chemistry teacher turned meth producer navigates danger, pride, and family collapse.",
       poster_path: "/ztkUQFLlC19CCMYHW9o1zWhJRNq.jpg",
       release_date: "2008-01-20",
-      runtime_minutes: null,
       typical_episode_runtime_minutes: 47,
       duration_bucket: "medium",
-      episode_count: null,
       season_count: 5,
-      season_number: null,
       genres: ["Drama", "Crime"],
       focus_required_score: 75,
       background_fit_score: 0,
@@ -212,30 +243,26 @@ const works = new Map<string, Work>([
       imdb_votes: 2300000,
       metacritic_score: 87,
       last_tmdb_synced_at: "2026-04-01T00:00:00.000Z",
-      series_title: null,
-    },
+    }),
   ],
   [
     "work-breaking-bad-season2",
-    {
+    createWork({
       id: "work-breaking-bad-season2",
-      created_by: TEST_USER_ID,
+      title: "ブレイキング・バッド シーズン2",
       source_type: "tmdb",
+      work_type: "season",
       tmdb_media_type: "tv",
       tmdb_id: 1396,
-      work_type: "season",
       parent_work_id: "work-breaking-bad",
-      title: "ブレイキング・バッド シーズン2",
       original_title: "Breaking Bad Season 2",
       search_text: "ブレイキング・バッド season 2",
       overview: "ウォルターとジェシーの選択がさらに重くなっていく第二シーズン。",
       poster_path: "/eSzpy96DwBujGFj0xMbXBcGcfxX.jpg",
       release_date: "2009-03-08",
-      runtime_minutes: null,
       typical_episode_runtime_minutes: 47,
       duration_bucket: "medium",
       episode_count: 13,
-      season_count: null,
       season_number: 2,
       genres: ["Drama", "Crime"],
       focus_required_score: 75,
@@ -249,19 +276,17 @@ const works = new Map<string, Work>([
       metacritic_score: 90,
       last_tmdb_synced_at: "2026-04-01T00:00:00.000Z",
       series_title: "ブレイキング・バッド",
-    },
+    }),
   ],
   [
     "work-matrix",
-    {
+    createWork({
       id: "work-matrix",
-      created_by: TEST_USER_ID,
+      title: "マトリックス",
       source_type: "tmdb",
+      work_type: "movie",
       tmdb_media_type: "movie",
       tmdb_id: 603,
-      work_type: "movie",
-      parent_work_id: null,
-      title: "マトリックス",
       original_title: "The Matrix",
       search_text: "マトリックス the matrix",
       overview:
@@ -269,11 +294,7 @@ const works = new Map<string, Work>([
       poster_path: "/f89U3ADr1oiB1s9GkdPOEpXUk5H.jpg",
       release_date: "1999-03-31",
       runtime_minutes: 136,
-      typical_episode_runtime_minutes: null,
       duration_bucket: "very_long",
-      episode_count: null,
-      season_count: null,
-      season_number: null,
       genres: ["Action", "Science Fiction"],
       focus_required_score: 75,
       background_fit_score: 25,
@@ -285,86 +306,65 @@ const works = new Map<string, Work>([
       imdb_votes: 2200000,
       metacritic_score: 73,
       last_tmdb_synced_at: "2026-04-01T00:00:00.000Z",
-      series_title: null,
-    },
+    }),
   ],
 ]);
 
 const backlogItems = new Map<string, BacklogItem>([
   [
     "backlog-stacked",
-    {
+    createBacklogItem({
       id: "backlog-stacked",
-      user_id: TEST_USER_ID,
       work_id: "work-manual-movie",
       status: "stacked",
-      primary_platform: null,
       note: "配信先不明。週末に腰を据えて観たい。",
-      sort_order: 1000,
-      display_title: null,
       created_at: "2026-04-10T00:00:00.000Z",
-    },
+    }),
   ],
   [
     "backlog-want",
-    {
+    createBacklogItem({
       id: "backlog-want",
-      user_id: TEST_USER_ID,
       work_id: "work-manual-series",
       status: "want_to_watch",
-      primary_platform: null,
       note: "軽い気分の日に候補へ回しておく。",
-      sort_order: 1000,
-      display_title: null,
       created_at: "2026-04-11T00:00:00.000Z",
-    },
+    }),
   ],
   [
     "backlog-watching",
-    {
+    createBacklogItem({
       id: "backlog-watching",
-      user_id: TEST_USER_ID,
       work_id: "work-breaking-bad",
       status: "watching",
       primary_platform: "netflix",
       note: "今月の平日夜に少しずつ進める。",
-      sort_order: 1000,
-      display_title: null,
       created_at: "2026-04-12T00:00:00.000Z",
-    },
+    }),
   ],
   [
     "backlog-interrupted",
-    {
+    createBacklogItem({
       id: "backlog-interrupted",
-      user_id: TEST_USER_ID,
       work_id: "work-breaking-bad-season2",
       status: "interrupted",
       primary_platform: "netflix",
       note: "再開ポイント確認待ち。",
-      sort_order: 1000,
-      display_title: null,
       created_at: "2026-04-13T00:00:00.000Z",
-    },
+    }),
   ],
   [
     "backlog-watched",
-    {
+    createBacklogItem({
       id: "backlog-watched",
-      user_id: TEST_USER_ID,
       work_id: "work-matrix",
       status: "watched",
       primary_platform: "prime_video",
       note: "視聴済みだけど比較用に残しているカード。",
-      sort_order: 1000,
-      display_title: null,
       created_at: "2026-04-14T00:00:00.000Z",
-    },
+    }),
   ],
 ]);
-
-let nextWorkId = 1;
-let nextBacklogItemId = 1;
 
 function json(
   res: ServerResponse,
@@ -401,16 +401,34 @@ async function readJson(req: IncomingMessage): Promise<unknown> {
   return JSON.parse(Buffer.concat(chunks).toString("utf8"));
 }
 
+function isNullable(value: unknown) {
+  return value === null || value === undefined;
+}
+
+function compareFieldValues(leftValue: unknown, rightValue: unknown, direction: "asc" | "desc") {
+  if (leftValue === rightValue) {
+    return 0;
+  }
+  if (isNullable(leftValue)) {
+    return direction === "desc" ? 1 : -1;
+  }
+  if (isNullable(rightValue)) {
+    return direction === "desc" ? -1 : 1;
+  }
+  if (leftValue < rightValue) {
+    return direction === "desc" ? 1 : -1;
+  }
+  return direction === "desc" ? -1 : 1;
+}
+
 function matchesFilters(row: Record<string, unknown>, url: URL) {
   for (const [key, value] of url.searchParams.entries()) {
     if (["select", "order", "limit", "offset", "columns", "on_conflict"].includes(key)) {
       continue;
     }
-
     if (!value.startsWith("eq.")) {
       continue;
     }
-
     if (String(row[key]) !== value.slice(3)) {
       return false;
     }
@@ -445,17 +463,12 @@ function sortRows<T extends Record<string, unknown>>(rows: T[], url: URL) {
 
   return [...rows].sort((left, right) => {
     for (const orderParam of orderParams) {
-      const [column, direction = "asc"] = orderParam.split(".");
-      const leftValue = left[column];
-      const rightValue = right[column];
-      if (leftValue === rightValue) {
-        continue;
+      const [column, rawDirection = "asc"] = orderParam.split(".");
+      const direction = rawDirection === "desc" ? "desc" : "asc";
+      const comparison = compareFieldValues(left[column], right[column], direction);
+      if (comparison !== 0) {
+        return comparison;
       }
-
-      if (leftValue === null || leftValue === undefined) return direction === "desc" ? 1 : -1;
-      if (rightValue === null || rightValue === undefined) return direction === "desc" ? -1 : 1;
-      if (leftValue < rightValue) return direction === "desc" ? 1 : -1;
-      if (leftValue > rightValue) return direction === "desc" ? -1 : 1;
     }
 
     return 0;
@@ -499,6 +512,37 @@ function createSessionResponse() {
   };
 }
 
+function buildContentRange(length: number) {
+  return `0-${Math.max(length - 1, 0)}/${length}`;
+}
+
+function respondWithRows(
+  req: IncomingMessage,
+  res: ServerResponse,
+  rows: Record<string, unknown>[],
+  status = 200,
+) {
+  const response = buildJsonResponseRows(req, rows, status);
+  json(res, response.status, response.body, {
+    "content-range": buildContentRange(rows.length),
+  });
+}
+
+function respondWithRepresentation(
+  req: IncomingMessage,
+  res: ServerResponse,
+  rows: Record<string, unknown>[],
+  created = false,
+) {
+  if (!shouldReturnRepresentation(req)) {
+    noContent(res, created ? 201 : 204);
+    return;
+  }
+
+  const response = buildJsonResponseRows(req, rows, created ? 201 : 200);
+  json(res, response.status, response.body);
+}
+
 function materializeBacklogRows(url: URL) {
   return sortRows(
     Array.from(backlogItems.values())
@@ -517,49 +561,143 @@ function materializeBacklogRows(url: URL) {
   );
 }
 
-function createSearchText(title: string) {
-  return title.trim().toLowerCase();
+function resolveTmdbWorkType(target: Record<string, unknown>) {
+  if (target.workType === "season") {
+    return "season";
+  }
+  if (target.workType === "series") {
+    return "series";
+  }
+  return "movie";
+}
+
+function readStringValue(target: Record<string, unknown>, key: string, fallback: string) {
+  return typeof target[key] === "string" ? (target[key] as string) : fallback;
+}
+
+function readNullableStringValue(
+  target: Record<string, unknown>,
+  key: string,
+  fallback: string | null,
+) {
+  const value = target[key];
+  return typeof value === "string" || value === null ? value : fallback;
+}
+
+function readNullableNumberValue(target: Record<string, unknown>, key: string) {
+  return typeof target[key] === "number" ? (target[key] as number) : null;
 }
 
 function createTmdbWorkDetails(target: Record<string, unknown>) {
-  const workType =
-    target.workType === "season" ? "season" : target.workType === "series" ? "series" : "movie";
-  const releaseDate = typeof target.releaseDate === "string" ? target.releaseDate : "2025-02-02";
-  const title = typeof target.title === "string" ? target.title : "テスト作品";
-  const originalTitle =
-    typeof target.originalTitle === "string" || target.originalTitle === null
-      ? target.originalTitle
-      : "Test Work";
+  const workType = resolveTmdbWorkType(target);
+  const isMovie = workType === "movie";
 
   return {
-    tmdbId: typeof target.tmdbId === "number" ? target.tmdbId : 777002,
+    tmdbId: readNullableNumberValue(target, "tmdbId") ?? 777002,
     tmdbMediaType: target.tmdbMediaType === "tv" ? "tv" : "movie",
     workType,
-    title,
-    originalTitle,
-    overview:
-      typeof target.overview === "string" || target.overview === null
-        ? target.overview
-        : "overview",
-    posterPath:
-      typeof target.posterPath === "string" || target.posterPath === null
-        ? target.posterPath
-        : null,
-    releaseDate,
-    genres: workType === "movie" ? ["Drama"] : ["Drama", "Crime"],
-    runtimeMinutes: workType === "movie" ? 110 : null,
-    typicalEpisodeRuntimeMinutes: workType === "movie" ? null : 47,
-    episodeCount: typeof target.episodeCount === "number" ? target.episodeCount : null,
+    title: readStringValue(target, "title", DEFAULT_WORK_TITLE),
+    originalTitle: readNullableStringValue(target, "originalTitle", DEFAULT_WORK_ORIGINAL_TITLE),
+    overview: readNullableStringValue(target, "overview", DEFAULT_WORK_OVERVIEW),
+    posterPath: readNullableStringValue(target, "posterPath", null),
+    releaseDate: readStringValue(target, "releaseDate", DEFAULT_RELEASE_DATE),
+    genres: isMovie ? ["Drama"] : ["Drama", "Crime"],
+    runtimeMinutes: isMovie ? 110 : null,
+    typicalEpisodeRuntimeMinutes: isMovie ? null : 47,
+    episodeCount: readNullableNumberValue(target, "episodeCount"),
     seasonCount: workType === "series" ? 3 : null,
-    seasonNumber: typeof target.seasonNumber === "number" ? target.seasonNumber : null,
-    imdbId: "tt7654321",
+    seasonNumber: readNullableNumberValue(target, "seasonNumber"),
+    imdbId: DEFAULT_IMDB_ID,
   };
+}
+
+function buildWorkRow(row: Partial<Work>) {
+  const id = row.id ?? `mock-work-${nextWorkId++}`;
+  return createWork({
+    id,
+    created_by: row.created_by ?? TEST_USER_ID,
+    source_type: row.source_type ?? "manual",
+    work_type: row.work_type ?? "movie",
+    tmdb_media_type: row.tmdb_media_type ?? null,
+    tmdb_id: row.tmdb_id ?? null,
+    parent_work_id: row.parent_work_id ?? null,
+    title: row.title ?? "",
+    original_title: row.original_title ?? null,
+    search_text: row.search_text ?? createSearchText(row.title ?? ""),
+    overview: row.overview ?? null,
+    poster_path: row.poster_path ?? null,
+    release_date: row.release_date ?? null,
+    runtime_minutes: row.runtime_minutes ?? null,
+    typical_episode_runtime_minutes: row.typical_episode_runtime_minutes ?? null,
+    duration_bucket: row.duration_bucket ?? null,
+    episode_count: row.episode_count ?? null,
+    season_count: row.season_count ?? null,
+    season_number: row.season_number ?? null,
+    genres: row.genres ?? [],
+    focus_required_score: row.focus_required_score ?? null,
+    background_fit_score: row.background_fit_score ?? null,
+    completion_load_score: row.completion_load_score ?? null,
+    imdb_id: row.imdb_id ?? null,
+    omdb_fetched_at: row.omdb_fetched_at ?? null,
+    rotten_tomatoes_score: row.rotten_tomatoes_score ?? null,
+    imdb_rating: row.imdb_rating ?? null,
+    imdb_votes: row.imdb_votes ?? null,
+    metacritic_score: row.metacritic_score ?? null,
+    last_tmdb_synced_at: row.last_tmdb_synced_at ?? null,
+    series_title: row.series_title ?? null,
+  });
+}
+
+function buildBacklogItemRow(row: Partial<BacklogItem>) {
+  return createBacklogItem({
+    id: row.id ?? `mock-backlog-item-${nextBacklogItemId++}`,
+    user_id: row.user_id ?? TEST_USER_ID,
+    work_id: row.work_id ?? "work-manual-movie",
+    status: row.status ?? "stacked",
+    primary_platform: row.primary_platform ?? null,
+    note: row.note ?? null,
+    sort_order: row.sort_order ?? 1000,
+    display_title: row.display_title ?? null,
+    created_at: row.created_at ?? new Date().toISOString(),
+  });
+}
+
+function hasWorkConflict(row: Work) {
+  return Array.from(works.values()).some(
+    (work) =>
+      work.created_by === row.created_by &&
+      work.source_type === row.source_type &&
+      work.work_type === row.work_type &&
+      work.search_text === row.search_text,
+  );
+}
+
+function findWork(url: URL) {
+  return Array.from(works.values()).find((work) => matchesFilters(work, url));
+}
+
+function findBacklogItem(url: URL) {
+  return Array.from(backlogItems.values()).find((item) => matchesFilters(item, url));
+}
+
+function upsertBacklogRows(rows: BacklogItem[]) {
+  rows.forEach((row) => {
+    const existing = Array.from(backlogItems.values()).find(
+      (item) => item.user_id === row.user_id && item.work_id === row.work_id,
+    );
+    backlogItems.set(existing?.id ?? row.id, {
+      ...existing,
+      ...row,
+      id: existing?.id ?? row.id,
+      created_at: existing?.created_at ?? row.created_at,
+    });
+  });
 }
 
 async function handleAuth(req: IncomingMessage, res: ServerResponse, url: URL) {
   if (req.method === "POST" && url.pathname === "/auth/v1/token") {
     const body = (await readJson(req)) as { email?: string; password?: string } | null;
-    if (body?.email !== TEST_USER_EMAIL || body?.password !== TEST_USER_PASSWORD) {
+    if (body?.email !== TEST_USER_EMAIL || body?.password !== TEST_USER_SECRET) {
       json(res, 400, { error: "invalid_grant", error_description: "Invalid login credentials" });
       return true;
     }
@@ -581,202 +719,207 @@ async function handleAuth(req: IncomingMessage, res: ServerResponse, url: URL) {
   return false;
 }
 
-async function handleRest(req: IncomingMessage, res: ServerResponse, url: URL) {
-  if (req.method === "GET" && url.pathname === "/rest/v1/backlog_items") {
-    const rows = materializeBacklogRows(url);
-    const response = buildJsonResponseRows(req, rows);
-    json(res, response.status, response.body, {
-      "content-range": `0-${Math.max(rows.length - 1, 0)}/${rows.length}`,
-    });
+function handleGetBacklogItems(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "GET" || url.pathname !== "/rest/v1/backlog_items") {
+    return false;
+  }
+
+  respondWithRows(req, res, materializeBacklogRows(url));
+  return true;
+}
+
+function handleGetWorks(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "GET" || url.pathname !== "/rest/v1/works") {
+    return false;
+  }
+
+  const rows = Array.from(works.values())
+    .filter((work) => matchesFilters(work, url))
+    .map((work) => pickSelectedFields(work, url.searchParams.get("select")));
+  respondWithRows(req, res, rows);
+  return true;
+}
+
+async function handlePostWorks(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "POST" || url.pathname !== "/rest/v1/works") {
+    return false;
+  }
+
+  const payload = (await readJson(req)) as Partial<Work> | Array<Partial<Work>>;
+  const rows = (Array.isArray(payload) ? payload : [payload]).map(buildWorkRow);
+
+  if (!url.searchParams.get("on_conflict") && rows.some(hasWorkConflict)) {
+    json(res, 409, { message: "duplicate key value", code: "23505" });
     return true;
   }
 
-  if (req.method === "GET" && url.pathname === "/rest/v1/works") {
-    const rows = Array.from(works.values())
-      .filter((work) => matchesFilters(work, url))
-      .map((work) => pickSelectedFields(work, url.searchParams.get("select")));
-    const response = buildJsonResponseRows(req, rows);
-    json(res, response.status, response.body, {
-      "content-range": `0-${Math.max(rows.length - 1, 0)}/${rows.length}`,
-    });
+  rows.forEach((row) => {
+    works.set(row.id, row);
+  });
+
+  respondWithRepresentation(
+    req,
+    res,
+    rows.map((row) => pickSelectedFields(row, url.searchParams.get("select"))),
+    true,
+  );
+  return true;
+}
+
+async function handlePatchWorks(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "PATCH" || url.pathname !== "/rest/v1/works") {
+    return false;
+  }
+
+  const body = (await readJson(req)) as Partial<Work>;
+  const target = findWork(url);
+  if (!target) {
+    json(res, 404, { message: "Work not found" });
     return true;
   }
 
-  if (req.method === "POST" && url.pathname === "/rest/v1/works") {
-    const payload = (await readJson(req)) as Partial<Work> | Array<Partial<Work>>;
-    const rows = (Array.isArray(payload) ? payload : [payload]).map((row) => {
-      const id = row.id ?? `mock-work-${nextWorkId++}`;
-      const createdBy = row.created_by ?? TEST_USER_ID;
-      return {
-        id,
-        created_by: createdBy,
-        source_type: row.source_type ?? "manual",
-        tmdb_media_type: row.tmdb_media_type ?? null,
-        tmdb_id: row.tmdb_id ?? null,
-        work_type: row.work_type ?? "movie",
-        parent_work_id: row.parent_work_id ?? null,
-        title: row.title ?? "",
-        original_title: row.original_title ?? null,
-        search_text: row.search_text ?? createSearchText(row.title ?? ""),
-        overview: row.overview ?? null,
-        poster_path: row.poster_path ?? null,
-        release_date: row.release_date ?? null,
-        runtime_minutes: row.runtime_minutes ?? null,
-        typical_episode_runtime_minutes: row.typical_episode_runtime_minutes ?? null,
-        duration_bucket: row.duration_bucket ?? null,
-        episode_count: row.episode_count ?? null,
-        season_count: row.season_count ?? null,
-        season_number: row.season_number ?? null,
-        genres: row.genres ?? [],
-        focus_required_score: row.focus_required_score ?? null,
-        background_fit_score: row.background_fit_score ?? null,
-        completion_load_score: row.completion_load_score ?? null,
-        imdb_id: row.imdb_id ?? null,
-        omdb_fetched_at: row.omdb_fetched_at ?? null,
-        rotten_tomatoes_score: row.rotten_tomatoes_score ?? null,
-        imdb_rating: row.imdb_rating ?? null,
-        imdb_votes: row.imdb_votes ?? null,
-        metacritic_score: row.metacritic_score ?? null,
-        last_tmdb_synced_at: row.last_tmdb_synced_at ?? null,
-        series_title: row.series_title ?? null,
-      } satisfies Work;
-    });
+  const updated = createWork({
+    ...target,
+    ...body,
+    id: target.id,
+    title: body.title ?? target.title,
+  });
+  works.set(updated.id, updated);
+  respondWithRepresentation(req, res, [
+    pickSelectedFields(updated, url.searchParams.get("select")),
+  ]);
+  return true;
+}
 
-    const hasConflict = rows.some((row) =>
-      Array.from(works.values()).some(
-        (work) =>
-          work.created_by === row.created_by &&
-          work.source_type === row.source_type &&
-          work.work_type === row.work_type &&
-          work.search_text === row.search_text,
-      ),
-    );
+async function handlePostBacklogItems(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "POST" || url.pathname !== "/rest/v1/backlog_items") {
+    return false;
+  }
 
-    if (!url.searchParams.get("on_conflict") && hasConflict) {
-      json(res, 409, { message: "duplicate key value", code: "23505" });
-      return true;
-    }
+  const payload = (await readJson(req)) as Partial<BacklogItem> | Array<Partial<BacklogItem>>;
+  const rows = (Array.isArray(payload) ? payload : [payload]).map(buildBacklogItemRow);
 
+  if (url.searchParams.get("on_conflict") === "user_id,work_id") {
+    upsertBacklogRows(rows);
+  } else {
     rows.forEach((row) => {
-      works.set(row.id, row);
+      backlogItems.set(row.id, row);
     });
+  }
 
-    if (!shouldReturnRepresentation(req)) {
-      noContent(res, 201);
-      return true;
-    }
+  respondWithRepresentation(req, res, rows, true);
+  return true;
+}
 
-    const response = buildJsonResponseRows(
-      req,
-      rows.map((row) => pickSelectedFields(row, url.searchParams.get("select"))),
-      201,
-    );
-    json(res, response.status, response.body);
+async function handlePatchBacklogItems(req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (req.method !== "PATCH" || url.pathname !== "/rest/v1/backlog_items") {
+    return false;
+  }
+
+  const body = (await readJson(req)) as Partial<BacklogItem>;
+  const target = findBacklogItem(url);
+  if (!target) {
+    json(res, 404, { message: "Backlog item not found" });
     return true;
   }
 
-  if (req.method === "PATCH" && url.pathname === "/rest/v1/works") {
-    const body = (await readJson(req)) as Partial<Work>;
-    const target = Array.from(works.values()).find((work) => matchesFilters(work, url));
+  const updated = createBacklogItem({
+    ...target,
+    ...body,
+    id: target.id,
+    work_id: target.work_id,
+    status: body.status ?? target.status,
+    created_at: target.created_at,
+  });
+  backlogItems.set(updated.id, updated);
+  respondWithRepresentation(req, res, [updated]);
+  return true;
+}
 
-    if (!target) {
-      json(res, 404, { message: "Work not found" });
-      return true;
-    }
-
-    const updated = { ...target, ...body };
-    works.set(updated.id, updated);
-
-    if (!shouldReturnRepresentation(req)) {
-      noContent(res);
-      return true;
-    }
-
-    json(res, 200, [pickSelectedFields(updated, url.searchParams.get("select"))]);
-    return true;
+function handleDeleteBacklogItems(_req: IncomingMessage, res: ServerResponse, url: URL) {
+  if (_req.method !== "DELETE" || url.pathname !== "/rest/v1/backlog_items") {
+    return false;
   }
 
-  if (req.method === "POST" && url.pathname === "/rest/v1/backlog_items") {
-    const payload = (await readJson(req)) as Partial<BacklogItem> | Array<Partial<BacklogItem>>;
-    const rows = (Array.isArray(payload) ? payload : [payload]).map(
-      (row) =>
-        ({
-          id: row.id ?? `mock-backlog-item-${nextBacklogItemId++}`,
-          user_id: row.user_id ?? TEST_USER_ID,
-          work_id: row.work_id ?? "work-manual-movie",
-          status: row.status ?? "stacked",
-          primary_platform: row.primary_platform ?? null,
-          note: row.note ?? null,
-          sort_order: row.sort_order ?? 1000,
-          display_title: row.display_title ?? null,
-          created_at: row.created_at ?? new Date().toISOString(),
-        }) satisfies BacklogItem,
-    );
-
-    if (url.searchParams.get("on_conflict") === "user_id,work_id") {
-      rows.forEach((row) => {
-        const existing = Array.from(backlogItems.values()).find(
-          (item) => item.user_id === row.user_id && item.work_id === row.work_id,
-        );
-        backlogItems.set(existing?.id ?? row.id, {
-          ...existing,
-          ...row,
-          id: existing?.id ?? row.id,
-          created_at: existing?.created_at ?? row.created_at,
-        });
-      });
-    } else {
-      rows.forEach((row) => {
-        backlogItems.set(row.id, row);
-      });
-    }
-
-    if (!shouldReturnRepresentation(req)) {
-      noContent(res, 201);
-      return true;
-    }
-
-    const response = buildJsonResponseRows(req, rows, 201);
-    json(res, response.status, response.body);
-    return true;
-  }
-
-  if (req.method === "PATCH" && url.pathname === "/rest/v1/backlog_items") {
-    const body = (await readJson(req)) as Partial<BacklogItem>;
-    const target = Array.from(backlogItems.values()).find((item) => matchesFilters(item, url));
-
-    if (!target) {
-      json(res, 404, { message: "Backlog item not found" });
-      return true;
-    }
-
-    const updated = { ...target, ...body };
-    backlogItems.set(updated.id, updated);
-
-    if (!shouldReturnRepresentation(req)) {
-      noContent(res);
-      return true;
-    }
-
-    json(res, 200, [updated]);
-    return true;
-  }
-
-  if (req.method === "DELETE" && url.pathname === "/rest/v1/backlog_items") {
-    const target = Array.from(backlogItems.values()).find((item) => matchesFilters(item, url));
-
-    if (!target) {
-      noContent(res);
-      return true;
-    }
-
-    backlogItems.delete(target.id);
+  const target = findBacklogItem(url);
+  if (!target) {
     noContent(res);
     return true;
   }
 
+  backlogItems.delete(target.id);
+  noContent(res);
+  return true;
+}
+
+async function handleRest(req: IncomingMessage, res: ServerResponse, url: URL) {
+  const handlers: RouteHandler[] = [
+    handleGetBacklogItems,
+    handleGetWorks,
+    handlePostWorks,
+    handlePatchWorks,
+    handlePostBacklogItems,
+    handlePatchBacklogItems,
+    handleDeleteBacklogItems,
+  ];
+
+  for (const handler of handlers) {
+    if (await handler(req, res, url)) {
+      return true;
+    }
+  }
+
   return false;
 }
+
+const functionResponses: Record<string, (body: Record<string, unknown>) => unknown> = {
+  "fetch-tmdb-trending": () => [
+    {
+      tmdbId: 777001,
+      tmdbMediaType: "movie",
+      workType: "movie",
+      title: "おすすめ作品",
+      originalTitle: "Recommended Work",
+      overview: "initial recommendation",
+      posterPath: null,
+      releaseDate: "2024-01-01",
+      jpWatchPlatforms: [],
+      hasJapaneseRelease: true,
+    },
+  ],
+  "fetch-tmdb-similar": () => [],
+  "search-tmdb-works": (body) => {
+    const query = typeof body.query === "string" ? body.query.trim() : "";
+    if (!query) {
+      return [];
+    }
+
+    return [
+      {
+        tmdbId: 777002,
+        tmdbMediaType: "movie",
+        workType: "movie",
+        title: `検索結果 ${query}`.trim(),
+        originalTitle: "Search Result",
+        overview: "search result overview",
+        posterPath: null,
+        releaseDate: DEFAULT_RELEASE_DATE,
+        jpWatchPlatforms: [],
+        hasJapaneseRelease: true,
+      },
+    ];
+  },
+  "fetch-tmdb-season-options": () => [],
+  "fetch-tmdb-work-details": (body) =>
+    createTmdbWorkDetails((body.target as Record<string, unknown>) ?? {}),
+  "suggest-display-title": () => ({ title: null }),
+  "fetch-omdb-work-details": () => ({
+    rottenTomatoesScore: 96,
+    imdbRating: 9.5,
+    imdbVotes: 2300000,
+    metacriticScore: 87,
+  }),
+};
 
 async function handleFunctions(req: IncomingMessage, res: ServerResponse, url: URL) {
   if (req.method !== "POST" || !url.pathname.startsWith("/functions/v1/")) {
@@ -785,81 +928,14 @@ async function handleFunctions(req: IncomingMessage, res: ServerResponse, url: U
 
   const body = ((await readJson(req)) ?? {}) as Record<string, unknown>;
   const functionName = url.pathname.replace("/functions/v1/", "");
+  const responder = functionResponses[functionName];
 
-  if (functionName === "fetch-tmdb-trending") {
-    json(res, 200, [
-      {
-        tmdbId: 777001,
-        tmdbMediaType: "movie",
-        workType: "movie",
-        title: "おすすめ作品",
-        originalTitle: "Recommended Work",
-        overview: "initial recommendation",
-        posterPath: null,
-        releaseDate: "2024-01-01",
-        jpWatchPlatforms: [],
-        hasJapaneseRelease: true,
-      },
-    ]);
+  if (!responder) {
+    json(res, 404, { error: `Unknown function: ${functionName}` });
     return true;
   }
 
-  if (functionName === "fetch-tmdb-similar") {
-    json(res, 200, []);
-    return true;
-  }
-
-  if (functionName === "search-tmdb-works") {
-    const query = typeof body.query === "string" ? body.query.trim() : "";
-    json(
-      res,
-      200,
-      query
-        ? [
-            {
-              tmdbId: 777002,
-              tmdbMediaType: "movie",
-              workType: "movie",
-              title: `検索結果 ${query}`.trim(),
-              originalTitle: "Search Result",
-              overview: "search result overview",
-              posterPath: null,
-              releaseDate: "2025-02-02",
-              jpWatchPlatforms: [],
-              hasJapaneseRelease: true,
-            },
-          ]
-        : [],
-    );
-    return true;
-  }
-
-  if (functionName === "fetch-tmdb-season-options") {
-    json(res, 200, []);
-    return true;
-  }
-
-  if (functionName === "fetch-tmdb-work-details") {
-    json(res, 200, createTmdbWorkDetails((body.target as Record<string, unknown>) ?? {}));
-    return true;
-  }
-
-  if (functionName === "suggest-display-title") {
-    json(res, 200, { title: null });
-    return true;
-  }
-
-  if (functionName === "fetch-omdb-work-details") {
-    json(res, 200, {
-      rottenTomatoesScore: 96,
-      imdbRating: 9.5,
-      imdbVotes: 2300000,
-      metacriticScore: 87,
-    });
-    return true;
-  }
-
-  json(res, 404, { error: `Unknown function: ${functionName}` });
+  json(res, 200, responder(body));
   return true;
 }
 

--- a/e2e/playwright-shared.ts
+++ b/e2e/playwright-shared.ts
@@ -1,0 +1,57 @@
+import { devices, type PlaywrightTestConfig } from "@playwright/test";
+
+const baseUrl = "http://localhost:5173";
+
+export function createSharedPlaywrightConfig(): Pick<
+  PlaywrightTestConfig,
+  | "testDir"
+  | "testMatch"
+  | "fullyParallel"
+  | "forbidOnly"
+  | "retries"
+  | "workers"
+  | "reporter"
+  | "use"
+  | "projects"
+> {
+  return {
+    testDir: "./e2e",
+    testMatch: "**/*.spec.ts",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 2 : undefined,
+    reporter: "html",
+    use: {
+      baseURL: baseUrl,
+      storageState: "e2e/.auth/user.json",
+      trace: "on-first-retry",
+      screenshot: "only-on-failure",
+      video: "retain-on-failure",
+    },
+    projects: [
+      {
+        name: "chromium",
+        use: { ...devices["Desktop Chrome"] },
+      },
+      {
+        name: "firefox",
+        use: { ...devices["Desktop Firefox"] },
+      },
+      {
+        name: "webkit",
+        use: { ...devices["Desktop Safari"] },
+      },
+      {
+        name: "Mobile Chrome",
+        use: { ...devices["Pixel 5"] },
+      },
+    ],
+  };
+}
+
+export function createPreviewCommand(supabaseUrl: string) {
+  return `bash -lc 'VITE_SUPABASE_URL=${supabaseUrl} vp build && VITE_SUPABASE_URL=${supabaseUrl} vp preview --host 127.0.0.1 --port 5173'`;
+}
+
+export const playwrightBaseUrl = baseUrl;

--- a/e2e/spec/regression-flow.spec.ts
+++ b/e2e/spec/regression-flow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   addManualWork,
   buildUniqueTitle,
+  closeDetailModal,
   deleteCard,
   dragCardToColumn,
   getCardInColumn,
@@ -19,7 +20,7 @@ test("手動追加したカードを編集して列移動し、最後に削除�
   const stackedCard = getCardInColumn(page, "stacked", title);
   await stackedCard.click();
 
-  const detailModal = page.getByRole("dialog");
+  const detailModal = page.getByRole("dialog", { name: title });
   await expect(detailModal).toBeVisible();
 
   await detailModal.getByRole("button", { name: "メモを追加" }).click();
@@ -30,15 +31,21 @@ test("手動追加したカードを編集して列移動し、最後に削除�
   await expect(detailModal.getByText(note)).toBeVisible();
   await detailModal.getByRole("button", { name: "Netflix" }).click();
 
-  await page.keyboard.press("Escape");
-  await expect(detailModal).not.toBeVisible();
+  await closeDetailModal(page, title);
 
   await page.reload();
   const reloadedStackedCard = getCardInColumn(page, "stacked", title);
   await expect(reloadedStackedCard).toBeVisible();
   await expect(reloadedStackedCard.getByText(note, { exact: true })).toBeVisible();
 
+  const persistMove = page.waitForResponse(
+    (response) =>
+      response.request().method() === "PATCH" &&
+      response.url().includes("/rest/v1/backlog_items") &&
+      response.ok(),
+  );
   await dragCardToColumn(page, reloadedStackedCard, "want_to_watch");
+  await persistMove;
   await expect(getCardInColumn(page, "want_to_watch", title)).toBeVisible();
   await expect(getCardInColumn(page, "stacked", title)).toHaveCount(0);
 

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -1,14 +1,13 @@
 import { expect, type Locator, type Page, type TestInfo } from "@playwright/test";
 
 const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || "akari@example.com";
-const TEST_USER_PASSWORD =
-  process.env.TEST_USER_PASSWORD || process.env.TEST_USER_SECRET || "ci-login-token";
+const TEST_USER_SECRET = process.env.TEST_USER_SECRET || "ci-login-token";
 
 export async function login(page: Page) {
   await page.goto("/");
   const submitButton = page.locator('form button[type="submit"]');
   await page.getByLabel("メールアドレス").fill(TEST_USER_EMAIL);
-  await page.getByLabel("パスワード").fill(TEST_USER_PASSWORD);
+  await page.getByLabel("パスワード").fill(TEST_USER_SECRET);
   await submitButton.click();
   await expect(page.getByRole("button", { name: "作品を検索してストックに追加" })).toBeVisible();
 }

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -39,6 +39,14 @@ export async function addManualWork(page: Page, title: string) {
   await expect(getCardInColumn(page, "stacked", title)).toBeVisible();
 }
 
+export async function closeDetailModal(page: Page, title: string) {
+  const dialog = page.getByRole("dialog", { name: title });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("textbox")).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await expect(dialog).not.toBeVisible();
+}
+
 export async function deleteCard(page: Page, status: string, title: string) {
   const card = getCardInColumn(page, status, title);
   await expect(card).toBeVisible();

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -1,7 +1,8 @@
 import { expect, type Locator, type Page, type TestInfo } from "@playwright/test";
 
 const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || "akari@example.com";
-const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD || "password123";
+const TEST_USER_PASSWORD =
+  process.env.TEST_USER_PASSWORD || process.env.TEST_USER_SECRET || "ci-login-token";
 
 export async function login(page: Page) {
   await page.goto("/");

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["supabase/functions/*/index.ts", "supabase/functions/**/*_test.ts"],
+  "entry": [
+    "supabase/functions/*/index.ts",
+    "supabase/functions/**/*_test.ts",
+    "playwright.integration.config.ts",
+    "e2e/global-setup.ts",
+    "e2e/mock-supabase-server.ts"
+  ],
   "project": [
     "src/**/*.{ts,tsx}",
     "supabase/functions/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "prepare": "vp config",
     "test": "vp exec vitest",
     "test:coverage": "vp exec vitest --coverage",
-    "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui",
-    "test:e2e:debug": "playwright test --debug",
+    "test:e2e": "vp exec playwright test",
+    "test:e2e:integration": "vp exec playwright test --config=playwright.integration.config.ts",
+    "test:e2e:ui": "vp exec playwright test --ui",
+    "test:e2e:debug": "vp exec playwright test --debug",
     "knip": "vp exec knip"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,10 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig } from "@playwright/test";
+
+import {
+  createPreviewCommand,
+  createSharedPlaywrightConfig,
+  playwrightBaseUrl,
+} from "./e2e/playwright-shared.ts";
 
 const mockSupabasePort = process.env.MOCK_SUPABASE_PORT || "55432";
 const mockSupabaseUrl = `http://127.0.0.1:${mockSupabasePort}`;
@@ -11,71 +17,8 @@ process.env.TEST_USER_SECRET ??= "ci-login-token";
  * 本物の Supabase を使う統合確認は `playwright.integration.config.ts` 側で扱う。
  */
 export default defineConfig({
-  testDir: "./e2e",
-  testMatch: "**/*.spec.ts",
+  ...createSharedPlaywrightConfig(),
   globalSetup: "./e2e/global-setup-mock.ts",
-
-  /* Run tests in files in parallel */
-  fullyParallel: true,
-
-  /* Fail the build on CI if you accidentally left test.only in the source code */
-  forbidOnly: !!process.env.CI,
-
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-
-  /* Keep CI deterministic enough while avoiding fully serial E2E execution */
-  workers: process.env.CI ? 2 : undefined,
-
-  /* Reporter to use */
-  reporter: "html",
-
-  /* Shared settings for all the projects below */
-  use: {
-    /* Base URL to use in actions like `await page.goto('/')` */
-    baseURL: "http://localhost:5173",
-
-    /* Reuse authenticated session for all tests by default */
-    storageState: "e2e/.auth/user.json",
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
-
-    /* Screenshot on failure */
-    screenshot: "only-on-failure",
-
-    /* Video on failure */
-    video: "retain-on-failure",
-  },
-
-  projects: [
-    // ── 必須ライン（CI で常時実行） ──────────────────────────────────────
-    // 更新系フロー（追加・編集・列移動・削除）は chromium のみで担保する。
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-
-    // ── 任意ライン（手動 QA・必要時の追加確認） ──────────────────────────
-    // 通常の CI チェックには含めない。
-    // ローカルで `vp test:e2e -- --project firefox` のように個別実行する。
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
-
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
-
-    // モバイル回帰は Mobile Chrome 1 本に絞る。
-    // 確認内容はタブ切り替えや導線確認など閲覧系に限定する。
-    {
-      name: "Mobile Chrome",
-      use: { ...devices["Pixel 5"] },
-    },
-  ],
 
   webServer: [
     {
@@ -84,8 +27,8 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: `bash -lc 'VITE_SUPABASE_URL=${mockSupabaseUrl} vp build && VITE_SUPABASE_URL=${mockSupabaseUrl} vp preview --host 127.0.0.1 --port 5173'`,
-      url: "http://localhost:5173",
+      command: createPreviewCommand(mockSupabaseUrl),
+      url: playwrightBaseUrl,
       reuseExistingServer: !process.env.CI,
     },
   ],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const mockSupabasePort = process.env.MOCK_SUPABASE_PORT || "55432";
 const mockSupabaseUrl = `http://127.0.0.1:${mockSupabasePort}`;
+process.env.TEST_USER_SECRET ??= "ci-login-token";
 
 /**
  * Playwright configuration for PR browser tests.
@@ -83,7 +84,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: `zsh -lc 'VITE_SUPABASE_URL=${mockSupabaseUrl} vp build && VITE_SUPABASE_URL=${mockSupabaseUrl} vp preview --host 127.0.0.1 --port 5173'`,
+      command: `bash -lc 'VITE_SUPABASE_URL=${mockSupabaseUrl} vp build && VITE_SUPABASE_URL=${mockSupabaseUrl} vp preview --host 127.0.0.1 --port 5173'`,
       url: "http://localhost:5173",
       reuseExistingServer: !process.env.CI,
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,21 +1,18 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const mockSupabasePort = process.env.MOCK_SUPABASE_PORT || "55432";
+const mockSupabaseUrl = `http://127.0.0.1:${mockSupabasePort}`;
+
 /**
- * Playwright configuration for E2E testing
- * See https://playwright.dev/docs/test-configuration
+ * Playwright configuration for PR browser tests.
  *
- * Project ライン:
- *   必須ライン（CI で常時実行）: chromium
- *   任意ライン（手動 QA・必要時の追加確認）: firefox, webkit, Mobile Chrome
- *
- * CI では `--project chromium` のみを実行する。
- * firefox / webkit / Mobile Chrome は `pnpm test:e2e` でローカル確認するか、
- * 必要なときに `pnpm test:e2e --project firefox` のように個別に実行する。
+ * PR では Supabase の mock backend を併用して高速な browser test を回す。
+ * 本物の Supabase を使う統合確認は `playwright.integration.config.ts` 側で扱う。
  */
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "**/*.spec.ts",
-  globalSetup: "./e2e/global-setup.ts",
+  globalSetup: "./e2e/global-setup-mock.ts",
 
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -60,7 +57,7 @@ export default defineConfig({
 
     // ── 任意ライン（手動 QA・必要時の追加確認） ──────────────────────────
     // 通常の CI チェックには含めない。
-    // ローカルで `pnpm test:e2e --project firefox` のように個別実行する。
+    // ローカルで `vp test:e2e -- --project firefox` のように個別実行する。
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] },
@@ -79,10 +76,16 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "vp dev",
-    url: "http://localhost:5173",
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: [
+    {
+      command: `MOCK_SUPABASE_PORT=${mockSupabasePort} vp exec node --experimental-strip-types e2e/mock-supabase-server.ts`,
+      url: `${mockSupabaseUrl}/health`,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: `zsh -lc 'VITE_SUPABASE_URL=${mockSupabaseUrl} vp build && VITE_SUPABASE_URL=${mockSupabaseUrl} vp preview --host 127.0.0.1 --port 5173'`,
+      url: "http://localhost:5173",
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
 });

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-process.env.TEST_USER_PASSWORD ??= "password123";
+process.env.TEST_USER_SECRET ??= "password123";
 
 export default defineConfig({
   testDir: "./e2e",

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,44 +1,15 @@
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig } from "@playwright/test";
+
+import { createSharedPlaywrightConfig, playwrightBaseUrl } from "./e2e/playwright-shared.ts";
 
 process.env.TEST_USER_SECRET ??= "password123";
 
 export default defineConfig({
-  testDir: "./e2e",
-  testMatch: "**/*.spec.ts",
+  ...createSharedPlaywrightConfig(),
   globalSetup: "./e2e/global-setup.ts",
-  fullyParallel: true,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : undefined,
-  reporter: "html",
-  use: {
-    baseURL: "http://localhost:5173",
-    storageState: "e2e/.auth/user.json",
-    trace: "on-first-retry",
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-  },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
-    {
-      name: "Mobile Chrome",
-      use: { ...devices["Pixel 5"] },
-    },
-  ],
   webServer: {
     command: "vp dev",
-    url: "http://localhost:5173",
+    url: playwrightBaseUrl,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  globalSetup: "./e2e/global-setup.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    storageState: "e2e/.auth/user.json",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+    {
+      name: "Mobile Chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+  webServer: {
+    command: "vp dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/playwright.integration.config.ts
+++ b/playwright.integration.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+process.env.TEST_USER_PASSWORD ??= "password123";
+
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "**/*.spec.ts",


### PR DESCRIPTION
## 関連 Issue

<!-- 関連 Issue があれば Refs #123 または Closes #123 の形式で記載 -->

## 変更内容

- PR の常時実行 E2E を、本物 Supabase 起動ありの統合テストから mock backend を使う高速 browser test に切り替え
- deploy 用に `main` push / 手動実行で本物 Supabase を立ち上げる `Deploy E2E` workflow を追加し、auth と更新系回帰だけを少数統合 test として実行
- mock backend 用の Playwright 設定、auth storage state、Supabase 互換の軽量 mock server を追加
- 更新系 E2E の待機条件を補強し、detail modal close と DnD 永続化待ちを安定化
- Playwright 実行 script を `vp exec playwright` に統一し、browser cache key を lockfile 依存から Playwright 設定 / package.json ベースへ調整
