### PR TITLE
test: quality report のテスト保守性を改善

### DIFF
--- a/src/features/backlog/components/UserMenu.test.tsx
+++ b/src/features/backlog/components/UserMenu.test.tsx
@@ -11,6 +11,10 @@ vi.mock("../../../lib/auth-repository.ts", () => authRepositoryMock);
 
 setupTestLifecycle();
 
+function renderUserMenu() {
+  render(<UserMenu email="user@example.com" />);
+}
+
 async function openMenuItem(user: ReturnType<typeof userEvent.setup>, name: string) {
   const trigger = screen.getByRole("button", { name: /user@example.com/i });
   trigger.focus();
@@ -20,6 +24,19 @@ async function openMenuItem(user: ReturnType<typeof userEvent.setup>, name: stri
 
 describe("UserMenu", () => {
   const openMock = vi.fn();
+
+  async function expectNewTabOpened(
+    user: ReturnType<typeof userEvent.setup>,
+    name: string,
+    path: string,
+  ) {
+    renderUserMenu();
+    await openMenuItem(user, name);
+
+    await waitFor(() =>
+      expect(openMock).toHaveBeenCalledWith(path, "_blank", "noopener,noreferrer"),
+    );
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,7 +51,7 @@ describe("UserMenu", () => {
   test("About からアプリの説明と TMDB attribution を確認できる", async () => {
     const user = userEvent.setup();
 
-    render(<UserMenu email="user@example.com" />);
+    renderUserMenu();
     await openMenuItem(user, "About");
 
     expect(await screen.findByRole("dialog", { name: "みるカンについて" })).toBeInTheDocument();
@@ -53,30 +70,18 @@ describe("UserMenu", () => {
 
   test("メニューから利用規約ページを新しいタブで開ける", async () => {
     const user = userEvent.setup();
-
-    render(<UserMenu email="user@example.com" />);
-    await openMenuItem(user, "利用規約");
-
-    await waitFor(() =>
-      expect(openMock).toHaveBeenCalledWith("/terms", "_blank", "noopener,noreferrer"),
-    );
+    await expectNewTabOpened(user, "利用規約", "/terms");
   });
 
   test("メニューからプライバシーポリシーページを新しいタブで開ける", async () => {
     const user = userEvent.setup();
-
-    render(<UserMenu email="user@example.com" />);
-    await openMenuItem(user, "プライバシーポリシー");
-
-    await waitFor(() =>
-      expect(openMock).toHaveBeenCalledWith("/privacy", "_blank", "noopener,noreferrer"),
-    );
+    await expectNewTabOpened(user, "プライバシーポリシー", "/privacy");
   });
 
   test("お問い合わせからメールと GitHub Issues の導線を確認できる", async () => {
     const user = userEvent.setup();
 
-    render(<UserMenu email="user@example.com" />);
+    renderUserMenu();
     await openMenuItem(user, "お問い合わせ");
 
     expect(await screen.findByRole("dialog", { name: "お問い合わせ" })).toBeInTheDocument();

--- a/src/test/mocks/handlers/supabase-rest.test.ts
+++ b/src/test/mocks/handlers/supabase-rest.test.ts
@@ -1,0 +1,173 @@
+import { setupTestLifecycle } from "../../test-lifecycle.ts";
+import {
+  getMockBacklogItems,
+  getMockWorks,
+  setMockBacklogItems,
+  setMockWorks,
+} from "./supabase-rest.ts";
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || "http://localhost:54321";
+
+setupTestLifecycle();
+
+function restUrl(path: string) {
+  return `${SUPABASE_URL}/rest/v1/${path}`;
+}
+
+async function readJson(response: Response) {
+  return (await response.json()) as unknown;
+}
+
+describe("supabaseRestHandlers", () => {
+  test("object response 指定で 0 件なら 406 を返す", async () => {
+    const response = await fetch(restUrl("works?select=id&tmdb_id=eq.999"), {
+      headers: { accept: "application/vnd.pgrst.object+json" },
+    });
+
+    expect(response.status).toBe(406);
+    await expect(readJson(response)).resolves.toEqual({
+      message: "JSON object requested, multiple (or no) rows returned",
+    });
+  });
+
+  test("object response 指定で複数件なら 406 を返す", async () => {
+    setMockWorks([
+      { id: "work-1", tmdb_id: 1, title: "作品1" },
+      { id: "work-2", tmdb_id: 2, title: "作品2" },
+    ]);
+
+    const response = await fetch(restUrl("works?select=id,title"), {
+      headers: { accept: "application/vnd.pgrst.object+json" },
+    });
+
+    expect(response.status).toBe(406);
+    await expect(readJson(response)).resolves.toEqual({
+      message: "JSON object requested, multiple (or no) rows returned",
+    });
+  });
+
+  test("backlog_items を複数 order で取得すると null を含めて並び替える", async () => {
+    setMockWorks([
+      { id: "work-1", title: "作品1" },
+      { id: "work-2", title: "作品2" },
+      { id: "work-3", title: "作品3" },
+    ]);
+    setMockBacklogItems([
+      { id: "item-1", work_id: "work-1", sort_order: 2000, display_title: "B" },
+      { id: "item-2", work_id: "work-2", sort_order: 1000, display_title: null },
+      { id: "item-3", work_id: "work-3", sort_order: 1000, display_title: "A" },
+    ]);
+
+    const response = await fetch(
+      restUrl("backlog_items?order=sort_order.asc&order=display_title.asc"),
+    );
+
+    await expect(readJson(response)).resolves.toEqual([
+      expect.objectContaining({ id: "item-2", display_title: null }),
+      expect.objectContaining({ id: "item-3", display_title: "A" }),
+      expect.objectContaining({ id: "item-1", display_title: "B" }),
+    ]);
+  });
+
+  test("backlog_items の on_conflict=user_id,work_id で既存行を更新する", async () => {
+    setMockBacklogItems([
+      {
+        id: "existing-item",
+        user_id: "user-1",
+        work_id: "work-1",
+        status: "stacked",
+        sort_order: 1000,
+        note: null,
+      },
+    ]);
+
+    const response = await fetch(restUrl("backlog_items?on_conflict=user_id,work_id"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        prefer: "return=representation",
+      },
+      body: JSON.stringify({
+        user_id: "user-1",
+        work_id: "work-1",
+        status: "watching",
+        sort_order: 2000,
+        note: "updated",
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    expect(getMockBacklogItems()).toEqual([
+      expect.objectContaining({
+        id: "existing-item",
+        status: "watching",
+        sort_order: 2000,
+        note: "updated",
+      }),
+    ]);
+  });
+
+  test("works の重複 insert は 409 を返す", async () => {
+    setMockWorks([
+      {
+        id: "existing-work",
+        created_by: "user-1",
+        source_type: "tmdb",
+        work_type: "movie",
+        search_text: "same-title",
+        title: "既存作品",
+      },
+    ]);
+
+    const response = await fetch(restUrl("works"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        created_by: "user-1",
+        source_type: "tmdb",
+        work_type: "movie",
+        search_text: "same-title",
+        title: "重複作品",
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(readJson(response)).resolves.toEqual({
+      message: "duplicate key value",
+      code: "23505",
+    });
+  });
+
+  test("Prefer:return=representation なしの PATCH は 204 を返す", async () => {
+    setMockWorks([
+      {
+        id: "work-1",
+        tmdb_id: 10,
+        title: "更新前",
+      },
+    ]);
+
+    const response = await fetch(restUrl("works?tmdb_id=eq.10"), {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "更新後" }),
+    });
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+    expect(getMockWorks()).toEqual([expect.objectContaining({ id: "work-1", title: "更新後" })]);
+  });
+
+  test("一致する backlog item が無ければ PATCH は 404 を返す", async () => {
+    const response = await fetch(restUrl("backlog_items?id=eq.missing"), {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ note: "updated" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(readJson(response)).resolves.toEqual({
+      message: "Backlog item not found",
+    });
+  });
+});

--- a/src/test/mocks/handlers/supabase-rest.ts
+++ b/src/test/mocks/handlers/supabase-rest.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import type { BacklogItem, Work } from "../types";
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || "http://localhost:54321";
+const IGNORED_FILTER_KEYS = ["select", "order", "limit", "offset", "columns", "on_conflict"];
 
 const mockWorks = new Map<string, Work>();
 const mockBacklogItems = new Map<string, BacklogItem>();
@@ -90,6 +91,10 @@ export function getMockBacklogItems() {
   return Array.from(mockBacklogItems.values()).map(clone);
 }
 
+type ComparableValue = string | number | boolean | null | undefined;
+type BacklogPayload = Partial<BacklogItem> | Array<Partial<BacklogItem>>;
+type WorkPayload = Partial<Work> | Array<Partial<Work>>;
+
 function isObjectResponse(request: Request) {
   return request.headers.get("accept")?.includes("application/vnd.pgrst.object+json") ?? false;
 }
@@ -133,7 +138,7 @@ function pickSelectedFields<T extends Record<string, unknown>>(row: T, selectVal
 
 function matchesFilters<T extends Record<string, unknown>>(row: T, url: URL) {
   for (const [key, value] of url.searchParams.entries()) {
-    if (["select", "order", "limit", "offset", "columns", "on_conflict"].includes(key)) {
+    if (IGNORED_FILTER_KEYS.includes(key)) {
       continue;
     }
 
@@ -176,15 +181,15 @@ function compareByOrderParam<T extends Record<string, unknown>>(
 ) {
   const [column, direction = "asc"] = orderParam.split(".");
   return compareOrderedValues(
-    left[column] as string | number | boolean | null | undefined,
-    right[column] as string | number | boolean | null | undefined,
+    left[column] as ComparableValue,
+    right[column] as ComparableValue,
     direction,
   );
 }
 
 function compareOrderedValues(
-  leftValue: string | number | boolean | null | undefined,
-  rightValue: string | number | boolean | null | undefined,
+  leftValue: ComparableValue,
+  rightValue: ComparableValue,
   direction: string,
 ) {
   if (leftValue === rightValue) {
@@ -225,6 +230,72 @@ function jsonNoContent(status = 201) {
   return new HttpResponse(null, { status });
 }
 
+function createRows<T>(payload: T | T[], ensureDefaults: (value: T) => T) {
+  return (Array.isArray(payload) ? payload : [payload]).map(ensureDefaults);
+}
+
+function upsertBacklogRows(rows: BacklogItem[], url: URL) {
+  if (url.searchParams.get("on_conflict") !== "user_id,work_id") {
+    rows.forEach((row) => {
+      mockBacklogItems.set(row.id, row);
+    });
+    return;
+  }
+
+  rows.forEach((row) => {
+    const existing = Array.from(mockBacklogItems.values()).find(
+      (item) => item.user_id === row.user_id && item.work_id === row.work_id,
+    );
+    const merged = ensureBacklogItemDefaults({
+      ...existing,
+      ...row,
+      id: existing?.id ?? row.id,
+    });
+    mockBacklogItems.set(merged.id, merged);
+  });
+}
+
+function hasWorkConflict(rows: Work[]) {
+  return rows.some((row) =>
+    Array.from(mockWorks.values()).some(
+      (work) =>
+        work.created_by === row.created_by &&
+        work.source_type === row.source_type &&
+        work.work_type === row.work_type &&
+        work.search_text === row.search_text,
+    ),
+  );
+}
+
+function upsertWorks(rows: Work[], url: URL) {
+  if (!url.searchParams.get("on_conflict") && hasWorkConflict(rows)) {
+    return HttpResponse.json({ message: "duplicate key value", code: "23505" }, { status: 409 });
+  }
+
+  rows.forEach((row) => {
+    mockWorks.set(row.id, row);
+  });
+
+  return null;
+}
+
+function patchStoredRow<T extends Record<string, unknown>>(
+  store: Map<string, T>,
+  url: URL,
+  body: Partial<T>,
+  notFoundMessage: string,
+  ensureDefaults: (value: Partial<T>) => T,
+) {
+  const target = Array.from(store.values()).find((row) => matchesFilters(row, url));
+  if (!target) {
+    return HttpResponse.json({ message: notFoundMessage }, { status: 404 });
+  }
+
+  const updated = ensureDefaults({ ...target, ...body });
+  store.set(String(updated.id), updated);
+  return updated;
+}
+
 export const supabaseRestHandlers = [
   http.get(`${SUPABASE_URL}/rest/v1/backlog_items`, ({ request }) => {
     const url = new URL(request.url);
@@ -243,26 +314,9 @@ export const supabaseRestHandlers = [
 
   http.post(`${SUPABASE_URL}/rest/v1/backlog_items`, async ({ request }) => {
     const url = new URL(request.url);
-    const payload = (await request.json()) as Partial<BacklogItem> | Array<Partial<BacklogItem>>;
-    const rows = (Array.isArray(payload) ? payload : [payload]).map(ensureBacklogItemDefaults);
-
-    if (url.searchParams.get("on_conflict") === "user_id,work_id") {
-      rows.forEach((row) => {
-        const existing = Array.from(mockBacklogItems.values()).find(
-          (item) => item.user_id === row.user_id && item.work_id === row.work_id,
-        );
-        const merged = ensureBacklogItemDefaults({
-          ...existing,
-          ...row,
-          id: existing?.id ?? row.id,
-        });
-        mockBacklogItems.set(merged.id, merged);
-      });
-    } else {
-      rows.forEach((row) => {
-        mockBacklogItems.set(row.id, row);
-      });
-    }
+    const payload = (await request.json()) as BacklogPayload;
+    const rows = createRows(payload, ensureBacklogItemDefaults);
+    upsertBacklogRows(rows, url);
 
     if (!shouldReturnRepresentation(request)) {
       return jsonNoContent();
@@ -273,34 +327,11 @@ export const supabaseRestHandlers = [
 
   http.post(`${SUPABASE_URL}/rest/v1/works`, async ({ request }) => {
     const url = new URL(request.url);
-    const payload = (await request.json()) as Partial<Work> | Array<Partial<Work>>;
-    const rows = (Array.isArray(payload) ? payload : [payload]).map(ensureWorkDefaults);
-
-    if (url.searchParams.get("on_conflict")) {
-      rows.forEach((row) => {
-        mockWorks.set(row.id, row);
-      });
-    } else {
-      const hasConflict = rows.some((row) =>
-        Array.from(mockWorks.values()).some(
-          (work) =>
-            work.created_by === row.created_by &&
-            work.source_type === row.source_type &&
-            work.work_type === row.work_type &&
-            work.search_text === row.search_text,
-        ),
-      );
-
-      if (hasConflict) {
-        return HttpResponse.json(
-          { message: "duplicate key value", code: "23505" },
-          { status: 409 },
-        );
-      }
-
-      rows.forEach((row) => {
-        mockWorks.set(row.id, row);
-      });
+    const payload = (await request.json()) as WorkPayload;
+    const rows = createRows(payload, ensureWorkDefaults);
+    const conflictResponse = upsertWorks(rows, url);
+    if (conflictResponse) {
+      return conflictResponse;
     }
 
     if (!shouldReturnRepresentation(request)) {
@@ -314,14 +345,10 @@ export const supabaseRestHandlers = [
   http.patch(`${SUPABASE_URL}/rest/v1/works`, async ({ request }) => {
     const url = new URL(request.url);
     const body = (await request.json()) as Partial<Work>;
-    const target = Array.from(mockWorks.values()).find((work) => matchesFilters(work, url));
-
-    if (!target) {
-      return HttpResponse.json({ message: "Work not found" }, { status: 404 });
+    const updated = patchStoredRow(mockWorks, url, body, "Work not found", ensureWorkDefaults);
+    if (updated instanceof HttpResponse) {
+      return updated;
     }
-
-    const updated = ensureWorkDefaults({ ...target, ...body });
-    mockWorks.set(updated.id, updated);
 
     if (!shouldReturnRepresentation(request)) {
       return new HttpResponse(null, { status: 204 });
@@ -335,14 +362,16 @@ export const supabaseRestHandlers = [
   http.patch(`${SUPABASE_URL}/rest/v1/backlog_items`, async ({ request }) => {
     const url = new URL(request.url);
     const body = (await request.json()) as Partial<BacklogItem>;
-    const target = Array.from(mockBacklogItems.values()).find((item) => matchesFilters(item, url));
-
-    if (!target) {
-      return HttpResponse.json({ message: "Backlog item not found" }, { status: 404 });
+    const updated = patchStoredRow(
+      mockBacklogItems,
+      url,
+      body,
+      "Backlog item not found",
+      ensureBacklogItemDefaults,
+    );
+    if (updated instanceof HttpResponse) {
+      return updated;
     }
-
-    const updated = ensureBacklogItemDefaults({ ...target, ...body });
-    mockBacklogItems.set(updated.id, updated);
 
     if (!shouldReturnRepresentation(request)) {
       return new HttpResponse(null, { status: 204 });

--- a/src/test/mocks/handlers/supabase-rest.ts
+++ b/src/test/mocks/handlers/supabase-rest.ts
@@ -2,7 +2,14 @@ import { http, HttpResponse } from "msw";
 import type { BacklogItem, Work } from "../types";
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || "http://localhost:54321";
-const IGNORED_FILTER_KEYS = ["select", "order", "limit", "offset", "columns", "on_conflict"];
+const IGNORED_FILTER_KEYS = new Set([
+  "select",
+  "order",
+  "limit",
+  "offset",
+  "columns",
+  "on_conflict",
+]);
 
 const mockWorks = new Map<string, Work>();
 const mockBacklogItems = new Map<string, BacklogItem>();
@@ -138,7 +145,7 @@ function pickSelectedFields<T extends Record<string, unknown>>(row: T, selectVal
 
 function matchesFilters<T extends Record<string, unknown>>(row: T, url: URL) {
   for (const [key, value] of url.searchParams.entries()) {
-    if (IGNORED_FILTER_KEYS.includes(key)) {
+    if (IGNORED_FILTER_KEYS.has(key)) {
       continue;
     }
 
@@ -230,7 +237,10 @@ function jsonNoContent(status = 201) {
   return new HttpResponse(null, { status });
 }
 
-function createRows<T>(payload: T | T[], ensureDefaults: (value: T) => T) {
+function createRows<TInput, TOutput>(
+  payload: TInput | TInput[],
+  ensureDefaults: (value: TInput) => TOutput,
+) {
   return (Array.isArray(payload) ? payload : [payload]).map(ensureDefaults);
 }
 


### PR DESCRIPTION
## 関連 Issue

Refs #266

## 変更内容

- `src/test/mocks/handlers/supabase-rest.ts` の比較値・POST/PATCH 分岐を helper に分割し、quick win の union type を type alias に置き換え
- `src/test/mocks/handlers/supabase-rest.test.ts` を追加し、object response、order、on_conflict、duplicate key、PATCH の境界ケースを直接検証
- `src/features/backlog/components/UserMenu.test.tsx` の重複したセットアップを helper に寄せ、quality report の重複率改善を同じ PR に集約

## 検証

- `vp test src/test/mocks/handlers/supabase-rest.test.ts src/features/backlog/components/UserMenu.test.tsx src/features/backlog/backlog-repository.test.ts src/features/backlog/work-repository.test.ts`
- `vp test`
- pre-commit による `vp check --fix`
