### PR TITLE
chore: vite-plus依存のバージョン指定を明示

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest",
+    "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.18",
+    "vite-plus": "^0.1.18",
     "vitest": "^4.1.2"
   },
   "packageManager": "pnpm@10.33.0",
@@ -66,7 +66,7 @@
       "msw": true
     },
     "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest"
+      "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.18"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vite: npm:@voidzero-dev/vite-plus-core@^0.1.18
 
 importers:
 
@@ -118,10 +118,10 @@ importers:
         specifier: ~6.0.0
         version: 6.0.3
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        specifier: npm:@voidzero-dev/vite-plus-core@^0.1.18
         version: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.3)'
       vite-plus:
-        specifier: latest
+        specifier: ^0.1.18
         version: 0.1.18(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(jiti@2.6.1)(typescript@6.0.3)(yaml@2.8.3))(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@1.8.0))(typescript@6.0.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.2


### PR DESCRIPTION
## 関連 Issue

<!-- 関連 Issue があれば Refs #123 または Closes #123 の形式で記載 -->

## 変更内容

- `vite-plus` の依存指定を `latest` から `^0.1.18` に変更
- `vite` の override / alias 指定を `npm:@voidzero-dev/vite-plus-core@^0.1.18` に変更
- `pnpm-lock.yaml` の specifier を同期し、Dependabot の誤検知ノイズを減らす
