### PR TITLE
refactor: quality report snapshot 2026-04-18 の即時改善

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -119,6 +119,23 @@ describe("App", () => {
     expect(globalThis.location.search).toBe("");
   });
 
+  test("SIGNED_OUT でも recovery パラメータを消してログイン画面へ戻す", async () => {
+    authRepositoryMock.getSession.mockResolvedValue({
+      data: { session: { user: { id: "user-1" } } },
+    });
+    globalThis.history.replaceState({}, "", "/?type=recovery");
+
+    renderApp("/");
+    expect(await screen.findByText("RESET_PASSWORD_PAGE")).toBeInTheDocument();
+
+    act(() => {
+      authState.callback?.("SIGNED_OUT", null);
+    });
+
+    expect(await screen.findByText("LOGIN_PAGE")).toBeInTheDocument();
+    expect(globalThis.location.search).toBe("");
+  });
+
   test("getSession が失敗してもローディング状態で止まらずログイン画面に戻る", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     authRepositoryMock.getSession.mockRejectedValueOnce(new Error("network error"));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,11 @@ function LazyRouteErrorFallback() {
   );
 }
 
+function clearRecoveryState(setIsPasswordRecovery: (value: boolean) => void) {
+  setIsPasswordRecovery(false);
+  clearPasswordRecoveryLocation();
+}
+
 function AuthenticatedApp() {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
   const [isPasswordRecovery, setIsPasswordRecovery] = useState(() =>
@@ -118,16 +123,19 @@ function AuthenticatedApp() {
     const {
       data: { subscription },
     } = onAuthStateChange((event, session) => {
-      if (event === "PASSWORD_RECOVERY") {
-        setIsPasswordRecovery(true);
-      } else if (event === "USER_UPDATED") {
-        setIsPasswordRecovery(false);
-        clearPasswordRecoveryLocation();
-      } else if (event === "SIGNED_IN") {
-        setIsPasswordRecovery(isPasswordRecoveryLocation(globalThis.location));
-      } else if (event === "SIGNED_OUT") {
-        setIsPasswordRecovery(false);
-        clearPasswordRecoveryLocation();
+      switch (event) {
+        case "PASSWORD_RECOVERY":
+          setIsPasswordRecovery(true);
+          break;
+        case "USER_UPDATED":
+        case "SIGNED_OUT":
+          clearRecoveryState(setIsPasswordRecovery);
+          break;
+        case "SIGNED_IN":
+          setIsPasswordRecovery(isPasswordRecoveryLocation(globalThis.location));
+          break;
+        default:
+          break;
       }
 
       setSession(session);

--- a/src/features/backlog/components/TmdbWorkCard.tsx
+++ b/src/features/backlog/components/TmdbWorkCard.tsx
@@ -16,50 +16,78 @@ type Props = Readonly<{
   footerLayout?: "panel" | "inline";
 }>;
 
-export function TmdbWorkCard({
-  result,
-  isSelected,
-  onSelect,
-  onAddToStacked,
-  isChecked,
-  footer,
-  footerLayout = "panel",
-}: Props) {
-  const posterUrl = result.posterPath
-    ? `https://image.tmdb.org/t/p/w185${result.posterPath}`
-    : null;
-  const rtScore = result.rottenTomatoesScore ?? null;
-  let rtVariant: "fresh" | "rotten" | null = null;
-  if (rtScore !== null) {
-    rtVariant = rtScore >= 60 ? "fresh" : "rotten";
+function buildPosterUrl(posterPath: string | null) {
+  return posterPath ? `https://image.tmdb.org/t/p/w185${posterPath}` : null;
+}
+
+function getRtVariant(score: number | null) {
+  if (score === null) {
+    return null;
   }
+
+  return score >= 60 ? "fresh" : "rotten";
+}
+
+function getCardBorderClass(isSelected?: boolean) {
+  return isSelected
+    ? " border-[rgba(191,90,54,0.45)] shadow-[inset_0_0_0_1px_rgba(191,90,54,0.2)]"
+    : " border-[rgba(92,59,35,0.2)]";
+}
+
+function WorkTypeLabel({ workType }: Readonly<{ workType: TmdbSearchResult["workType"] }>) {
+  const icon =
+    workType === "movie" ? (
+      <FilmIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+    ) : (
+      <TvIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+    );
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      {icon}
+      {workType === "movie" ? "映画" : "シリーズ"}
+    </span>
+  );
+}
+
+function WatchPlatformBadge({
+  logoPath,
+  label,
+}: Readonly<{
+  logoPath: string | null;
+  label: string;
+}>) {
+  if (logoPath) {
+    return (
+      <img
+        src={`https://image.tmdb.org/t/p/w45${logoPath}`}
+        alt={label}
+        title={label}
+        className="w-5 h-5 rounded-[4px] object-cover shrink-0"
+      />
+    );
+  }
+
+  return (
+    <span className="inline-block px-[7px] py-[1px] rounded-full text-[0.78rem] bg-black/[0.07] text-muted-foreground whitespace-nowrap">
+      {label}
+    </span>
+  );
+}
+
+function CardBody({
+  result,
+  checkButton,
+}: Readonly<{
+  result: TmdbSearchResult;
+  checkButton: ReactNode;
+}>) {
+  const posterUrl = buildPosterUrl(result.posterPath);
+  const rtScore = result.rottenTomatoesScore ?? null;
+  const rtVariant = getRtVariant(rtScore);
   const metadataLabels = getTmdbSearchResultMetadataLabels(result);
 
-  const checkButton = onAddToStacked ? (
-    <button
-      type="button"
-      className={`group shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center self-center transition-colors cursor-pointer ${
-        isChecked
-          ? "bg-[rgb(191,90,54)] border-[rgb(191,90,54)]"
-          : "border-[rgba(255,255,255,0.3)] hover:border-[rgba(255,255,255,0.5)]"
-      }`}
-      aria-label="ストックに追加"
-      title="ストックに追加"
-      onClick={(e) => {
-        e.stopPropagation();
-        onAddToStacked();
-      }}
-    >
-      <CheckIcon
-        className={`w-4 h-4 text-white transition-opacity ${
-          isChecked ? "opacity-100" : "opacity-0 group-hover:opacity-100"
-        }`}
-        aria-hidden="true"
-      />
-    </button>
-  ) : null;
-
-  const cardContent = (
+  return (
     <>
       {checkButton}
       <div
@@ -84,14 +112,7 @@ export function TmdbWorkCard({
       <div className="grid gap-1 min-w-0 pr-8">
         <span className="font-bold">{result.title}</span>
         <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground text-[0.88rem]">
-          <span className="inline-flex items-center gap-1">
-            {result.workType === "movie" ? (
-              <FilmIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
-            ) : (
-              <TvIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
-            )}
-            {result.workType === "movie" ? "映画" : "シリーズ"}
-          </span>
+          <WorkTypeLabel workType={result.workType} />
           {metadataLabels.map((label) => (
             <span key={label} className="text-[0.8rem] leading-none text-muted-foreground/80">
               {label}
@@ -110,23 +131,11 @@ export function TmdbWorkCard({
           <span className="flex flex-wrap gap-1">
             {result.jpWatchPlatforms.map(({ key, logoPath }) => {
               const label = platformLabels[key as keyof typeof platformLabels];
-              if (!label) return null;
-              return logoPath ? (
-                <img
-                  key={key}
-                  src={`https://image.tmdb.org/t/p/w45${logoPath}`}
-                  alt={label}
-                  title={label}
-                  className="w-5 h-5 rounded-[4px] object-cover shrink-0"
-                />
-              ) : (
-                <span
-                  key={key}
-                  className="inline-block px-[7px] py-[1px] rounded-full text-[0.78rem] bg-black/[0.07] text-muted-foreground whitespace-nowrap"
-                >
-                  {label}
-                </span>
-              );
+              if (!label) {
+                return null;
+              }
+
+              return <WatchPlatformBadge key={key} logoPath={logoPath} label={label} />;
             })}
           </span>
         )}
@@ -138,6 +147,88 @@ export function TmdbWorkCard({
       </div>
     </>
   );
+}
+
+function InlineCard({
+  onSelect,
+  isSelected,
+  cardButtonClass,
+  cardStaticClass,
+  cardContent,
+  footer,
+}: Readonly<{
+  onSelect?: () => void;
+  isSelected?: boolean;
+  cardButtonClass: string;
+  cardStaticClass: string;
+  cardContent: ReactNode;
+  footer: ReactNode;
+}>) {
+  if (onSelect) {
+    return (
+      <div
+        className={`overflow-hidden border rounded-2xl bg-[#353535] text-foreground${getCardBorderClass(isSelected)}`}
+      >
+        <button className={`${cardButtonClass} cursor-pointer`} type="button" onClick={onSelect}>
+          {cardContent}
+        </button>
+        <div
+          className="flex items-end justify-end gap-3 border-t border-[rgba(92,59,35,0.16)] px-4 py-3"
+          data-footer-layout="inline"
+        >
+          {footer}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden border border-[rgba(92,59,35,0.2)] rounded-2xl bg-[#353535] text-foreground">
+      <div className={cardStaticClass}>{cardContent}</div>
+      <div
+        className="flex items-end justify-end gap-3 border-t border-[rgba(92,59,35,0.16)] px-4 py-3"
+        data-footer-layout="inline"
+      >
+        {footer}
+      </div>
+    </div>
+  );
+}
+
+export function TmdbWorkCard({
+  result,
+  isSelected,
+  onSelect,
+  onAddToStacked,
+  isChecked,
+  footer,
+  footerLayout = "panel",
+}: Props) {
+  const checkButton = onAddToStacked ? (
+    <button
+      type="button"
+      className={`group shrink-0 w-6 h-6 rounded-full border-2 flex items-center justify-center self-center transition-colors cursor-pointer ${
+        isChecked
+          ? "bg-[rgb(191,90,54)] border-[rgb(191,90,54)]"
+          : "border-[rgba(255,255,255,0.3)] hover:border-[rgba(255,255,255,0.5)]"
+      }`}
+      aria-label="ストックに追加"
+      title="ストックに追加"
+      onClick={(e) => {
+        e.stopPropagation();
+        onAddToStacked();
+      }}
+    >
+      <CheckIcon
+        className={`w-4 h-4 text-white transition-opacity ${
+          isChecked ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+        }`}
+        aria-hidden="true"
+      />
+    </button>
+  ) : null;
+
+  const cardContent = <CardBody result={result} checkButton={checkButton} />;
 
   const tmdbHref = `https://www.themoviedb.org/${result.tmdbMediaType}/${result.tmdbId}`;
 
@@ -158,38 +249,16 @@ export function TmdbWorkCard({
   const cardStaticClass = `grid ${gridCols} gap-3 items-start w-full px-4 py-3.5 text-foreground cursor-default`;
 
   if (footer && footerLayout === "inline") {
-    return onSelect ? (
-      <div className="relative">
-        <div
-          className={`overflow-hidden border rounded-2xl bg-[#353535] text-foreground${
-            isSelected
-              ? " border-[rgba(191,90,54,0.45)] shadow-[inset_0_0_0_1px_rgba(191,90,54,0.2)]"
-              : " border-[rgba(92,59,35,0.2)]"
-          }`}
-        >
-          <button className={`${cardButtonClass} cursor-pointer`} type="button" onClick={onSelect}>
-            {cardContent}
-          </button>
-          <div
-            className="flex items-end justify-end gap-3 border-t border-[rgba(92,59,35,0.16)] px-4 py-3"
-            data-footer-layout="inline"
-          >
-            {footer}
-          </div>
-        </div>
-        {tmdbLink}
-      </div>
-    ) : (
+    return (
       <div className="relative w-full">
-        <div className="overflow-hidden border border-[rgba(92,59,35,0.2)] rounded-2xl bg-[#353535] text-foreground">
-          <div className={cardStaticClass}>{cardContent}</div>
-          <div
-            className="flex items-end justify-end gap-3 border-t border-[rgba(92,59,35,0.16)] px-4 py-3"
-            data-footer-layout="inline"
-          >
-            {footer}
-          </div>
-        </div>
+        <InlineCard
+          onSelect={onSelect}
+          isSelected={isSelected}
+          cardButtonClass={cardButtonClass}
+          cardStaticClass={cardStaticClass}
+          cardContent={cardContent}
+          footer={footer}
+        />
         {tmdbLink}
       </div>
     );
@@ -198,11 +267,7 @@ export function TmdbWorkCard({
   return onSelect ? (
     <div className="relative">
       <button
-        className={`${cardButtonClass} border rounded-2xl bg-[#353535] text-foreground cursor-pointer${
-          isSelected
-            ? " border-[rgba(191,90,54,0.45)] shadow-[inset_0_0_0_1px_rgba(191,90,54,0.2)]"
-            : " border-[rgba(92,59,35,0.2)]"
-        }`}
+        className={`${cardButtonClass} border rounded-2xl bg-[#353535] text-foreground cursor-pointer${getCardBorderClass(isSelected)}`}
         type="button"
         onClick={onSelect}
       >

--- a/src/features/backlog/hooks/useAddSubmit.ts
+++ b/src/features/backlog/hooks/useAddSubmit.ts
@@ -49,6 +49,10 @@ function buildDisplayTitle(
   return trimmedTitle;
 }
 
+function toWorkSaveErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "作品の保存中に予期しないエラーが発生しました。";
+}
+
 export function useAddSubmit({
   items,
   session,
@@ -68,6 +72,14 @@ export function useAddSubmit({
   const clearSubmissionState = () => {
     setSubmitPhase({ phase: "idle" });
   };
+
+  const buildBacklogOptions = (workIds: string[], displayTitle: string | null) => ({
+    workIds,
+    backlogOptions: {
+      ...buildStackedBacklogOptions(primaryPlatform, note),
+      display_title: displayTitle,
+    },
+  });
 
   const saveToStacked = async (payload: {
     workIds: string[];
@@ -112,6 +124,119 @@ export function useAddSubmit({
     setSubmitPhase({ phase: "idle" });
   };
 
+  const saveWithConfirmation = async ({
+    workIds,
+    subject,
+    emptyMessage,
+    displayTitle,
+  }: {
+    workIds: string[];
+    subject: ReturnType<typeof buildSelectedSubject>;
+    emptyMessage: string;
+    displayTitle: string | null;
+  }) => {
+    const confirmResult = confirmStackedSave({
+      items,
+      workIds,
+      subject,
+      emptyMessage,
+    });
+
+    if (confirmResult.type === "empty") {
+      setSubmitPhase({ phase: "error", message: confirmResult.message });
+      return;
+    }
+
+    const savePayload = buildBacklogOptions(workIds, displayTitle);
+
+    if (confirmResult.type === "confirm") {
+      setSubmitPhase({
+        phase: "pending_confirm",
+        message: confirmResult.message,
+        ...savePayload,
+      });
+      return;
+    }
+
+    await saveToStacked(savePayload);
+  };
+
+  const createWork = async (title: string) => {
+    try {
+      return selectedTmdbResult
+        ? await upsertTmdbWork(selectedTmdbResult, session.user.id)
+        : await upsertManualWork(
+            title,
+            resolvedWorkType as Extract<WorkType, "movie" | "series">,
+            session.user.id,
+          );
+    } catch (error) {
+      return {
+        data: null,
+        error: { message: toWorkSaveErrorMessage(error) },
+      };
+    }
+  };
+
+  const submitTvSelection = async (subject: ReturnType<typeof buildSelectedSubject>) => {
+    if (selectedSeasonNumbers.length === 0 || !selectedTmdbResult) {
+      setSubmitPhase({
+        phase: "error",
+        message: "追加するシーズンを1つ以上選択してください。",
+      });
+      return;
+    }
+
+    setSubmitPhase({ phase: "loading", message: "シーズンをストックへ追加しています..." });
+    const result = await resolveSelectedSeasonWorkIds(
+      selectedTmdbResult,
+      session.user.id,
+      selectedSeasonNumbers,
+      {
+        seasonOptions,
+      },
+    );
+
+    if (result.error) {
+      setSubmitPhase({
+        phase: "error",
+        message: `シーズンの準備に失敗しました: ${result.error}`,
+      });
+      return;
+    }
+
+    await saveWithConfirmation({
+      workIds: result.workIds,
+      subject,
+      emptyMessage: "選択したシーズンはすでにストックにあります。",
+      // シーズン row には series タイトルを上書きしない
+      displayTitle: null,
+    });
+  };
+
+  const submitSingleWork = async (
+    title: string,
+    subject: ReturnType<typeof buildSelectedSubject>,
+  ) => {
+    setSubmitPhase({ phase: "loading", message: "作品をストックへ追加しています..." });
+
+    const result = await createWork(title);
+    if (result.error || !result.data) {
+      setSubmitPhase({
+        phase: "error",
+        message: `作品の保存に失敗しました: ${result.error?.message ?? "不明なエラー"}`,
+      });
+      return;
+    }
+
+    await saveWithConfirmation({
+      workIds: [result.data.id],
+      subject,
+      emptyMessage: "すでにストックにあります。",
+      displayTitle: buildDisplayTitle(selectedTmdbResult, resolvedTitle, 1),
+    });
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -121,138 +246,17 @@ export function useAddSubmit({
       selectedSeasonNumbers,
       resolvedTitle,
     });
-    const baseBacklogOptions = buildStackedBacklogOptions(primaryPlatform, note);
-
     if (!title) {
       setSubmitPhase({ phase: "error", message: "タイトルを入力してください。" });
       return;
     }
 
     if (isTvSelection) {
-      if (selectedSeasonNumbers.length === 0 || !selectedTmdbResult) {
-        setSubmitPhase({
-          phase: "error",
-          message: "追加するシーズンを1つ以上選択してください。",
-        });
-        return;
-      }
-
-      setSubmitPhase({ phase: "loading", message: "シーズンをストックへ追加しています..." });
-      const result = await resolveSelectedSeasonWorkIds(
-        selectedTmdbResult,
-        session.user.id,
-        selectedSeasonNumbers,
-        { seasonOptions },
-      );
-
-      if (result.error) {
-        setSubmitPhase({
-          phase: "error",
-          message: `シーズンの準備に失敗しました: ${result.error}`,
-        });
-        return;
-      }
-
-      const confirmResult = confirmStackedSave({
-        items,
-        workIds: result.workIds,
-        subject,
-        emptyMessage: "選択したシーズンはすでにストックにあります。",
-      });
-
-      if (confirmResult.type === "empty") {
-        setSubmitPhase({ phase: "error", message: confirmResult.message });
-        return;
-      }
-
-      if (confirmResult.type === "confirm") {
-        setSubmitPhase({
-          phase: "pending_confirm",
-          message: confirmResult.message,
-          workIds: result.workIds,
-          backlogOptions: {
-            ...baseBacklogOptions,
-            // シーズン row には series タイトルを上書きしない
-            display_title: null,
-          },
-        });
-        return;
-      }
-
-      await saveToStacked({
-        workIds: result.workIds,
-        backlogOptions: {
-          ...baseBacklogOptions,
-          // シーズン row には series タイトルを上書きしない
-          display_title: null,
-        },
-      });
+      await submitTvSelection(subject);
       return;
     }
 
-    setSubmitPhase({ phase: "loading", message: "作品をストックへ追加しています..." });
-
-    let work: { id: string } | null = null;
-    let workError: { message: string } | null = null;
-
-    try {
-      const result = selectedTmdbResult
-        ? await upsertTmdbWork(selectedTmdbResult, session.user.id)
-        : await upsertManualWork(
-            title,
-            resolvedWorkType as Extract<WorkType, "movie" | "series">,
-            session.user.id,
-          );
-
-      work = result.data;
-      workError = result.error ? { message: result.error.message } : null;
-    } catch (error) {
-      workError = {
-        message:
-          error instanceof Error ? error.message : "作品の保存中に予期しないエラーが発生しました。",
-      };
-    }
-
-    if (workError || !work) {
-      setSubmitPhase({
-        phase: "error",
-        message: `作品の保存に失敗しました: ${workError?.message ?? "不明なエラー"}`,
-      });
-      return;
-    }
-
-    const confirmResult = confirmStackedSave({
-      items,
-      workIds: [work.id],
-      subject,
-      emptyMessage: "すでにストックにあります。",
-    });
-
-    if (confirmResult.type === "empty") {
-      setSubmitPhase({ phase: "error", message: confirmResult.message });
-      return;
-    }
-
-    if (confirmResult.type === "confirm") {
-      setSubmitPhase({
-        phase: "pending_confirm",
-        message: confirmResult.message,
-        workIds: [work.id],
-        backlogOptions: {
-          ...baseBacklogOptions,
-          display_title: buildDisplayTitle(selectedTmdbResult, resolvedTitle, 1),
-        },
-      });
-      return;
-    }
-
-    await saveToStacked({
-      workIds: [work.id],
-      backlogOptions: {
-        ...baseBacklogOptions,
-        display_title: buildDisplayTitle(selectedTmdbResult, resolvedTitle, 1),
-      },
-    });
+    await submitSingleWork(title, subject);
   };
 
   // useAddFlow が参照する既存 API との互換を維持するための導出値

--- a/src/test/mocks/handlers/supabase-rest.ts
+++ b/src/test/mocks/handlers/supabase-rest.ts
@@ -159,22 +159,55 @@ function sortByOrderParams<T extends Record<string, unknown>>(rows: T[], url: UR
 
   return [...rows].sort((left, right) => {
     for (const orderParam of orderParams) {
-      const [column, direction = "asc"] = orderParam.split(".");
-      const leftValue = left[column];
-      const rightValue = right[column];
-      if (leftValue === rightValue) {
-        continue;
+      const comparison = compareByOrderParam(left, right, orderParam);
+      if (comparison !== 0) {
+        return comparison;
       }
-
-      if (leftValue === null || leftValue === undefined) return direction === "desc" ? 1 : -1;
-      if (rightValue === null || rightValue === undefined) return direction === "desc" ? -1 : 1;
-
-      if (leftValue < rightValue) return direction === "desc" ? 1 : -1;
-      if (leftValue > rightValue) return direction === "desc" ? -1 : 1;
     }
 
     return 0;
   });
+}
+
+function compareByOrderParam<T extends Record<string, unknown>>(
+  left: T,
+  right: T,
+  orderParam: string,
+) {
+  const [column, direction = "asc"] = orderParam.split(".");
+  return compareOrderedValues(
+    left[column] as string | number | boolean | null | undefined,
+    right[column] as string | number | boolean | null | undefined,
+    direction,
+  );
+}
+
+function compareOrderedValues(
+  leftValue: string | number | boolean | null | undefined,
+  rightValue: string | number | boolean | null | undefined,
+  direction: string,
+) {
+  if (leftValue === rightValue) {
+    return 0;
+  }
+
+  if (leftValue === null || leftValue === undefined) {
+    return direction === "desc" ? 1 : -1;
+  }
+
+  if (rightValue === null || rightValue === undefined) {
+    return direction === "desc" ? -1 : 1;
+  }
+
+  if (leftValue < rightValue) {
+    return direction === "desc" ? 1 : -1;
+  }
+
+  if (leftValue > rightValue) {
+    return direction === "desc" ? -1 : 1;
+  }
+
+  return 0;
 }
 
 function materializeBacklogRows(url: URL) {

--- a/supabase/functions/_shared/tmdb.ts
+++ b/supabase/functions/_shared/tmdb.ts
@@ -1229,12 +1229,13 @@ export async function fetchTmdbWorkDetails(target: TmdbSelectionTarget): Promise
 }
 
 async function fetchPreferredJapaneseTitle(target: TmdbSelectionTarget) {
-  const path =
-    target.tmdbMediaType === "movie"
-      ? `/movie/${target.tmdbId}/translations`
-      : target.workType === "season"
-        ? `/tv/${target.tmdbId}/season/${target.seasonNumber}/translations`
-        : `/tv/${target.tmdbId}/translations`;
+  let path = `/tv/${target.tmdbId}/translations`;
+
+  if (target.tmdbMediaType === "movie") {
+    path = `/movie/${target.tmdbId}/translations`;
+  } else if (target.workType === "season") {
+    path = `/tv/${target.tmdbId}/season/${target.seasonNumber}/translations`;
+  }
 
   return fetchPreferredJapaneseTitleForPath(path, target.tmdbMediaType);
 }
@@ -1251,9 +1252,11 @@ async function fetchPreferredJapaneseTitleForPath(path: string, mediaType: TmdbM
       return null;
     }
 
-    return mediaType === "movie"
-      ? (japaneseTranslation.data.title ?? null)
-      : (japaneseTranslation.data.name ?? null);
+    if (mediaType === "movie") {
+      return japaneseTranslation.data.title ?? null;
+    }
+
+    return japaneseTranslation.data.name ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## 関連 Issue

Refs #262

## 変更内容

- `App.tsx` の認証イベント分岐を `switch` に整理し、`USER_UPDATED` と `SIGNED_OUT` の重複処理を共通化
- `useAddSubmit.ts` を TV 選択保存と単体作品保存の helper に分解し、確認フローとエラーハンドリングを整理
- `TmdbWorkCard.tsx` の表示ロジックを部品化して認知複雑度を削減
- `supabase-rest.ts` の order 比較処理と `tmdb.ts` の翻訳タイトル分岐を明示化して Sonar 指摘を解消
- `App.test.tsx` に `SIGNED_OUT` 時の recovery パラメータ掃除を追加

## 検証

- `vp test src/App.test.tsx src/features/backlog/hooks/useAddSubmit.test.tsx src/features/backlog/components/TmdbWorkCard.test.tsx src/features/backlog/work-repository.test.ts`
- `vp build`
- `vp run knip`

## 見送った項目

- quality report の `構造改善が必要` は、今回の PR では即時対応 5 件に閉じるため未対応
- `supabase/functions/_shared/tmdb_test.ts` はこの環境に `deno` コマンドがなく未実行
