### PR TITLE
fix: quality report 優先項目の修正

### DIFF
--- a/src/features/backlog/hooks/useAddSubmit.test.tsx
+++ b/src/features/backlog/hooks/useAddSubmit.test.tsx
@@ -64,7 +64,7 @@ function HookHarness({
   selectedSeasonNumbers = [],
   onClose = vi.fn(),
   onAdded = vi.fn(),
-}: HarnessProps) {
+}: Readonly<HarnessProps>) {
   const {
     formMessage,
     pendingSaveMessage,

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -75,7 +75,7 @@ function HookHarness({
   onWorksAdded = vi.fn(),
   results = [createSearchResult()],
   feedback = createToastFeedback(),
-}: {
+}: Readonly<{
   items?: BacklogItem[];
   localItems?: BacklogItem[];
   setLocalItems?: React.Dispatch<React.SetStateAction<BacklogItem[]>>;
@@ -85,7 +85,7 @@ function HookHarness({
   onWorksAdded?: () => void;
   results?: TmdbSearchResult[];
   feedback?: ReturnType<typeof createToastFeedback>;
-}) {
+}>) {
   const { handleDeleteItem, handleAddTmdbWorksToStacked } = useBacklogActions({
     items,
     localItems: localItems ?? items,

--- a/src/features/backlog/hooks/useBacklogItems.test.ts
+++ b/src/features/backlog/hooks/useBacklogItems.test.ts
@@ -76,7 +76,7 @@ describe("useBacklogItems", () => {
       }),
     );
 
-    void result.current.loadItems();
+    result.current.loadItems().catch(() => {});
 
     // 再取得中も isLoading は false のまま（画面が暗転しない）
     expect(result.current.isLoading).toBe(false);

--- a/src/features/backlog/hooks/useBacklogItems.ts
+++ b/src/features/backlog/hooks/useBacklogItems.ts
@@ -13,17 +13,13 @@ export function useBacklogItems(userId: string) {
   const loadItems = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: backlogItemsQueryKey(userId) });
   }, [queryClient, userId]);
+  const error = query.data || !(query.error instanceof Error) ? null : query.error.message;
 
   return {
     items: query.data ?? [],
     isLoading: query.isPending,
     // キャッシュデータがない場合のみエラーを表示（バックグラウンド refetch エラーはキャッシュがあれば無視）
-    error:
-      !query.data && query.error
-        ? query.error instanceof Error
-          ? query.error.message
-          : null
-        : null,
+    error,
     loadItems,
   };
 }

--- a/src/features/backlog/hooks/useBoardPageController.ts
+++ b/src/features/backlog/hooks/useBoardPageController.ts
@@ -80,7 +80,7 @@ export function useBoardPageController({ session }: UseBoardPageControllerOption
       onClose: boardPageState.handleCloseAddModal,
       onAdded: () => {
         boardPageState.handleNavigateToStacked();
-        void loadItems();
+        loadItems().catch(() => {});
       },
     },
     detailModal: {

--- a/src/features/backlog/hooks/useTmdbSearchRequest.ts
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.ts
@@ -210,14 +210,14 @@ export function useTmdbSearchRequest({
       const results = await searchTmdbWorks(trimmed);
       if (requestId !== searchRequestIdRef.current) return;
       const visibleResults = prioritizeLocalizedResults(filterVisibleResults(items, results));
-      dispatchRequest({ type: "set_search_results", results: visibleResults });
-      onSetSearchMessage(
+      const searchMessage =
         visibleResults.length > 0
           ? null
           : results.length > 0
             ? "すでにストック済みの作品は候補から除外しています。"
-            : "候補が見つかりませんでした。このまま入力して追加できます。",
-      );
+            : "候補が見つかりませんでした。このまま入力して追加できます。";
+      dispatchRequest({ type: "set_search_results", results: visibleResults });
+      onSetSearchMessage(searchMessage);
     } catch (error) {
       if (requestId !== searchRequestIdRef.current) return;
       onSetSearchMessage(
@@ -231,7 +231,7 @@ export function useTmdbSearchRequest({
       globalThis.clearTimeout(searchTimerRef.current);
     }
     searchTimerRef.current = globalThis.setTimeout(() => {
-      void runSearch(query);
+      runSearch(query).catch(() => {});
     }, SEARCH_DEBOUNCE_MS);
   };
 

--- a/src/features/backlog/work-metadata.ts
+++ b/src/features/backlog/work-metadata.ts
@@ -86,11 +86,12 @@ export function calcBackgroundFitScore(
   ratings: RatingInfo = DEFAULT_RATING_INFO,
 ): number {
   if (genres.some((genre) => BG_LOW_GENRES.has(genre))) return 0;
-  const genreScore = genres.some((genre) => BG_HIGH_GENRES.has(genre))
-    ? 75
-    : genres.some((genre) => BG_MED_GENRES.has(genre))
-      ? 50
-      : 25;
+  let genreScore = 25;
+  if (genres.some((genre) => BG_HIGH_GENRES.has(genre))) {
+    genreScore = 75;
+  } else if (genres.some((genre) => BG_MED_GENRES.has(genre))) {
+    genreScore = 50;
+  }
   if (genreScore >= 50 && isHighlyRated(ratings)) return 25;
   return genreScore;
 }

--- a/src/test/query-client.tsx
+++ b/src/test/query-client.tsx
@@ -11,7 +11,7 @@ function createTestQueryClient() {
   });
 }
 
-export function TestQueryClientProvider({ children }: { children: ReactNode }) {
+export function TestQueryClientProvider({ children }: Readonly<{ children: ReactNode }>) {
   const queryClient = createTestQueryClient();
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/supabase/functions/_shared/tmdb_test.ts
+++ b/supabase/functions/_shared/tmdb_test.ts
@@ -53,7 +53,7 @@ async function withMockFetch(
 
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
     const url =
-      input instanceof Request ? new URL(input.url) : new URL(input instanceof URL ? input : input);
+      input instanceof Request ? new URL(input.url) : input instanceof URL ? input : new URL(input);
     return await handler(url, init);
   }) as typeof fetch;
 


### PR DESCRIPTION
## 関連 Issue

Refs #255

## 変更内容

- SonarCloud のバグ指摘だった `supabase/functions/_shared/tmdb_test.ts` の URL 変換条件式を修正
- `useBacklogItems` / `useTmdbSearchRequest` / `work-metadata` の nested ternary や `void` 利用を整理
- テスト用 harness / provider の props を readonly 化
- UI 目視確認が必要そうなアクセシビリティ指摘は今回は対象外にして、低リスクな項目に限定

## 検証

- `vp test src/features/backlog/hooks/useBacklogItems.test.ts src/features/backlog/hooks/useAddSubmit.test.tsx src/features/backlog/hooks/useBacklogActions.test.tsx`
- `vp test src/features/backlog/hooks/useBoardPageController.test.tsx src/features/backlog/hooks/useTmdbSearchRequest.test.tsx src/features/backlog/work-metadata.test.ts`

## 未実施

- `supabase/functions/_shared/tmdb_test.ts` の Deno テストはローカルに `deno` ランタイムがなく未実施