### PR TITLE
refactor: backlog DnD の構造整理とテスト補強

### DIFF
--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -1,50 +1,26 @@
-import {
-  resolveDragOverItems,
-  resolveDropPersistence,
-  type RectLike,
-} from "./useBacklogDnd.logic.ts";
+import { resolveDragOverItems, resolveDropPersistence } from "./useBacklogDnd.logic.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
-import type { BacklogItem } from "../types.ts";
+import {
+  createBacklogItem,
+  createTouchEvent,
+  makeLogicRect,
+} from "./useBacklogDnd.test-helpers.ts";
 
 setupTestLifecycle();
-
-function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
-  return {
-    id: "item-1",
-    status: "stacked",
-    primary_platform: null,
-    note: null,
-    sort_order: 1000,
-    works: null,
-    ...overrides,
-  };
-}
-
-function makeRect(top = 100, height = 200): RectLike {
-  return { top, height };
-}
-
-function createTouchEvent(clientY?: number): TouchEvent {
-  return {
-    type: "touchmove",
-    touches: clientY === undefined ? [] : [{ clientY }],
-    changedTouches: clientY === undefined ? [] : [{ clientY }],
-  } as unknown as TouchEvent;
-}
 
 describe("resolveDragOverItems", () => {
   test("同列内では pointer 位置に応じて before/after を切り替える", () => {
     const items = [
-      createItem({ id: "item-1", sort_order: 1000 }),
-      createItem({ id: "item-2", sort_order: 2000 }),
-      createItem({ id: "item-3", sort_order: 3000 }),
+      createBacklogItem({ id: "item-1", sort_order: 1000 }),
+      createBacklogItem({ id: "item-2", sort_order: 2000 }),
+      createBacklogItem({ id: "item-3", sort_order: 3000 }),
     ];
 
     const beforeItems = resolveDragOverItems({
       items,
       activeId: "item-3",
       overId: "item-2",
-      rect: makeRect(),
+      rect: makeLogicRect(),
       activatorEvent: { clientY: 120 } as MouseEvent,
       isMobileLayout: false,
     });
@@ -52,7 +28,7 @@ describe("resolveDragOverItems", () => {
       items,
       activeId: "item-1",
       overId: "item-2",
-      rect: makeRect(),
+      rect: makeLogicRect(),
       activatorEvent: { clientY: 260 } as MouseEvent,
       isMobileLayout: false,
     });
@@ -63,16 +39,16 @@ describe("resolveDragOverItems", () => {
 
   test("touch event でも clientY を読んで列またぎ挿入位置を決める", () => {
     const items = [
-      createItem({ id: "item-1", status: "stacked" }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+      createBacklogItem({ id: "item-1", status: "stacked" }),
+      createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
     ];
 
     const nextItems = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-3",
-      rect: makeRect(),
+      rect: makeLogicRect(),
       activatorEvent: createTouchEvent(120),
       isMobileLayout: false,
     });
@@ -86,16 +62,16 @@ describe("resolveDragOverItems", () => {
 
   test("touch event に座標が無ければ rect 中央を使って after 扱いにする", () => {
     const items = [
-      createItem({ id: "item-1", status: "stacked" }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+      createBacklogItem({ id: "item-1", status: "stacked" }),
+      createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
     ];
 
     const nextItems = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-2",
-      rect: makeRect(),
+      rect: makeLogicRect(),
       activatorEvent: createTouchEvent(),
       isMobileLayout: false,
     });
@@ -109,17 +85,17 @@ describe("resolveDragOverItems", () => {
 
   test("watched 列の背景ドロップでは列先頭に入れる", () => {
     const items = [
-      createItem({ id: "item-1", status: "stacked" }),
-      createItem({ id: "item-2", status: "watched", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watched", sort_order: 2000 }),
+      createBacklogItem({ id: "item-1", status: "stacked" }),
+      createBacklogItem({ id: "item-2", status: "watched", sort_order: 1000 }),
+      createBacklogItem({ id: "item-3", status: "watched", sort_order: 2000 }),
     ];
 
     const nextItems = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "column:watched",
-      rect: makeRect(),
-      activatorEvent: null,
+      rect: makeLogicRect(),
+      activatorEvent: new MouseEvent("mousemove"),
       isMobileLayout: false,
     });
 
@@ -132,8 +108,8 @@ describe("resolveDragOverItems", () => {
 
   test("モバイルでは列またぎ移動を抑止する", () => {
     const items = [
-      createItem({ id: "item-1", status: "stacked" }),
-      createItem({ id: "item-2", status: "watching" }),
+      createBacklogItem({ id: "item-1", status: "stacked" }),
+      createBacklogItem({ id: "item-2", status: "watching" }),
     ];
 
     expect(
@@ -141,23 +117,23 @@ describe("resolveDragOverItems", () => {
         items,
         activeId: "item-1",
         overId: "item-2",
-        rect: makeRect(),
-        activatorEvent: null,
+        rect: makeLogicRect(),
+        activatorEvent: new MouseEvent("mousemove"),
         isMobileLayout: true,
       }),
     ).toEqual(items);
   });
 
   test("対象が見つからない場合や同一 id への drag over は何もしない", () => {
-    const items = [createItem({ id: "item-1" }), createItem({ id: "item-2" })];
+    const items = [createBacklogItem({ id: "item-1" }), createBacklogItem({ id: "item-2" })];
 
     expect(
       resolveDragOverItems({
         items,
         activeId: "missing",
         overId: "item-2",
-        rect: makeRect(),
-        activatorEvent: null,
+        rect: makeLogicRect(),
+        activatorEvent: new MouseEvent("mousemove"),
         isMobileLayout: false,
       }),
     ).toBe(items);
@@ -166,8 +142,8 @@ describe("resolveDragOverItems", () => {
         items,
         activeId: "item-1",
         overId: "item-1",
-        rect: makeRect(),
-        activatorEvent: null,
+        rect: makeLogicRect(),
+        activatorEvent: new MouseEvent("mousemove"),
         isMobileLayout: false,
       }),
     ).toBe(items);
@@ -177,9 +153,9 @@ describe("resolveDragOverItems", () => {
 describe("resolveDropPersistence", () => {
   test("先頭挿入では次要素の sort_order から補間する", () => {
     const items = [
-      createItem({ id: "item-1", sort_order: 1000 }),
-      createItem({ id: "item-2", sort_order: 2000 }),
-      createItem({ id: "item-3", sort_order: 3000 }),
+      createBacklogItem({ id: "item-1", sort_order: 1000 }),
+      createBacklogItem({ id: "item-2", sort_order: 2000 }),
+      createBacklogItem({ id: "item-3", sort_order: 3000 }),
     ];
     const localItems = [items[2], items[0], items[1]];
 
@@ -192,14 +168,14 @@ describe("resolveDropPersistence", () => {
 
   test("末尾挿入では直前要素の sort_order に 1000 足す", () => {
     const items = [
-      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+      createBacklogItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+      createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
     ];
     const localItems = [
       items[1],
       items[2],
-      createItem({ id: "item-1", status: "watching", sort_order: 1000 }),
+      createBacklogItem({ id: "item-1", status: "watching", sort_order: 1000 }),
     ];
 
     expect(resolveDropPersistence({ items, localItems, activeId: "item-1" })).toEqual({
@@ -211,9 +187,9 @@ describe("resolveDropPersistence", () => {
 
   test("前後要素がある場合は中間値を使う", () => {
     const items = [
-      createItem({ id: "item-1", sort_order: 1000 }),
-      createItem({ id: "item-2", sort_order: 2000 }),
-      createItem({ id: "item-3", sort_order: 3000 }),
+      createBacklogItem({ id: "item-1", sort_order: 1000 }),
+      createBacklogItem({ id: "item-2", sort_order: 2000 }),
+      createBacklogItem({ id: "item-3", sort_order: 3000 }),
     ];
     const localItems = [items[0], items[2], items[1]];
 
@@ -225,7 +201,7 @@ describe("resolveDropPersistence", () => {
   });
 
   test("列内に 1 件だけなら初期 sort_order を使う", () => {
-    const items = [createItem({ id: "item-1", status: "stacked", sort_order: 1000 })];
+    const items = [createBacklogItem({ id: "item-1", status: "stacked", sort_order: 1000 })];
 
     expect(resolveDropPersistence({ items, localItems: items, activeId: "item-1" })).toEqual({
       activeId: "item-1",
@@ -235,7 +211,7 @@ describe("resolveDropPersistence", () => {
   });
 
   test("drag 中アイテムが localItems に無ければ null を返す", () => {
-    const items = [createItem({ id: "item-1", sort_order: 1000 })];
+    const items = [createBacklogItem({ id: "item-1", sort_order: 1000 })];
 
     expect(resolveDropPersistence({ items, localItems: items, activeId: "missing" })).toBeNull();
   });

--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -8,6 +8,18 @@ import {
 
 setupTestLifecycle();
 
+function watchingIds(items: ReturnType<typeof createWatchingItemsFixture>) {
+  return items.filter((item) => item.status === "watching").map((item) => item.id);
+}
+
+function createWatchingItemsFixture() {
+  return [
+    createBacklogItem({ id: "item-1", status: "stacked" }),
+    createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+    createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+  ];
+}
+
 describe("resolveDragOverItems", () => {
   test("同列内では pointer 位置に応じて before/after を切り替える", () => {
     const items = [
@@ -37,50 +49,28 @@ describe("resolveDragOverItems", () => {
     expect(afterItems.map((item) => item.id)).toEqual(["item-2", "item-1", "item-3"]);
   });
 
-  test("touch event でも clientY を読んで列またぎ挿入位置を決める", () => {
-    const items = [
-      createBacklogItem({ id: "item-1", status: "stacked" }),
-      createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-    ];
-
-    const nextItems = resolveDragOverItems({
-      items,
-      activeId: "item-1",
+  test.each([
+    {
+      name: "touch event でも clientY を読んで列またぎ挿入位置を決める",
       overId: "item-3",
-      rect: makeLogicRect(),
       activatorEvent: createTouchEvent(120),
-      isMobileLayout: false,
-    });
-
-    expect(nextItems.filter((item) => item.status === "watching").map((item) => item.id)).toEqual([
-      "item-2",
-      "item-1",
-      "item-3",
-    ]);
-  });
-
-  test("touch event に座標が無ければ rect 中央を使って after 扱いにする", () => {
-    const items = [
-      createBacklogItem({ id: "item-1", status: "stacked" }),
-      createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-      createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-    ];
-
-    const nextItems = resolveDragOverItems({
-      items,
-      activeId: "item-1",
+    },
+    {
+      name: "touch event に座標が無ければ rect 中央を使って after 扱いにする",
       overId: "item-2",
-      rect: makeLogicRect(),
       activatorEvent: createTouchEvent(),
+    },
+  ])("$name", ({ overId, activatorEvent }) => {
+    const nextItems = resolveDragOverItems({
+      items: createWatchingItemsFixture(),
+      activeId: "item-1",
+      overId,
+      rect: makeLogicRect(),
+      activatorEvent,
       isMobileLayout: false,
     });
 
-    expect(nextItems.filter((item) => item.status === "watching").map((item) => item.id)).toEqual([
-      "item-2",
-      "item-1",
-      "item-3",
-    ]);
+    expect(watchingIds(nextItems)).toEqual(["item-2", "item-1", "item-3"]);
   });
 
   test("watched 列の背景ドロップでは列先頭に入れる", () => {

--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -1,0 +1,242 @@
+import {
+  resolveDragOverItems,
+  resolveDropPersistence,
+  type RectLike,
+} from "./useBacklogDnd.logic.ts";
+import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import type { BacklogItem } from "../types.ts";
+
+setupTestLifecycle();
+
+function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
+  return {
+    id: "item-1",
+    status: "stacked",
+    primary_platform: null,
+    note: null,
+    sort_order: 1000,
+    works: null,
+    ...overrides,
+  };
+}
+
+function makeRect(top = 100, height = 200): RectLike {
+  return { top, height };
+}
+
+function createTouchEvent(clientY?: number): TouchEvent {
+  return {
+    type: "touchmove",
+    touches: clientY === undefined ? [] : [{ clientY }],
+    changedTouches: clientY === undefined ? [] : [{ clientY }],
+  } as unknown as TouchEvent;
+}
+
+describe("resolveDragOverItems", () => {
+  test("同列内では pointer 位置に応じて before/after を切り替える", () => {
+    const items = [
+      createItem({ id: "item-1", sort_order: 1000 }),
+      createItem({ id: "item-2", sort_order: 2000 }),
+      createItem({ id: "item-3", sort_order: 3000 }),
+    ];
+
+    const beforeItems = resolveDragOverItems({
+      items,
+      activeId: "item-3",
+      overId: "item-2",
+      rect: makeRect(),
+      activatorEvent: { clientY: 120 } as MouseEvent,
+      isMobileLayout: false,
+    });
+    const afterItems = resolveDragOverItems({
+      items,
+      activeId: "item-1",
+      overId: "item-2",
+      rect: makeRect(),
+      activatorEvent: { clientY: 260 } as MouseEvent,
+      isMobileLayout: false,
+    });
+
+    expect(beforeItems.map((item) => item.id)).toEqual(["item-1", "item-3", "item-2"]);
+    expect(afterItems.map((item) => item.id)).toEqual(["item-2", "item-1", "item-3"]);
+  });
+
+  test("touch event でも clientY を読んで列またぎ挿入位置を決める", () => {
+    const items = [
+      createItem({ id: "item-1", status: "stacked" }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+
+    const nextItems = resolveDragOverItems({
+      items,
+      activeId: "item-1",
+      overId: "item-3",
+      rect: makeRect(),
+      activatorEvent: createTouchEvent(120),
+      isMobileLayout: false,
+    });
+
+    expect(nextItems.filter((item) => item.status === "watching").map((item) => item.id)).toEqual([
+      "item-2",
+      "item-1",
+      "item-3",
+    ]);
+  });
+
+  test("touch event に座標が無ければ rect 中央を使って after 扱いにする", () => {
+    const items = [
+      createItem({ id: "item-1", status: "stacked" }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+
+    const nextItems = resolveDragOverItems({
+      items,
+      activeId: "item-1",
+      overId: "item-2",
+      rect: makeRect(),
+      activatorEvent: createTouchEvent(),
+      isMobileLayout: false,
+    });
+
+    expect(nextItems.filter((item) => item.status === "watching").map((item) => item.id)).toEqual([
+      "item-2",
+      "item-1",
+      "item-3",
+    ]);
+  });
+
+  test("watched 列の背景ドロップでは列先頭に入れる", () => {
+    const items = [
+      createItem({ id: "item-1", status: "stacked" }),
+      createItem({ id: "item-2", status: "watched", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watched", sort_order: 2000 }),
+    ];
+
+    const nextItems = resolveDragOverItems({
+      items,
+      activeId: "item-1",
+      overId: "column:watched",
+      rect: makeRect(),
+      activatorEvent: null,
+      isMobileLayout: false,
+    });
+
+    expect(nextItems.filter((item) => item.status === "watched").map((item) => item.id)).toEqual([
+      "item-1",
+      "item-2",
+      "item-3",
+    ]);
+  });
+
+  test("モバイルでは列またぎ移動を抑止する", () => {
+    const items = [
+      createItem({ id: "item-1", status: "stacked" }),
+      createItem({ id: "item-2", status: "watching" }),
+    ];
+
+    expect(
+      resolveDragOverItems({
+        items,
+        activeId: "item-1",
+        overId: "item-2",
+        rect: makeRect(),
+        activatorEvent: null,
+        isMobileLayout: true,
+      }),
+    ).toEqual(items);
+  });
+
+  test("対象が見つからない場合や同一 id への drag over は何もしない", () => {
+    const items = [createItem({ id: "item-1" }), createItem({ id: "item-2" })];
+
+    expect(
+      resolveDragOverItems({
+        items,
+        activeId: "missing",
+        overId: "item-2",
+        rect: makeRect(),
+        activatorEvent: null,
+        isMobileLayout: false,
+      }),
+    ).toBe(items);
+    expect(
+      resolveDragOverItems({
+        items,
+        activeId: "item-1",
+        overId: "item-1",
+        rect: makeRect(),
+        activatorEvent: null,
+        isMobileLayout: false,
+      }),
+    ).toBe(items);
+  });
+});
+
+describe("resolveDropPersistence", () => {
+  test("先頭挿入では次要素の sort_order から補間する", () => {
+    const items = [
+      createItem({ id: "item-1", sort_order: 1000 }),
+      createItem({ id: "item-2", sort_order: 2000 }),
+      createItem({ id: "item-3", sort_order: 3000 }),
+    ];
+    const localItems = [items[2], items[0], items[1]];
+
+    expect(resolveDropPersistence({ items, localItems, activeId: "item-3" })).toEqual({
+      activeId: "item-3",
+      status: "stacked",
+      sortOrder: 0,
+    });
+  });
+
+  test("末尾挿入では直前要素の sort_order に 1000 足す", () => {
+    const items = [
+      createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+      createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+      createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+    ];
+    const localItems = [
+      items[1],
+      items[2],
+      createItem({ id: "item-1", status: "watching", sort_order: 1000 }),
+    ];
+
+    expect(resolveDropPersistence({ items, localItems, activeId: "item-1" })).toEqual({
+      activeId: "item-1",
+      status: "watching",
+      sortOrder: 3000,
+    });
+  });
+
+  test("前後要素がある場合は中間値を使う", () => {
+    const items = [
+      createItem({ id: "item-1", sort_order: 1000 }),
+      createItem({ id: "item-2", sort_order: 2000 }),
+      createItem({ id: "item-3", sort_order: 3000 }),
+    ];
+    const localItems = [items[0], items[2], items[1]];
+
+    expect(resolveDropPersistence({ items, localItems, activeId: "item-3" })).toEqual({
+      activeId: "item-3",
+      status: "stacked",
+      sortOrder: 1500,
+    });
+  });
+
+  test("列内に 1 件だけなら初期 sort_order を使う", () => {
+    const items = [createItem({ id: "item-1", status: "stacked", sort_order: 1000 })];
+
+    expect(resolveDropPersistence({ items, localItems: items, activeId: "item-1" })).toEqual({
+      activeId: "item-1",
+      status: "stacked",
+      sortOrder: 1000,
+    });
+  });
+
+  test("drag 中アイテムが localItems に無ければ null を返す", () => {
+    const items = [createItem({ id: "item-1", sort_order: 1000 })];
+
+    expect(resolveDropPersistence({ items, localItems: items, activeId: "missing" })).toBeNull();
+  });
+});

--- a/src/features/backlog/hooks/useBacklogDnd.logic.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.ts
@@ -19,7 +19,7 @@ type DropPersistenceInput = Readonly<{
   activeId: string;
 }>;
 
-export type DropPersistence = Readonly<{
+type DropPersistence = Readonly<{
   activeId: string;
   status: BacklogStatus;
   sortOrder: number;

--- a/src/features/backlog/hooks/useBacklogDnd.logic.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.ts
@@ -1,0 +1,253 @@
+import type { DragOverEvent } from "@dnd-kit/core";
+import type { BacklogItem, BacklogStatus } from "../types.ts";
+
+export type RectLike = Pick<DOMRect, "top" | "height">;
+type TouchListKey = "touches" | "changedTouches";
+
+type DragOverResolutionInput = Readonly<{
+  items: BacklogItem[];
+  activeId: string;
+  overId: string;
+  rect: RectLike;
+  activatorEvent: DragOverEvent["activatorEvent"];
+  isMobileLayout: boolean;
+}>;
+
+type DropPersistenceInput = Readonly<{
+  items: BacklogItem[];
+  localItems: BacklogItem[];
+  activeId: string;
+}>;
+
+export type DropPersistence = Readonly<{
+  activeId: string;
+  status: BacklogStatus;
+  sortOrder: number;
+}>;
+
+function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null {
+  return items.find((item) => item.id === id)?.status ?? null;
+}
+
+function getDropSideFromRect(rect: RectLike, clientY: number) {
+  return clientY < rect.top + rect.height / 2 ? "before" : "after";
+}
+
+function getClientYFromPointerEvent(
+  event: MouseEvent | TouchEvent | null | undefined,
+  rect: RectLike,
+  touchListKey: TouchListKey = "touches",
+) {
+  const fallbackY = rect.top + rect.height / 2;
+
+  if (!event) {
+    return fallbackY;
+  }
+
+  if ("touches" in event && event.type.includes("touch")) {
+    const touchList = touchListKey === "changedTouches" ? event.changedTouches : event.touches;
+    return touchList?.[0]?.clientY ?? fallbackY;
+  }
+
+  return "clientY" in event ? (event.clientY ?? fallbackY) : fallbackY;
+}
+
+function resolveDropSide(
+  activatorEvent: DragOverEvent["activatorEvent"],
+  rect: RectLike,
+): "before" | "after" {
+  const clientY = getClientYFromPointerEvent(
+    activatorEvent as MouseEvent | TouchEvent | null | undefined,
+    rect,
+  );
+  return getDropSideFromRect(rect, clientY);
+}
+
+function getReorderedColumnItems(
+  columnItems: BacklogItem[],
+  activeId: string,
+  overId: string,
+  side: "before" | "after",
+) {
+  const activeIdx = columnItems.findIndex((item) => item.id === activeId);
+  const overIdx = columnItems.findIndex((item) => item.id === overId);
+  if (activeIdx === -1 || overIdx === -1) {
+    return columnItems;
+  }
+
+  const baseItems = columnItems.filter((item) => item.id !== activeId);
+  const targetIdx = baseItems.findIndex((item) => item.id === overId);
+  if (targetIdx === -1) {
+    return columnItems;
+  }
+
+  const insertionIdx = side === "before" ? targetIdx : targetIdx + 1;
+  const activeItem = columnItems[activeIdx];
+
+  return [...baseItems.slice(0, insertionIdx), activeItem, ...baseItems.slice(insertionIdx)];
+}
+
+function moveItemToColumnEnd(items: BacklogItem[], activeId: string, status: BacklogStatus) {
+  const activeItem = items.find((item) => item.id === activeId);
+  if (!activeItem) {
+    return items;
+  }
+
+  const updatedItems = items.map((item) => (item.id === activeId ? { ...item, status } : item));
+  const columnItems = updatedItems.filter((item) => item.status === status && item.id !== activeId);
+  const others = updatedItems.filter((item) => item.status !== status);
+
+  return [...others, ...columnItems, { ...activeItem, status }];
+}
+
+function moveItemToColumnTop(items: BacklogItem[], activeId: string, status: BacklogStatus) {
+  const activeItem = items.find((item) => item.id === activeId);
+  if (!activeItem) {
+    return items;
+  }
+
+  const updatedItems = items.map((item) => (item.id === activeId ? { ...item, status } : item));
+  const columnItems = updatedItems.filter((item) => item.status === status && item.id !== activeId);
+  const others = updatedItems.filter((item) => item.status !== status);
+
+  return [...others, { ...activeItem, status }, ...columnItems];
+}
+
+function reorderWithinColumn(
+  items: BacklogItem[],
+  status: BacklogStatus,
+  activeId: string,
+  overId: string,
+  side: "before" | "after",
+) {
+  const columnItems = items.filter((item) => item.status === status);
+  const others = items.filter((item) => item.status !== status);
+  return [...others, ...getReorderedColumnItems(columnItems, activeId, overId, side)];
+}
+
+function moveToColumnEdge(items: BacklogItem[], activeId: string, status: BacklogStatus) {
+  return status === "watched"
+    ? moveItemToColumnTop(items, activeId, status)
+    : moveItemToColumnEnd(items, activeId, status);
+}
+
+function moveAcrossColumns(
+  items: BacklogItem[],
+  activeId: string,
+  status: BacklogStatus,
+  overId: string,
+  side: "before" | "after",
+) {
+  const updatedItems = items.map((item) => (item.id === activeId ? { ...item, status } : item));
+  const columnItems = updatedItems.filter((item) => item.status === status);
+  const others = updatedItems.filter((item) => item.status !== status);
+  return [...others, ...getReorderedColumnItems(columnItems, activeId, overId, side)];
+}
+
+function resolveOverStatus(items: BacklogItem[], overId: string): BacklogStatus | null {
+  return overId.startsWith("column:")
+    ? (overId.replace("column:", "") as BacklogStatus)
+    : findItemStatus(items, overId);
+}
+
+function calculateInsertedSortOrder(
+  prevSortOrder: number | null,
+  nextSortOrder: number | null,
+): number {
+  if (prevSortOrder === null && nextSortOrder === null) {
+    return 1000;
+  }
+
+  if (prevSortOrder === null) {
+    return (nextSortOrder as number) - 1000;
+  }
+
+  if (nextSortOrder === null) {
+    return prevSortOrder + 1000;
+  }
+
+  return (prevSortOrder + nextSortOrder) / 2;
+}
+
+export function resolveDragOverItems({
+  items,
+  activeId,
+  overId,
+  rect,
+  activatorEvent,
+  isMobileLayout,
+}: DragOverResolutionInput): BacklogItem[] {
+  if (activeId === overId) {
+    return items;
+  }
+
+  const activeItem = items.find((item) => item.id === activeId);
+  if (!activeItem) {
+    return items;
+  }
+
+  const overStatus = resolveOverStatus(items, overId);
+  if (!overStatus) {
+    return items;
+  }
+
+  if (isMobileLayout && activeItem.status !== overStatus) {
+    return items;
+  }
+
+  if (activeItem.status === overStatus) {
+    if (overId.startsWith("column:")) {
+      return items;
+    }
+
+    return reorderWithinColumn(
+      items,
+      overStatus,
+      activeId,
+      overId,
+      resolveDropSide(activatorEvent, rect),
+    );
+  }
+
+  if (overId.startsWith("column:")) {
+    return moveToColumnEdge(items, activeId, overStatus);
+  }
+
+  return moveAcrossColumns(
+    items,
+    activeId,
+    overStatus,
+    overId,
+    resolveDropSide(activatorEvent, rect),
+  );
+}
+
+export function resolveDropPersistence({
+  items,
+  localItems,
+  activeId,
+}: DropPersistenceInput): DropPersistence | null {
+  const draggedItem = localItems.find((item) => item.id === activeId);
+  if (!draggedItem) {
+    return null;
+  }
+
+  const columnOrder = localItems
+    .filter((item) => item.status === draggedItem.status)
+    .map((item) => item.id);
+  const insertedIndex = columnOrder.indexOf(activeId);
+  const prevId = insertedIndex > 0 ? columnOrder[insertedIndex - 1] : null;
+  const nextId = insertedIndex < columnOrder.length - 1 ? columnOrder[insertedIndex + 1] : null;
+
+  const prevItem = prevId ? items.find((item) => item.id === prevId) : null;
+  const nextItem = nextId ? items.find((item) => item.id === nextId) : null;
+
+  return {
+    activeId,
+    status: draggedItem.status,
+    sortOrder: calculateInsertedSortOrder(
+      prevItem?.sort_order ?? null,
+      nextItem?.sort_order ?? null,
+    ),
+  };
+}

--- a/src/features/backlog/hooks/useBacklogDnd.test-helpers.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.test-helpers.ts
@@ -1,0 +1,63 @@
+import type { BacklogItem } from "../types.ts";
+import type { RectLike } from "./useBacklogDnd.logic.ts";
+
+export function createBacklogItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
+  return {
+    id: "item-1",
+    status: "stacked",
+    primary_platform: null,
+    note: null,
+    sort_order: 1000,
+    works: null,
+    ...overrides,
+  };
+}
+
+export function createStackedItems(): BacklogItem[] {
+  return [
+    createBacklogItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+    createBacklogItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
+  ];
+}
+
+export function createWatchingItems(): BacklogItem[] {
+  return [
+    createBacklogItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+    createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+    createBacklogItem({ id: "item-3", status: "watching", sort_order: 2000 }),
+  ];
+}
+
+export function createMixedColumnItems(): BacklogItem[] {
+  return [
+    createBacklogItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+    createBacklogItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
+    createBacklogItem({ id: "item-3", status: "watching", sort_order: 1000 }),
+  ];
+}
+
+export function makeLogicRect(top = 100, height = 200): RectLike {
+  return { top, height };
+}
+
+export function makeDomRect(top = 100, height = 200): DOMRect {
+  return {
+    top,
+    height,
+    left: 0,
+    right: 100,
+    bottom: top + height,
+    width: 100,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+export function createTouchEvent(clientY?: number): TouchEvent {
+  return {
+    type: "touchmove",
+    touches: clientY === undefined ? [] : [{ clientY }],
+    changedTouches: clientY === undefined ? [] : [{ clientY }],
+  } as unknown as TouchEvent;
+}

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -3,6 +3,13 @@ import type { DragEndEvent, DragOverEvent, DragStartEvent } from "@dnd-kit/core"
 import { useBacklogDnd } from "./useBacklogDnd.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import type { BacklogItem } from "../types.ts";
+import {
+  createBacklogItem,
+  createMixedColumnItems,
+  createStackedItems,
+  createWatchingItems,
+  makeDomRect,
+} from "./useBacklogDnd.test-helpers.ts";
 
 const supabaseMocks = vi.hoisted(() => {
   const eq = vi.fn();
@@ -20,54 +27,12 @@ vi.mock("../../../lib/supabase.ts", () => ({
 
 setupTestLifecycle();
 
-function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
-  return {
-    id: "item-1",
-    status: "stacked",
-    primary_platform: null,
-    note: null,
-    sort_order: 1000,
-    works: null,
-    ...overrides,
-  };
-}
-
-function makeRect(top = 100, height = 200): DOMRect {
-  return {
-    top,
-    height,
-    left: 0,
-    right: 100,
-    bottom: top + height,
-    width: 100,
-    x: 0,
-    y: top,
-    toJSON: () => ({}),
-  } as DOMRect;
-}
-
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   const promise = new Promise<T>((res) => {
     resolve = res;
   });
   return { promise, resolve };
-}
-
-function createWatchingItems(): BacklogItem[] {
-  return [
-    createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-    createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
-    createItem({ id: "item-3", status: "watching", sort_order: 2000 }),
-  ];
-}
-
-function createMixedColumnItems(): BacklogItem[] {
-  return [
-    createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-    createItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
-    createItem({ id: "item-3", status: "watching", sort_order: 1000 }),
-  ];
 }
 
 const onAfterDrop = vi.fn().mockResolvedValue(undefined);
@@ -106,7 +71,7 @@ function dragOver(
     result.current.handleDragStart({ active: { id: activeId } } as DragStartEvent);
     result.current.handleDragOver({
       active: { id: activeId },
-      over: { id: overId, rect: makeRect(100, 200) },
+      over: { id: overId, rect: makeDomRect(100, 200) },
       activatorEvent: { clientY } as MouseEvent,
     } as unknown as DragOverEvent);
   });
@@ -120,10 +85,7 @@ function getOrderByStatus(
 }
 
 describe("useBacklogDnd", () => {
-  const stackedItems = [
-    createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-    createItem({ id: "item-2", status: "stacked", sort_order: 2000 }),
-  ];
+  const stackedItems = createStackedItems();
 
   beforeEach(() => {
     supabaseMocks.eq.mockResolvedValue({ error: null });
@@ -160,7 +122,7 @@ describe("useBacklogDnd", () => {
 
   test("handleDragEnd 成功時に supabase を更新して onAfterDrop を呼び dragItemId をクリアする", async () => {
     const { result } = renderDnd(stackedItems);
-    const rect = makeRect(100, 200);
+    const rect = makeDomRect(100, 200);
 
     await act(async () => {
       await result.current.handleDragEnd({
@@ -180,7 +142,7 @@ describe("useBacklogDnd", () => {
   test("handleDragEnd で supabase がエラーを返したら alert を出して onAfterDrop を呼ばない", async () => {
     supabaseMocks.eq.mockResolvedValueOnce({ error: { message: "DB エラー" } });
     const { result } = renderDnd(stackedItems);
-    const rect = makeRect(100, 200);
+    const rect = makeDomRect(100, 200);
 
     await act(async () => {
       await result.current.handleDragEnd({
@@ -208,7 +170,7 @@ describe("useBacklogDnd", () => {
     act(() => {
       dragEndPromise = result.current.handleDragEnd({
         active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
+        over: { id: "item-2", rect: makeDomRect(100, 200) },
         activatorEvent: null,
       } as unknown as DragEndEvent);
     });
@@ -227,8 +189,8 @@ describe("useBacklogDnd", () => {
   test("handleDragEnd 後に onAfterDrop が失敗しても次回同期をブロックし続けない", async () => {
     const failingOnAfterDrop = vi.fn().mockRejectedValue(new Error("reload failed"));
     const reorderedItems = [
-      createItem({ id: "item-2", status: "stacked", sort_order: 1000 }),
-      createItem({ id: "item-1", status: "stacked", sort_order: 2000 }),
+      createBacklogItem({ id: "item-2", status: "stacked", sort_order: 1000 }),
+      createBacklogItem({ id: "item-1", status: "stacked", sort_order: 2000 }),
     ];
     const { result, rerender } = renderHook(
       ({ items }) =>
@@ -247,7 +209,7 @@ describe("useBacklogDnd", () => {
       act(async () => {
         await result.current.handleDragEnd({
           active: { id: "item-1" },
-          over: { id: "item-2", rect: makeRect(100, 200) },
+          over: { id: "item-2", rect: makeDomRect(100, 200) },
           activatorEvent: null,
         } as unknown as DragEndEvent);
       }),
@@ -283,12 +245,12 @@ describe("useBacklogDnd", () => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-3", rect: makeRect(100, 200) },
+        over: { id: "item-3", rect: makeDomRect(100, 200) },
         activatorEvent: { clientY: 120 } as MouseEvent,
       } as unknown as DragOverEvent);
       result.current.handleDragOver({
         active: { id: "item-1" },
-        over: { id: "item-2", rect: makeRect(100, 200) },
+        over: { id: "item-2", rect: makeDomRect(100, 200) },
         activatorEvent: { clientY: 120 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
@@ -310,7 +272,7 @@ describe("useBacklogDnd", () => {
     await act(async () => {
       await result.current.handleDragEnd({
         active: { id: "item-1" },
-        over: { id: "column:watching", rect: makeRect(100, 200) },
+        over: { id: "column:watching", rect: makeDomRect(100, 200) },
         activatorEvent: null,
       } as unknown as DragEndEvent);
     });
@@ -324,8 +286,8 @@ describe("useBacklogDnd", () => {
   test("モバイルレイアウトでは handleDragOver が列間移動をブロックする", () => {
     const { result } = renderDnd(
       [
-        createItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
-        createItem({ id: "item-2", status: "watching", sort_order: 1000 }),
+        createBacklogItem({ id: "item-1", status: "stacked", sort_order: 1000 }),
+        createBacklogItem({ id: "item-2", status: "watching", sort_order: 1000 }),
       ],
       { isMobileLayout: true },
     );

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -9,8 +9,9 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core";
 import { supabase } from "../../../lib/supabase.ts";
-import type { BacklogItem, BacklogStatus } from "../types.ts";
+import type { BacklogItem } from "../types.ts";
 import { browserBacklogFeedback, type BacklogFeedback } from "../ui-feedback.ts";
+import { resolveDragOverItems, resolveDropPersistence } from "./useBacklogDnd.logic.ts";
 
 const EMPTY_PENDING_DELETES: ReadonlySet<string> = new Set();
 
@@ -21,136 +22,6 @@ type Props = Readonly<{
   onAfterDrop: () => Promise<void>;
   feedback?: BacklogFeedback;
 }>;
-
-type RectLike = Pick<DOMRect, "top" | "height">;
-type TouchListKey = "touches" | "changedTouches";
-
-function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null {
-  return items.find((i) => i.id === id)?.status ?? null;
-}
-
-function getDropSideFromRect(rect: RectLike, clientY: number) {
-  return clientY < rect.top + rect.height / 2 ? "before" : "after";
-}
-
-function getClientYFromPointerEvent(
-  event: MouseEvent | TouchEvent | null | undefined,
-  rect: RectLike,
-  touchListKey: TouchListKey = "touches",
-) {
-  const fallbackY = rect.top + rect.height / 2;
-
-  if (!event) {
-    return fallbackY;
-  }
-
-  if ("touches" in event && event.type.includes("touch")) {
-    const touchList = touchListKey === "changedTouches" ? event.changedTouches : event.touches;
-    return touchList?.[0]?.clientY ?? fallbackY;
-  }
-
-  return "clientY" in event ? (event.clientY ?? fallbackY) : fallbackY;
-}
-
-function getReorderedColumnItems(
-  columnItems: BacklogItem[],
-  activeId: string,
-  overId: string,
-  side: "before" | "after",
-) {
-  const activeIdx = columnItems.findIndex((i) => i.id === activeId);
-  const overIdx = columnItems.findIndex((i) => i.id === overId);
-  if (activeIdx === -1 || overIdx === -1) return columnItems;
-
-  const baseItems = columnItems.filter((i) => i.id !== activeId);
-  const targetIdx = baseItems.findIndex((i) => i.id === overId);
-  if (targetIdx === -1) return columnItems;
-
-  const insertionIdx = side === "before" ? targetIdx : targetIdx + 1;
-  const activeItem = columnItems[activeIdx];
-
-  return [...baseItems.slice(0, insertionIdx), activeItem, ...baseItems.slice(insertionIdx)];
-}
-
-function moveItemToColumnEnd(items: BacklogItem[], activeId: string, status: BacklogStatus) {
-  const activeItem = items.find((i) => i.id === activeId);
-  if (!activeItem) return items;
-
-  const updatedItems = items.map((i) => (i.id === activeId ? { ...i, status } : i));
-  const columnItems = updatedItems.filter((i) => i.status === status && i.id !== activeId);
-  const others = updatedItems.filter((i) => i.status !== status);
-
-  return [...others, ...columnItems, { ...activeItem, status }];
-}
-
-function moveItemToColumnTop(items: BacklogItem[], activeId: string, status: BacklogStatus) {
-  const activeItem = items.find((i) => i.id === activeId);
-  if (!activeItem) return items;
-
-  const updatedItems = items.map((i) => (i.id === activeId ? { ...i, status } : i));
-  const columnItems = updatedItems.filter((i) => i.status === status && i.id !== activeId);
-  const others = updatedItems.filter((i) => i.status !== status);
-
-  return [...others, { ...activeItem, status }, ...columnItems];
-}
-
-function resolveDropSide(
-  activatorEvent: DragOverEvent["activatorEvent"],
-  rect: RectLike,
-): "before" | "after" {
-  const clientY = getClientYFromPointerEvent(
-    activatorEvent as MouseEvent | TouchEvent | null | undefined,
-    rect,
-  );
-  return getDropSideFromRect(rect, clientY);
-}
-
-function reorderWithinColumn(
-  prev: BacklogItem[],
-  overStatus: BacklogStatus,
-  activeId: string,
-  overId: string,
-  side: "before" | "after",
-) {
-  const colItems = prev.filter((i) => i.status === overStatus);
-  const others = prev.filter((i) => i.status !== overStatus);
-  return [...others, ...getReorderedColumnItems(colItems, activeId, overId, side)];
-}
-
-function moveToColumnEdge(prev: BacklogItem[], activeId: string, overStatus: BacklogStatus) {
-  return overStatus === "watched"
-    ? moveItemToColumnTop(prev, activeId, overStatus)
-    : moveItemToColumnEnd(prev, activeId, overStatus);
-}
-
-function moveAcrossColumns(
-  prev: BacklogItem[],
-  activeId: string,
-  overStatus: BacklogStatus,
-  overId: string,
-  side: "before" | "after",
-) {
-  const withUpdatedStatus = prev.map((i) => (i.id === activeId ? { ...i, status: overStatus } : i));
-  const newColItems = withUpdatedStatus.filter((i) => i.status === overStatus);
-  const others = withUpdatedStatus.filter((i) => i.status !== overStatus);
-  return [...others, ...getReorderedColumnItems(newColItems, activeId, overId, side)];
-}
-
-function calculateInsertedSortOrder(
-  prevSortOrder: number | null,
-  nextSortOrder: number | null,
-): number {
-  if (prevSortOrder === null && nextSortOrder === null) {
-    return 1000;
-  }
-  if (prevSortOrder === null) {
-    return (nextSortOrder as number) - 1000;
-  }
-  if (nextSortOrder === null) {
-    return prevSortOrder + 1000;
-  }
-  return (prevSortOrder + nextSortOrder) / 2;
-}
 
 export function useBacklogDnd({
   items,
@@ -187,39 +58,22 @@ export function useBacklogDnd({
 
   const handleDragOver = (event: DragOverEvent) => {
     const { active, over, activatorEvent } = event;
-    if (!over) return;
+    if (!over) {
+      return;
+    }
 
     const activeId = active.id as string;
     const overId = over.id as string;
 
-    if (activeId === overId) return;
-
     setLocalItems((prev) => {
-      const activeItem = prev.find((i) => i.id === activeId);
-      if (!activeItem) return prev;
-      const activeStatus = activeItem.status;
-      const overStatus = overId.startsWith("column:")
-        ? (overId.replace("column:", "") as BacklogStatus)
-        : findItemStatus(prev, overId);
-
-      if (!overStatus) return prev;
-      if (isMobileLayout && activeStatus !== overStatus) return prev;
-
-      if (activeStatus === overStatus) {
-        // 同列内での並び替え
-        if (overId.startsWith("column:")) return prev;
-        const side = resolveDropSide(activatorEvent, over.rect);
-        return reorderWithinColumn(prev, overStatus, activeId, overId, side);
-      }
-
-      // 列またぎ: ステータスを変更して over アイテムの位置に挿入
-      // watched への列端ドロップは先頭挿入（handleMarkAsWatched と同じ並び順）
-      if (overId.startsWith("column:")) {
-        return moveToColumnEdge(prev, activeId, overStatus);
-      }
-
-      const side = resolveDropSide(activatorEvent, over.rect);
-      return moveAcrossColumns(prev, activeId, overStatus, overId, side);
+      return resolveDragOverItems({
+        items: prev,
+        activeId,
+        overId,
+        rect: over.rect,
+        activatorEvent,
+        isMobileLayout,
+      });
     });
   };
 
@@ -240,34 +94,19 @@ export function useBacklogDnd({
     }
 
     const activeId = active.id as string;
-    const draggedItem = localItems.find((i) => i.id === activeId);
-    if (!draggedItem) {
+    const dropPersistence = resolveDropPersistence({ items, localItems, activeId });
+    if (!dropPersistence) {
       setIsDropSyncPending(false);
       setLocalItems(items);
       return;
     }
 
-    const targetStatus = draggedItem.status;
-    const columnOrder = localItems.filter((i) => i.status === targetStatus).map((i) => i.id);
-    const insertedIndex = columnOrder.indexOf(activeId);
-
-    const prevId = insertedIndex > 0 ? columnOrder[insertedIndex - 1] : null;
-    const nextId = insertedIndex < columnOrder.length - 1 ? columnOrder[insertedIndex + 1] : null;
-
-    // sort_order はサーバーアイテムの値を使って補間する
-    const prevItem = prevId ? items.find((i) => i.id === prevId) : null;
-    const nextItem = nextId ? items.find((i) => i.id === nextId) : null;
-    const sortOrder = calculateInsertedSortOrder(
-      prevItem?.sort_order ?? null,
-      nextItem?.sort_order ?? null,
-    );
-
     setIsDropSyncPending(true);
     try {
       const { error: updateError } = await supabase
         .from("backlog_items")
-        .update({ status: targetStatus, sort_order: sortOrder })
-        .eq("id", activeId);
+        .update({ status: dropPersistence.status, sort_order: dropPersistence.sortOrder })
+        .eq("id", dropPersistence.activeId);
 
       if (updateError) {
         await Promise.resolve(feedback.alert(`ドラッグ移動に失敗しました: ${updateError.message}`));


### PR DESCRIPTION
## 関連 Issue

Refs #262

## 変更内容

- `useBacklogDnd` のドラッグ判定と drop 永続化計算を `useBacklogDnd.logic.ts` に切り出し、hook 側の責務を縮小
- 切り出した純粋ロジックに対して、同列並び替え、列またぎ、モバイル制約、touch event、sort_order 補間を直接検証するテストを追加
- 既存の hook テストはそのまま維持しつつ、関連 hooks テスト一式で回帰確認

