### PR TITLE
test: quality report 残りの低カバレッジ箇所を補強

### DIFF
--- a/src/features/backlog/components/ContactDialog.test.tsx
+++ b/src/features/backlog/components/ContactDialog.test.tsx
@@ -1,0 +1,59 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { ContactDialog } from "./ContactDialog.tsx";
+
+describe("ContactDialog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("問い合わせ先と不具合報告先を表示する", () => {
+    render(<ContactDialog onClose={vi.fn()} />);
+
+    expect(screen.getByText("support@mirukan.app")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /github\.com\/isshi-hasegawa\/mirukan\/issues/i }),
+    ).toHaveAttribute("href", "https://github.com/isshi-hasegawa/mirukan/issues/new/choose");
+  });
+
+  test("メールアドレスをコピーできる", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText },
+    });
+
+    render(<ContactDialog onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "メールアドレスをコピー" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(writeText).toHaveBeenCalledWith("support@mirukan.app");
+    expect(screen.getByRole("button", { name: "コピーしました" })).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.getByRole("button", { name: "メールアドレスをコピー" })).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  test("クリップボード API が拒否されても閉じずに継続できる", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText },
+    });
+
+    render(<ContactDialog onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "メールアドレスをコピー" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("button", { name: "メールアドレスをコピー" })).toBeInTheDocument();
+  });
+});

--- a/src/features/backlog/components/ContactDialog.test.tsx
+++ b/src/features/backlog/components/ContactDialog.test.tsx
@@ -4,6 +4,7 @@ import { ContactDialog } from "./ContactDialog.tsx";
 describe("ContactDialog", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   test("問い合わせ先と不具合報告先を表示する", () => {

--- a/src/features/backlog/components/DialogShell.test.tsx
+++ b/src/features/backlog/components/DialogShell.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DialogShell } from "./DialogShell.tsx";
+
+describe("DialogShell", () => {
+  test("ポータル経由でダイアログを描画し、閉じる操作を受け付ける", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <DialogShell
+        titleId="dialog-title"
+        badge="Contact"
+        title="お問い合わせ"
+        closeLabel="閉じる"
+        onClose={onClose}
+      >
+        <p>本文</p>
+      </DialogShell>,
+    );
+
+    expect(screen.getByRole("dialog", { name: "お問い合わせ" })).toBeInTheDocument();
+    expect(screen.getByText("本文")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape と backdrop click でも閉じる", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <DialogShell
+        titleId="dialog-title"
+        badge="Contact"
+        title="お問い合わせ"
+        closeLabel="閉じる"
+        onClose={onClose}
+      >
+        <p>本文</p>
+      </DialogShell>,
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const backdrop = document.querySelector('button[aria-hidden="true"]');
+    expect(backdrop).not.toBeNull();
+    await user.click(backdrop!);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/backlog/components/PlatformIcon.test.tsx
+++ b/src/features/backlog/components/PlatformIcon.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { PlatformIcon } from "./PlatformIcon.tsx";
+import { platformBackgrounds, platformIcons, platformLabels } from "../constants.ts";
+
+describe("PlatformIcon", () => {
+  test("選択されたプラットフォームのアイコン情報を表示する", () => {
+    render(<PlatformIcon platform="netflix" />);
+
+    const icon = screen.getByRole("img", { name: platformLabels.netflix });
+    expect(icon).toHaveAttribute("src", platformIcons.netflix);
+    expect(icon).toHaveAttribute("title", platformLabels.netflix);
+    expect(icon).toHaveStyle({ background: platformBackgrounds.netflix });
+  });
+});

--- a/src/features/backlog/hooks/useBacklogFeedback.test.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.test.tsx
@@ -1,0 +1,174 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useBacklogFeedback } from "./useBacklogFeedback.tsx";
+
+function FeedbackHarness() {
+  const { feedback, feedbackUi } = useBacklogFeedback();
+
+  return (
+    <>
+      <button type="button" onClick={() => void feedback.alert("通知メッセージ")}>
+        alert
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void feedback.confirm("本当に続けますか?");
+        }}
+      >
+        confirm
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void feedback.toast("保存しました", { undoLabel: "元に戻す", timeoutMs: 1000 });
+        }}
+      >
+        toast
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          void feedback.toast("別の保存", { timeoutMs: 1000 });
+        }}
+      >
+        replace toast
+      </button>
+      {feedbackUi}
+    </>
+  );
+}
+
+describe("useBacklogFeedback", () => {
+  test("alert を表示して閉じられる", async () => {
+    render(<FeedbackHarness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "alert" }));
+    expect(screen.getByText("通知メッセージ")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(screen.queryByText("通知メッセージ")).not.toBeInTheDocument();
+  });
+
+  test("confirm の結果をボタン操作で解決する", async () => {
+    const resolver = vi.fn();
+
+    function ConfirmHarness() {
+      const { feedback, feedbackUi } = useBacklogFeedback();
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              void feedback.confirm("本当に続けますか?").then(resolver);
+            }}
+          >
+            open confirm
+          </button>
+          {feedbackUi}
+        </>
+      );
+    }
+
+    render(<ConfirmHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "open confirm" }));
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "続ける" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(resolver).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  test("toast は undo と自動 close を処理し、置き換え時に前の promise を解決する", async () => {
+    vi.useFakeTimers();
+    const firstResolver = vi.fn();
+    const secondResolver = vi.fn();
+
+    function ToastHarness() {
+      const { feedback, feedbackUi } = useBacklogFeedback();
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              void feedback
+                .toast("保存しました", { undoLabel: "元に戻す", timeoutMs: 1000 })
+                .then(firstResolver);
+            }}
+          >
+            open first toast
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void feedback.toast("次の保存", { timeoutMs: 1000 }).then(secondResolver);
+            }}
+          >
+            open second toast
+          </button>
+          {feedbackUi}
+        </>
+      );
+    }
+
+    render(<ToastHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "open first toast" }));
+    expect(screen.getByText("保存しました")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "open second toast" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(firstResolver).toHaveBeenCalledWith({ undone: false });
+    expect(screen.getByText("次の保存")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(secondResolver).toHaveBeenCalledWith({ undone: false });
+
+    const view = render(<FeedbackHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "toast" }));
+    fireEvent.click(screen.getByRole("button", { name: "元に戻す" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByText("保存しました")).not.toBeInTheDocument();
+    view.unmount();
+
+    vi.useRealTimers();
+  });
+
+  test("confirm をキャンセルで閉じると false を返す", async () => {
+    const resolver = vi.fn();
+
+    function CancelHarness() {
+      const { feedback, feedbackUi } = useBacklogFeedback();
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              void feedback.confirm("確認").then(resolver);
+            }}
+          >
+            open confirm
+          </button>
+          {feedbackUi}
+        </>
+      );
+    }
+
+    render(<CancelHarness />);
+    fireEvent.click(screen.getByRole("button", { name: "open confirm" }));
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(resolver).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/features/backlog/hooks/useBacklogFeedback.test.tsx
+++ b/src/features/backlog/hooks/useBacklogFeedback.test.tsx
@@ -1,18 +1,27 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useBacklogFeedback } from "./useBacklogFeedback.tsx";
 
+function settleFeedback<T>(result: T | Promise<T>) {
+  Promise.resolve(result).catch(() => undefined);
+}
+
 function FeedbackHarness() {
   const { feedback, feedbackUi } = useBacklogFeedback();
 
   return (
     <>
-      <button type="button" onClick={() => void feedback.alert("通知メッセージ")}>
+      <button
+        type="button"
+        onClick={() => {
+          settleFeedback(feedback.alert("通知メッセージ"));
+        }}
+      >
         alert
       </button>
       <button
         type="button"
         onClick={() => {
-          void feedback.confirm("本当に続けますか?");
+          settleFeedback(feedback.confirm("本当に続けますか?"));
         }}
       >
         confirm
@@ -20,7 +29,9 @@ function FeedbackHarness() {
       <button
         type="button"
         onClick={() => {
-          void feedback.toast("保存しました", { undoLabel: "元に戻す", timeoutMs: 1000 });
+          settleFeedback(
+            feedback.toast("保存しました", { undoLabel: "元に戻す", timeoutMs: 1000 }),
+          );
         }}
       >
         toast
@@ -28,7 +39,7 @@ function FeedbackHarness() {
       <button
         type="button"
         onClick={() => {
-          void feedback.toast("別の保存", { timeoutMs: 1000 });
+          settleFeedback(feedback.toast("別の保存", { timeoutMs: 1000 }));
         }}
       >
         replace toast
@@ -59,7 +70,7 @@ describe("useBacklogFeedback", () => {
           <button
             type="button"
             onClick={() => {
-              void feedback.confirm("本当に続けますか?").then(resolver);
+              Promise.resolve(feedback.confirm("本当に続けますか?")).then(resolver);
             }}
           >
             open confirm
@@ -93,9 +104,9 @@ describe("useBacklogFeedback", () => {
           <button
             type="button"
             onClick={() => {
-              void feedback
-                .toast("保存しました", { undoLabel: "元に戻す", timeoutMs: 1000 })
-                .then(firstResolver);
+              Promise.resolve(
+                feedback.toast("保存しました", { undoLabel: "元に戻す", timeoutMs: 1000 }),
+              ).then(firstResolver);
             }}
           >
             open first toast
@@ -103,7 +114,7 @@ describe("useBacklogFeedback", () => {
           <button
             type="button"
             onClick={() => {
-              void feedback.toast("次の保存", { timeoutMs: 1000 }).then(secondResolver);
+              Promise.resolve(feedback.toast("次の保存", { timeoutMs: 1000 })).then(secondResolver);
             }}
           >
             open second toast
@@ -151,7 +162,7 @@ describe("useBacklogFeedback", () => {
           <button
             type="button"
             onClick={() => {
-              void feedback.confirm("確認").then(resolver);
+              Promise.resolve(feedback.confirm("確認")).then(resolver);
             }}
           >
             open confirm

--- a/src/features/backlog/ui-feedback.test.ts
+++ b/src/features/backlog/ui-feedback.test.ts
@@ -1,0 +1,36 @@
+import { act } from "@testing-library/react";
+import { browserBacklogFeedback } from "./ui-feedback.ts";
+
+describe("browserBacklogFeedback", () => {
+  test("alert と confirm をブラウザ API に委譲する", async () => {
+    const alertSpy = vi.spyOn(globalThis, "alert").mockImplementation(() => {});
+    const confirmSpy = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+
+    await browserBacklogFeedback.alert("通知");
+    const confirmed = await browserBacklogFeedback.confirm("確認");
+
+    expect(alertSpy).toHaveBeenCalledWith("通知");
+    expect(confirmSpy).toHaveBeenCalledWith("確認");
+    expect(confirmed).toBe(true);
+  });
+
+  test("toast は指定時間の経過後に未 undo として解決する", async () => {
+    vi.useFakeTimers();
+
+    const resultPromise = browserBacklogFeedback.toast("保存しました", { timeoutMs: 1200 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1199);
+    });
+    await expect(Promise.race([resultPromise, Promise.resolve("pending")])).resolves.toBe(
+      "pending",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    await expect(resultPromise).resolves.toEqual({ undone: false });
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## 関連 Issue

Refs #262

## 変更内容

- `PlatformIcon` の表示内容を固定するテストを追加
- `browserBacklogFeedback` の alert / confirm / toast を検証するテストを追加
- `useBacklogFeedback` の alert / confirm / toast UI と解決経路を検証するテストを追加
- `DialogShell` の portal 描画と close 操作を検証するテストを追加
- `ContactDialog` の問い合わせ先表示とクリップボード操作を検証するテストを追加

## 検証

- `vp test src/features/backlog/components/PlatformIcon.test.tsx src/features/backlog/ui-feedback.test.ts src/features/backlog/hooks/useBacklogFeedback.test.tsx src/features/backlog/components/DialogShell.test.tsx src/features/backlog/components/ContactDialog.test.tsx`
- `vp build`

## 見送った項目

- quality report の `構造改善が必要` は、今回の PR では低カバレッジ箇所のテスト追加に絞るため未対応
