### PR TITLE
ci: deploy workflow の追従修正

### DIFF
--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -45,7 +45,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        uses: supabase/setup-cli@2eca1b4d35d9016e560c763c9159a350aa80c370 # v2.0.0 prep
         with:
           version: latest
 

--- a/.github/workflows/deploy-e2e.yml
+++ b/.github/workflows/deploy-e2e.yml
@@ -58,9 +58,9 @@ jobs:
         run: >-
           vp exec playwright test
           --config=playwright.integration.config.ts
-          --project chromium
           e2e/spec/auth.spec.ts
           e2e/spec/regression-flow.spec.ts
+          --project=chromium
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        uses: supabase/setup-cli@2eca1b4d35d9016e560c763c9159a350aa80c370 # v2.0.0 prep
         with:
           version: latest
 


### PR DESCRIPTION
## 関連 Issue

Refs #252

## 変更内容

- deploy E2E workflow の Playwright 実行引数順を修正し、spec パスが project 名として誤解釈されないように変更
- `supabase/setup-cli` を Node 24 / composite action 化済みの upstream commit へ更新し、GitHub Actions の Node 20 deprecation annotation を解消
- `deploy-e2e.yml` と `deploy-functions.yml` の両方で同じ Supabase CLI action pin を更新

## 検証

- `vp exec playwright test --config=playwright.integration.config.ts e2e/spec/auth.spec.ts e2e/spec/regression-flow.spec.ts --project=chromium --list`
- Deploy E2E: https://github.com/isshi-hasegawa/mirukan/actions/runs/24563446913
- Deploy E2E: https://github.com/isshi-hasegawa/mirukan/actions/runs/24563853525
