### PR TITLE
feat: ゲーム作品 (IGDB) 連携のバックエンド基盤追加

### DIFF
--- a/src/features/backlog/helpers.test.ts
+++ b/src/features/backlog/helpers.test.ts
@@ -138,6 +138,10 @@ describe("getWorkTypeLabel", () => {
   test("returns series for season works", () => {
     expect(getWorkTypeLabel("season")).toBe("シリーズ");
   });
+
+  test("returns game for game works", () => {
+    expect(getWorkTypeLabel("game")).toBe("ゲーム");
+  });
 });
 
 describe("getWorkMetadataLabels", () => {

--- a/src/features/backlog/helpers.ts
+++ b/src/features/backlog/helpers.ts
@@ -64,7 +64,9 @@ export function escapeHtml(value: string) {
 }
 
 export function getWorkTypeLabel(workType: WorkType) {
-  return workType === "movie" ? "映画" : "シリーズ";
+  if (workType === "movie") return "映画";
+  if (workType === "game") return "ゲーム";
+  return "シリーズ";
 }
 
 type WorkMetadataLabelOptions = {

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -12,8 +12,6 @@ export type PrimaryPlatform =
   | "apple_tv_plus"
   | "apple_tv"
   | null;
-export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
-export type GameReleaseDates = Partial<Record<GamePlatform, string>>;
 
 export type WorkSummary = {
   id: string;

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -12,6 +12,8 @@ export type PrimaryPlatform =
   | "apple_tv_plus"
   | "apple_tv"
   | null;
+export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
+export type GameReleaseDates = Partial<Record<GamePlatform, string>>;
 
 export type WorkSummary = {
   id: string;

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -1,8 +1,8 @@
 export type BacklogStatus = "stacked" | "want_to_watch" | "watching" | "interrupted" | "watched";
 export type ViewingMode = "focus" | "thoughtful" | "quick" | "background";
 
-export type WorkType = "movie" | "series" | "season";
-export type SourceType = "tmdb" | "manual";
+export type WorkType = "movie" | "series" | "season" | "game";
+export type SourceType = "tmdb" | "manual" | "igdb";
 export type PrimaryPlatform =
   | "netflix"
   | "prime_video"
@@ -12,6 +12,8 @@ export type PrimaryPlatform =
   | "apple_tv_plus"
   | "apple_tv"
   | null;
+export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
+export type GameReleaseDates = Partial<Record<GamePlatform, string>>;
 
 export type WorkSummary = {
   id: string;

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -1,5 +1,7 @@
 TMDB_API_KEY=your-tmdb-api-key
 OMDB_API_KEY=your-omdb-api-key
 GEMINI_API_KEY=your-gemini-api-key
+TWITCH_CLIENT_ID=your-twitch-client-id
+TWITCH_CLIENT_SECRET=your-twitch-client-secret
 SUPABASE_URL=your-supabase-url
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key

--- a/supabase/functions/_shared/igdb-auth.ts
+++ b/supabase/functions/_shared/igdb-auth.ts
@@ -15,7 +15,7 @@ export type TwitchOauthClient = {
   fetchAccessToken(): Promise<TwitchAccessToken>;
 };
 
-export const TWITCH_TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
+const TWITCH_TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
 
 export function isTwitchTokenValid(
   token: TwitchAccessToken,
@@ -34,7 +34,7 @@ export function deriveTwitchExpiresAt(
   return new Date(now.getTime() + Math.max(expiresInMs - bufferMs, 0));
 }
 
-export type EnsureValidAccessTokenOptions = {
+type EnsureValidAccessTokenOptions = {
   now?: Date;
   bufferMs?: number;
   force?: boolean;
@@ -74,7 +74,7 @@ type TwitchOauthResponse = {
   token_type: string;
 };
 
-export function createTwitchOauthClient(options: {
+function createTwitchOauthClient(options: {
   clientId: string;
   clientSecret: string;
   now?: () => Date;
@@ -203,8 +203,4 @@ export function getDefaultTwitchOauthClient(): TwitchOauthClient {
 
   cachedEnvOauthClient = createTwitchOauthClient({ clientId, clientSecret });
   return cachedEnvOauthClient;
-}
-
-export function resetDefaultTwitchOauthClientForTest() {
-  cachedEnvOauthClient = null;
 }

--- a/supabase/functions/_shared/igdb-auth.ts
+++ b/supabase/functions/_shared/igdb-auth.ts
@@ -1,0 +1,210 @@
+import "./edge-runtime.d.ts";
+import { getSupabaseAdminClient } from "./supabase-admin.ts";
+
+export type TwitchAccessToken = {
+  accessToken: string;
+  expiresAt: Date;
+};
+
+export type TwitchTokenStore = {
+  read(): Promise<TwitchAccessToken | null>;
+  upsertIfExpired(token: TwitchAccessToken): Promise<TwitchAccessToken | null>;
+};
+
+export type TwitchOauthClient = {
+  fetchAccessToken(): Promise<TwitchAccessToken>;
+};
+
+export const TWITCH_TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
+
+export function isTwitchTokenValid(
+  token: TwitchAccessToken,
+  now: Date,
+  bufferMs: number = TWITCH_TOKEN_REFRESH_BUFFER_MS,
+): boolean {
+  return token.expiresAt.getTime() - now.getTime() > bufferMs;
+}
+
+export function deriveTwitchExpiresAt(
+  now: Date,
+  expiresInSeconds: number,
+  bufferMs: number = TWITCH_TOKEN_REFRESH_BUFFER_MS,
+): Date {
+  const expiresInMs = expiresInSeconds * 1000;
+  return new Date(now.getTime() + Math.max(expiresInMs - bufferMs, 0));
+}
+
+export type EnsureValidAccessTokenOptions = {
+  now?: Date;
+  bufferMs?: number;
+  force?: boolean;
+};
+
+export async function ensureValidTwitchAccessToken(
+  store: TwitchTokenStore,
+  oauth: TwitchOauthClient,
+  options: EnsureValidAccessTokenOptions = {},
+): Promise<string> {
+  const now = options.now ?? new Date();
+  const bufferMs = options.bufferMs ?? TWITCH_TOKEN_REFRESH_BUFFER_MS;
+
+  if (!options.force) {
+    const cached = await store.read();
+    if (cached && isTwitchTokenValid(cached, now, bufferMs)) {
+      return cached.accessToken;
+    }
+  }
+
+  const fresh = await oauth.fetchAccessToken();
+  const claimed = await store.upsertIfExpired(fresh);
+  if (claimed) {
+    return claimed.accessToken;
+  }
+
+  const latest = await store.read();
+  if (!latest) {
+    throw new Error("Twitch token store returned no row after refresh");
+  }
+  return latest.accessToken;
+}
+
+type TwitchOauthResponse = {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+};
+
+export function createTwitchOauthClient(options: {
+  clientId: string;
+  clientSecret: string;
+  now?: () => Date;
+  fetchImpl?: typeof fetch;
+}): TwitchOauthClient {
+  const now = options.now ?? (() => new Date());
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  return {
+    async fetchAccessToken() {
+      const url = new URL("https://id.twitch.tv/oauth2/token");
+      url.searchParams.set("client_id", options.clientId);
+      url.searchParams.set("client_secret", options.clientSecret);
+      url.searchParams.set("grant_type", "client_credentials");
+
+      const response = await fetchImpl(url.toString(), { method: "POST" });
+      if (!response.ok) {
+        throw new Error(`Twitch token request failed with status ${response.status}`);
+      }
+
+      const json = (await response.json()) as TwitchOauthResponse;
+      if (!json.access_token || typeof json.expires_in !== "number") {
+        throw new Error("Twitch token response is malformed");
+      }
+
+      return {
+        accessToken: json.access_token,
+        expiresAt: deriveTwitchExpiresAt(now(), json.expires_in),
+      };
+    },
+  };
+}
+
+type TwitchTokenRow = {
+  access_token: string;
+  expires_at: string;
+};
+
+const TWITCH_TOKEN_ROW_ID = 1;
+
+export function createSupabaseTwitchTokenStore(): TwitchTokenStore {
+  return {
+    async read() {
+      const admin = getRequiredAdminClient();
+      const { data, error } = await admin
+        .from("twitch_tokens")
+        .select("access_token, expires_at")
+        .eq("id", TWITCH_TOKEN_ROW_ID)
+        .maybeSingle<TwitchTokenRow>();
+
+      if (error) {
+        throw new Error(`Failed to read twitch_tokens: ${error.message}`);
+      }
+      if (!data) {
+        return null;
+      }
+      return {
+        accessToken: data.access_token,
+        expiresAt: new Date(data.expires_at),
+      };
+    },
+
+    async upsertIfExpired(token) {
+      const admin = getRequiredAdminClient();
+      const expiresAtIso = token.expiresAt.toISOString();
+      const nowIso = new Date().toISOString();
+
+      const { data: updated, error: updateError } = await admin
+        .from("twitch_tokens")
+        .update({ access_token: token.accessToken, expires_at: expiresAtIso })
+        .eq("id", TWITCH_TOKEN_ROW_ID)
+        .lt("expires_at", nowIso)
+        .select("access_token, expires_at");
+
+      if (updateError) {
+        throw new Error(`Failed to update twitch_tokens: ${updateError.message}`);
+      }
+
+      if (updated && updated.length > 0) {
+        const row = updated[0] as TwitchTokenRow;
+        return {
+          accessToken: row.access_token,
+          expiresAt: new Date(row.expires_at),
+        };
+      }
+
+      const { error: insertError } = await admin.from("twitch_tokens").insert({
+        id: TWITCH_TOKEN_ROW_ID,
+        access_token: token.accessToken,
+        expires_at: expiresAtIso,
+      });
+
+      if (insertError) {
+        if (insertError.code === "23505") {
+          return null;
+        }
+        throw new Error(`Failed to insert twitch_tokens: ${insertError.message}`);
+      }
+
+      return token;
+    },
+  };
+}
+
+function getRequiredAdminClient() {
+  const admin = getSupabaseAdminClient();
+  if (!admin) {
+    throw new Error("Supabase admin client is not configured");
+  }
+  return admin;
+}
+
+let cachedEnvOauthClient: TwitchOauthClient | null = null;
+
+export function getDefaultTwitchOauthClient(): TwitchOauthClient {
+  if (cachedEnvOauthClient) {
+    return cachedEnvOauthClient;
+  }
+
+  const clientId = Deno.env.get("TWITCH_CLIENT_ID");
+  const clientSecret = Deno.env.get("TWITCH_CLIENT_SECRET");
+
+  if (!clientId || !clientSecret) {
+    throw new Error("Missing TWITCH_CLIENT_ID or TWITCH_CLIENT_SECRET");
+  }
+
+  cachedEnvOauthClient = createTwitchOauthClient({ clientId, clientSecret });
+  return cachedEnvOauthClient;
+}
+
+export function resetDefaultTwitchOauthClientForTest() {
+  cachedEnvOauthClient = null;
+}

--- a/supabase/functions/_shared/igdb-auth_test.ts
+++ b/supabase/functions/_shared/igdb-auth_test.ts
@@ -1,0 +1,183 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert";
+import {
+  deriveTwitchExpiresAt,
+  ensureValidTwitchAccessToken,
+  isTwitchTokenValid,
+  type TwitchAccessToken,
+  type TwitchOauthClient,
+  type TwitchTokenStore,
+} from "./igdb-auth.ts";
+
+function createOauthClient(token: TwitchAccessToken): {
+  oauth: TwitchOauthClient;
+  callCount: () => number;
+} {
+  let calls = 0;
+  return {
+    oauth: {
+      async fetchAccessToken() {
+        calls += 1;
+        return token;
+      },
+    },
+    callCount: () => calls,
+  };
+}
+
+Deno.test("isTwitchTokenValid はバッファ越えなら有効と判定する", () => {
+  const now = new Date("2026-04-18T00:00:00Z");
+  assertEquals(
+    isTwitchTokenValid(
+      { accessToken: "a", expiresAt: new Date("2026-04-18T00:02:00Z") },
+      now,
+      60 * 1000,
+    ),
+    true,
+  );
+  assertEquals(
+    isTwitchTokenValid(
+      { accessToken: "a", expiresAt: new Date("2026-04-18T00:00:30Z") },
+      now,
+      60 * 1000,
+    ),
+    false,
+  );
+});
+
+Deno.test("deriveTwitchExpiresAt はバッファ分手前を expiresAt として返す", () => {
+  const now = new Date("2026-04-18T00:00:00Z");
+  const expiresAt = deriveTwitchExpiresAt(now, 3600, 60 * 1000);
+  assertEquals(expiresAt.toISOString(), "2026-04-18T00:59:00.000Z");
+});
+
+Deno.test("deriveTwitchExpiresAt は expires_in がバッファ未満なら now と等価", () => {
+  const now = new Date("2026-04-18T00:00:00Z");
+  const expiresAt = deriveTwitchExpiresAt(now, 30, 60 * 1000);
+  assertEquals(expiresAt.toISOString(), now.toISOString());
+});
+
+Deno.test("ensureValidTwitchAccessToken はキャッシュ有効時に Twitch を呼ばない", async () => {
+  const cached: TwitchAccessToken = {
+    accessToken: "cached",
+    expiresAt: new Date("2026-04-18T01:00:00Z"),
+  };
+  const store: TwitchTokenStore = {
+    read: async () => cached,
+    upsertIfExpired: async () => {
+      throw new Error("should not refresh");
+    },
+  };
+  const { oauth, callCount } = createOauthClient({
+    accessToken: "fresh",
+    expiresAt: new Date("2026-04-18T02:00:00Z"),
+  });
+
+  const result = await ensureValidTwitchAccessToken(store, oauth, {
+    now: new Date("2026-04-18T00:00:00Z"),
+  });
+
+  assertEquals(result, "cached");
+  assertEquals(callCount(), 0);
+});
+
+Deno.test("ensureValidTwitchAccessToken は期限切れで refresh し勝者の token を返す", async () => {
+  const stored: TwitchAccessToken = {
+    accessToken: "old",
+    expiresAt: new Date("2026-04-18T00:00:30Z"),
+  };
+  let writes = 0;
+  const store: TwitchTokenStore = {
+    read: async () => stored,
+    upsertIfExpired: async (token) => {
+      writes += 1;
+      return token;
+    },
+  };
+  const { oauth, callCount } = createOauthClient({
+    accessToken: "fresh",
+    expiresAt: new Date("2026-04-18T02:00:00Z"),
+  });
+
+  const result = await ensureValidTwitchAccessToken(store, oauth, {
+    now: new Date("2026-04-18T00:01:00Z"),
+  });
+
+  assertEquals(result, "fresh");
+  assertEquals(writes, 1);
+  assertEquals(callCount(), 1);
+});
+
+Deno.test("ensureValidTwitchAccessToken は競合敗北時に DB の最新値を読み直す", async () => {
+  let readCount = 0;
+  const stored: TwitchAccessToken = {
+    accessToken: "old",
+    expiresAt: new Date("2026-04-18T00:00:30Z"),
+  };
+  const winnerToken: TwitchAccessToken = {
+    accessToken: "winner",
+    expiresAt: new Date("2026-04-18T03:00:00Z"),
+  };
+  const store: TwitchTokenStore = {
+    read: async () => {
+      readCount += 1;
+      return readCount === 1 ? stored : winnerToken;
+    },
+    upsertIfExpired: async () => null,
+  };
+  const { oauth } = createOauthClient({
+    accessToken: "loser",
+    expiresAt: new Date("2026-04-18T02:00:00Z"),
+  });
+
+  const result = await ensureValidTwitchAccessToken(store, oauth, {
+    now: new Date("2026-04-18T00:01:00Z"),
+  });
+
+  assertEquals(result, "winner");
+  assertEquals(readCount, 2);
+});
+
+Deno.test("ensureValidTwitchAccessToken は force 指定で常に refresh する", async () => {
+  const cached: TwitchAccessToken = {
+    accessToken: "cached",
+    expiresAt: new Date("2026-04-18T05:00:00Z"),
+  };
+  let writes = 0;
+  const store: TwitchTokenStore = {
+    read: async () => cached,
+    upsertIfExpired: async (token) => {
+      writes += 1;
+      return token;
+    },
+  };
+  const { oauth, callCount } = createOauthClient({
+    accessToken: "fresh",
+    expiresAt: new Date("2026-04-18T06:00:00Z"),
+  });
+
+  const result = await ensureValidTwitchAccessToken(store, oauth, {
+    now: new Date("2026-04-18T00:00:00Z"),
+    force: true,
+  });
+
+  assertEquals(result, "fresh");
+  assertEquals(writes, 1);
+  assertEquals(callCount(), 1);
+});
+
+Deno.test("ensureValidTwitchAccessToken は再読込でも row が無いと例外を投げる", async () => {
+  const store: TwitchTokenStore = {
+    read: async () => null,
+    upsertIfExpired: async () => null,
+  };
+  const { oauth } = createOauthClient({
+    accessToken: "fresh",
+    expiresAt: new Date("2026-04-18T02:00:00Z"),
+  });
+
+  await assertRejects(
+    () => ensureValidTwitchAccessToken(store, oauth),
+    Error,
+    "Twitch token store returned no row after refresh",
+  );
+});

--- a/supabase/functions/_shared/igdb.ts
+++ b/supabase/functions/_shared/igdb.ts
@@ -5,9 +5,9 @@ import {
   getDefaultTwitchOauthClient,
 } from "./igdb-auth.ts";
 
-export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
+type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
 
-export type IgdbSearchResult = {
+type IgdbSearchResult = {
   igdbId: number;
   title: string;
   coverImageId: string | null;
@@ -16,7 +16,7 @@ export type IgdbSearchResult = {
   summary: string | null;
 };
 
-export type IgdbWorkDetails = {
+type IgdbWorkDetails = {
   igdbId: number;
   title: string;
   summary: string | null;

--- a/supabase/functions/_shared/igdb.ts
+++ b/supabase/functions/_shared/igdb.ts
@@ -1,0 +1,294 @@
+import "./edge-runtime.d.ts";
+import {
+  createSupabaseTwitchTokenStore,
+  ensureValidTwitchAccessToken,
+  getDefaultTwitchOauthClient,
+} from "./igdb-auth.ts";
+
+export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
+
+export type IgdbSearchResult = {
+  igdbId: number;
+  title: string;
+  coverImageId: string | null;
+  releaseDate: string | null;
+  platforms: GamePlatform[];
+  summary: string | null;
+};
+
+export type IgdbWorkDetails = {
+  igdbId: number;
+  title: string;
+  summary: string | null;
+  coverImageId: string | null;
+  releaseDate: string | null;
+  releaseDates: Partial<Record<GamePlatform, string>>;
+  platforms: GamePlatform[];
+  developer: string | null;
+  publisher: string | null;
+  franchise: string | null;
+};
+
+export type IgdbCallContext = {
+  clientId: string;
+  getAccessToken: (force: boolean) => Promise<string>;
+  fetchImpl?: typeof fetch;
+};
+
+const IGDB_BASE_URL = "https://api.igdb.com/v4";
+
+const IGDB_PLATFORM_SLUG_MAP: Record<string, GamePlatform> = {
+  win: "steam",
+  linux: "steam",
+  mac: "steam",
+  ps3: "playstation",
+  ps4: "playstation",
+  ps5: "playstation",
+  psvita: "playstation",
+  switch: "switch",
+  "switch-2": "switch",
+  xboxone: "xbox",
+  "series-x-s": "xbox",
+  "series-x": "xbox",
+  xbox360: "xbox",
+  ios: "ios",
+  android: "android",
+};
+
+export function mapIgdbPlatformSlug(slug: string | null | undefined): GamePlatform | null {
+  if (!slug) return null;
+  return IGDB_PLATFORM_SLUG_MAP[slug] ?? null;
+}
+
+export function dedupePlatforms(values: Array<GamePlatform | null>): GamePlatform[] {
+  const seen = new Set<GamePlatform>();
+  const result: GamePlatform[] = [];
+  for (const value of values) {
+    if (value && !seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+export function unixSecondsToIsoDate(seconds: number | null | undefined): string | null {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds)) {
+    return null;
+  }
+  return new Date(seconds * 1000).toISOString().slice(0, 10);
+}
+
+type IgdbSearchRow = {
+  id: number;
+  name?: string | null;
+  summary?: string | null;
+  cover?: { image_id?: string | null } | null;
+  first_release_date?: number | null;
+  platforms?: Array<{ slug?: string | null }> | null;
+};
+
+type IgdbReleaseDateRow = {
+  date?: number | null;
+  platform?: { slug?: string | null } | null;
+};
+
+type IgdbInvolvedCompanyRow = {
+  developer?: boolean | null;
+  publisher?: boolean | null;
+  company?: { name?: string | null } | null;
+};
+
+type IgdbDetailsRow = IgdbSearchRow & {
+  release_dates?: IgdbReleaseDateRow[] | null;
+  involved_companies?: IgdbInvolvedCompanyRow[] | null;
+  franchises?: Array<{ name?: string | null }> | null;
+  franchise?: { name?: string | null } | null;
+};
+
+const SEARCH_FIELDS = [
+  "id",
+  "name",
+  "summary",
+  "cover.image_id",
+  "first_release_date",
+  "platforms.slug",
+].join(",");
+
+const DETAILS_FIELDS = [
+  "id",
+  "name",
+  "summary",
+  "cover.image_id",
+  "first_release_date",
+  "platforms.slug",
+  "release_dates.date",
+  "release_dates.platform.slug",
+  "involved_companies.developer",
+  "involved_companies.publisher",
+  "involved_companies.company.name",
+  "franchise.name",
+  "franchises.name",
+].join(",");
+
+function escapeIgdbString(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+export function buildIgdbSearchBody(query: string, limit = 20): string {
+  const escapedQuery = escapeIgdbString(query);
+  return [
+    `fields ${SEARCH_FIELDS};`,
+    `search "${escapedQuery}";`,
+    "where category = (0,8,9,10,11);",
+    `limit ${limit};`,
+  ].join(" ");
+}
+
+export function buildIgdbDetailsBody(igdbId: number): string {
+  return [`fields ${DETAILS_FIELDS};`, `where id = ${igdbId};`, "limit 1;"].join(" ");
+}
+
+async function performIgdbCall(
+  ctx: IgdbCallContext,
+  endpoint: string,
+  body: string,
+): Promise<Response> {
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  let token = await ctx.getAccessToken(false);
+
+  const buildRequest = (accessToken: string) =>
+    fetchImpl(`${IGDB_BASE_URL}/${endpoint}`, {
+      method: "POST",
+      headers: {
+        "Client-ID": ctx.clientId,
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "text/plain",
+      },
+      body,
+    });
+
+  let response = await buildRequest(token);
+
+  if (response.status === 401) {
+    token = await ctx.getAccessToken(true);
+    response = await buildRequest(token);
+  }
+
+  return response;
+}
+
+export async function callIgdbEndpoint<T>(
+  ctx: IgdbCallContext,
+  endpoint: string,
+  body: string,
+): Promise<T> {
+  const response = await performIgdbCall(ctx, endpoint, body);
+  if (!response.ok) {
+    throw new Error(`IGDB ${endpoint} failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+function mapSearchRow(row: IgdbSearchRow): IgdbSearchResult | null {
+  if (typeof row.id !== "number" || !row.name) {
+    return null;
+  }
+  return {
+    igdbId: row.id,
+    title: row.name,
+    coverImageId: row.cover?.image_id ?? null,
+    releaseDate: unixSecondsToIsoDate(row.first_release_date ?? null),
+    platforms: dedupePlatforms((row.platforms ?? []).map((p) => mapIgdbPlatformSlug(p.slug))),
+    summary: row.summary ?? null,
+  };
+}
+
+export function selectInvolvedCompany(
+  rows: IgdbInvolvedCompanyRow[] | null | undefined,
+  role: "developer" | "publisher",
+): string | null {
+  for (const row of rows ?? []) {
+    if (row[role] && row.company?.name) {
+      return row.company.name;
+    }
+  }
+  return null;
+}
+
+export function buildReleaseDatesByPlatform(
+  rows: IgdbReleaseDateRow[] | null | undefined,
+): Partial<Record<GamePlatform, string>> {
+  const result: Partial<Record<GamePlatform, string>> = {};
+  for (const row of rows ?? []) {
+    const platform = mapIgdbPlatformSlug(row.platform?.slug);
+    const iso = unixSecondsToIsoDate(row.date ?? null);
+    if (!platform || !iso) {
+      continue;
+    }
+    const existing = result[platform];
+    if (!existing || iso < existing) {
+      result[platform] = iso;
+    }
+  }
+  return result;
+}
+
+function mapDetailsRow(row: IgdbDetailsRow): IgdbWorkDetails | null {
+  if (typeof row.id !== "number" || !row.name) {
+    return null;
+  }
+  const releaseDates = buildReleaseDatesByPlatform(row.release_dates);
+  return {
+    igdbId: row.id,
+    title: row.name,
+    summary: row.summary ?? null,
+    coverImageId: row.cover?.image_id ?? null,
+    releaseDate: unixSecondsToIsoDate(row.first_release_date ?? null),
+    releaseDates,
+    platforms: dedupePlatforms((row.platforms ?? []).map((p) => mapIgdbPlatformSlug(p.slug))),
+    developer: selectInvolvedCompany(row.involved_companies, "developer"),
+    publisher: selectInvolvedCompany(row.involved_companies, "publisher"),
+    franchise: row.franchise?.name ?? row.franchises?.[0]?.name ?? null,
+  };
+}
+
+export async function searchIgdbWorks(
+  query: string,
+  ctx: IgdbCallContext,
+): Promise<IgdbSearchResult[]> {
+  const body = buildIgdbSearchBody(query.trim());
+  const rows = await callIgdbEndpoint<IgdbSearchRow[]>(ctx, "games", body);
+  return rows.flatMap((row) => {
+    const mapped = mapSearchRow(row);
+    return mapped ? [mapped] : [];
+  });
+}
+
+export async function fetchIgdbWorkDetails(
+  igdbId: number,
+  ctx: IgdbCallContext,
+): Promise<IgdbWorkDetails> {
+  const body = buildIgdbDetailsBody(igdbId);
+  const rows = await callIgdbEndpoint<IgdbDetailsRow[]>(ctx, "games", body);
+  const first = rows[0];
+  const mapped = first ? mapDetailsRow(first) : null;
+  if (!mapped) {
+    throw new Error(`IGDB game ${igdbId} not found`);
+  }
+  return mapped;
+}
+
+export function getDefaultIgdbCallContext(): IgdbCallContext {
+  const clientId = Deno.env.get("TWITCH_CLIENT_ID");
+  if (!clientId) {
+    throw new Error("Missing TWITCH_CLIENT_ID");
+  }
+  const store = createSupabaseTwitchTokenStore();
+  const oauth = getDefaultTwitchOauthClient();
+  return {
+    clientId,
+    getAccessToken: (force) =>
+      ensureValidTwitchAccessToken(store, oauth, force ? { force: true } : undefined),
+  };
+}

--- a/supabase/functions/_shared/igdb_test.ts
+++ b/supabase/functions/_shared/igdb_test.ts
@@ -1,0 +1,241 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert";
+import {
+  buildIgdbDetailsBody,
+  buildIgdbSearchBody,
+  buildReleaseDatesByPlatform,
+  callIgdbEndpoint,
+  dedupePlatforms,
+  fetchIgdbWorkDetails,
+  type IgdbCallContext,
+  mapIgdbPlatformSlug,
+  searchIgdbWorks,
+  selectInvolvedCompany,
+  unixSecondsToIsoDate,
+} from "./igdb.ts";
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+}
+
+function createContext(
+  fetchImpl: typeof fetch,
+  options: { tokenSequence?: string[] } = {},
+): { ctx: IgdbCallContext; tokenCalls: Array<{ force: boolean }> } {
+  const tokenCalls: Array<{ force: boolean }> = [];
+  const sequence = options.tokenSequence ?? ["token-1", "token-2"];
+  return {
+    ctx: {
+      clientId: "test-client",
+      fetchImpl,
+      getAccessToken: async (force) => {
+        tokenCalls.push({ force });
+        return sequence[Math.min(tokenCalls.length, sequence.length) - 1];
+      },
+    },
+    tokenCalls,
+  };
+}
+
+Deno.test("mapIgdbPlatformSlug は既知 slug を GamePlatform に変換する", () => {
+  assertEquals(mapIgdbPlatformSlug("win"), "steam");
+  assertEquals(mapIgdbPlatformSlug("ps5"), "playstation");
+  assertEquals(mapIgdbPlatformSlug("switch"), "switch");
+  assertEquals(mapIgdbPlatformSlug("series-x"), "xbox");
+  assertEquals(mapIgdbPlatformSlug("ios"), "ios");
+  assertEquals(mapIgdbPlatformSlug("android"), "android");
+  assertEquals(mapIgdbPlatformSlug("unknown"), null);
+  assertEquals(mapIgdbPlatformSlug(null), null);
+});
+
+Deno.test("dedupePlatforms は順序を保ちつつ重複と null を除外する", () => {
+  assertEquals(dedupePlatforms(["steam", "playstation", null, "steam", "switch", null]), [
+    "steam",
+    "playstation",
+    "switch",
+  ]);
+});
+
+Deno.test("unixSecondsToIsoDate は秒を YYYY-MM-DD に変換する", () => {
+  assertEquals(unixSecondsToIsoDate(1700000000), "2023-11-14");
+  assertEquals(unixSecondsToIsoDate(0), "1970-01-01");
+  assertEquals(unixSecondsToIsoDate(null), null);
+  assertEquals(unixSecondsToIsoDate(undefined), null);
+  assertEquals(unixSecondsToIsoDate(Number.NaN), null);
+});
+
+Deno.test("buildIgdbSearchBody はクエリをエスケープしてカテゴリで絞る", () => {
+  assertEquals(
+    buildIgdbSearchBody('Zelda "BOTW"'),
+    `fields id,name,summary,cover.image_id,first_release_date,platforms.slug; search "Zelda \\"BOTW\\""; where category = (0,8,9,10,11); limit 20;`,
+  );
+});
+
+Deno.test("buildIgdbDetailsBody は id 検索を組み立てる", () => {
+  const expected = `fields id,name,summary,cover.image_id,first_release_date,platforms.slug,release_dates.date,release_dates.platform.slug,involved_companies.developer,involved_companies.publisher,involved_companies.company.name,franchise.name,franchises.name; where id = 1234; limit 1;`;
+  assertEquals(buildIgdbDetailsBody(1234), expected);
+});
+
+Deno.test("selectInvolvedCompany は role 一致の最初の company name を返す", () => {
+  assertEquals(
+    selectInvolvedCompany(
+      [
+        { developer: false, publisher: true, company: { name: "Pub" } },
+        { developer: true, publisher: false, company: { name: "Dev" } },
+      ],
+      "developer",
+    ),
+    "Dev",
+  );
+  assertEquals(selectInvolvedCompany([], "publisher"), null);
+});
+
+Deno.test("buildReleaseDatesByPlatform はプラットフォーム別最古日を採用する", () => {
+  const result = buildReleaseDatesByPlatform([
+    { date: 1700000000, platform: { slug: "ps5" } },
+    { date: 1690000000, platform: { slug: "ps4" } },
+    { date: 1680000000, platform: { slug: "win" } },
+    { date: 1695000000, platform: { slug: "win" } },
+    { date: 1700000000, platform: { slug: "unknown" } },
+    { date: null, platform: { slug: "switch" } },
+  ]);
+  assertEquals(result, {
+    playstation: "2023-07-22",
+    steam: "2023-03-28",
+  });
+});
+
+Deno.test("callIgdbEndpoint は 401 で 1 度だけ force refresh して再試行する", async () => {
+  let calls = 0;
+  const fetchImpl = (async (input: string | URL | Request) => {
+    calls += 1;
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    assertEquals(url, "https://api.igdb.com/v4/games");
+    if (calls === 1) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    return jsonResponse([{ id: 1, name: "Sample" }]);
+  }) as typeof fetch;
+
+  const { ctx, tokenCalls } = createContext(fetchImpl);
+  const result = await callIgdbEndpoint<Array<{ id: number; name: string }>>(
+    ctx,
+    "games",
+    "fields id;",
+  );
+
+  assertEquals(result, [{ id: 1, name: "Sample" }]);
+  assertEquals(calls, 2);
+  assertEquals(tokenCalls, [{ force: false }, { force: true }]);
+});
+
+Deno.test("callIgdbEndpoint は連続 401 で例外を投げる", async () => {
+  const fetchImpl = (async () => new Response("Unauthorized", { status: 401 })) as typeof fetch;
+  const { ctx } = createContext(fetchImpl);
+  await assertRejects(
+    () => callIgdbEndpoint(ctx, "games", "fields id;"),
+    Error,
+    "IGDB games failed with status 401",
+  );
+});
+
+Deno.test("searchIgdbWorks は IGDB レスポンスを IgdbSearchResult[] に変換する", async () => {
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    assertEquals(url, "https://api.igdb.com/v4/games");
+    assertEquals(init?.method, "POST");
+    return jsonResponse([
+      {
+        id: 11,
+        name: "Title A",
+        summary: "summary",
+        cover: { image_id: "abc" },
+        first_release_date: 1700000000,
+        platforms: [{ slug: "win" }, { slug: "ps5" }, { slug: "unknown" }],
+      },
+      {
+        id: 12,
+        name: null,
+      },
+      {
+        id: 13,
+        name: "Title B",
+      },
+    ]);
+  }) as typeof fetch;
+
+  const { ctx } = createContext(fetchImpl);
+  const result = await searchIgdbWorks("query", ctx);
+
+  assertEquals(result, [
+    {
+      igdbId: 11,
+      title: "Title A",
+      coverImageId: "abc",
+      releaseDate: "2023-11-14",
+      platforms: ["steam", "playstation"],
+      summary: "summary",
+    },
+    {
+      igdbId: 13,
+      title: "Title B",
+      coverImageId: null,
+      releaseDate: null,
+      platforms: [],
+      summary: null,
+    },
+  ]);
+});
+
+Deno.test("fetchIgdbWorkDetails はメタデータを集約して返す", async () => {
+  const fetchImpl = (async () =>
+    jsonResponse([
+      {
+        id: 21,
+        name: "Detail Game",
+        summary: "long summary",
+        cover: { image_id: "xyz" },
+        first_release_date: 1700000000,
+        platforms: [{ slug: "switch" }, { slug: "win" }],
+        release_dates: [
+          { date: 1700000000, platform: { slug: "switch" } },
+          { date: 1690000000, platform: { slug: "win" } },
+        ],
+        involved_companies: [
+          { developer: true, publisher: false, company: { name: "Dev Co" } },
+          { developer: false, publisher: true, company: { name: "Pub Co" } },
+        ],
+        franchise: { name: "Major Franchise" },
+        franchises: [{ name: "Sub Franchise" }],
+      },
+    ])) as typeof fetch;
+
+  const { ctx } = createContext(fetchImpl);
+  const result = await fetchIgdbWorkDetails(21, ctx);
+
+  assertEquals(result, {
+    igdbId: 21,
+    title: "Detail Game",
+    summary: "long summary",
+    coverImageId: "xyz",
+    releaseDate: "2023-11-14",
+    releaseDates: {
+      switch: "2023-11-14",
+      steam: "2023-07-22",
+    },
+    platforms: ["switch", "steam"],
+    developer: "Dev Co",
+    publisher: "Pub Co",
+    franchise: "Major Franchise",
+  });
+});
+
+Deno.test("fetchIgdbWorkDetails は空配列で例外を投げる", async () => {
+  const fetchImpl = (async () => jsonResponse([])) as typeof fetch;
+  const { ctx } = createContext(fetchImpl);
+  await assertRejects(() => fetchIgdbWorkDetails(99, ctx), Error, "IGDB game 99 not found");
+});

--- a/supabase/functions/fetch-igdb-work-details/index.ts
+++ b/supabase/functions/fetch-igdb-work-details/index.ts
@@ -1,0 +1,36 @@
+import "../_shared/edge-runtime.d.ts";
+import {
+  badRequestResponse,
+  handleCorsPreflightRequest,
+  internalServerErrorResponse,
+  jsonResponse,
+  methodNotAllowedResponse,
+  readJsonBody,
+} from "../_shared/http.ts";
+import { fetchIgdbWorkDetails, getDefaultIgdbCallContext } from "../_shared/igdb.ts";
+
+type FetchIgdbWorkDetailsRequest = {
+  igdbId?: number;
+};
+
+Deno.serve(async (request) => {
+  const corsResponse = handleCorsPreflightRequest(request);
+  if (corsResponse) {
+    return corsResponse;
+  }
+
+  if (request.method !== "POST") {
+    return methodNotAllowedResponse();
+  }
+
+  try {
+    const body = await readJsonBody<FetchIgdbWorkDetailsRequest>(request);
+    if (typeof body.igdbId !== "number" || !Number.isFinite(body.igdbId)) {
+      return badRequestResponse("igdbId is required");
+    }
+
+    return jsonResponse(await fetchIgdbWorkDetails(body.igdbId, getDefaultIgdbCallContext()));
+  } catch (error) {
+    return internalServerErrorResponse(error);
+  }
+});

--- a/supabase/functions/search-igdb-works/index.ts
+++ b/supabase/functions/search-igdb-works/index.ts
@@ -1,0 +1,38 @@
+import "../_shared/edge-runtime.d.ts";
+import {
+  badRequestResponse,
+  handleCorsPreflightRequest,
+  internalServerErrorResponse,
+  jsonResponse,
+  methodNotAllowedResponse,
+  readJsonBody,
+} from "../_shared/http.ts";
+import { getDefaultIgdbCallContext, searchIgdbWorks } from "../_shared/igdb.ts";
+
+type SearchIgdbWorksRequest = {
+  query?: string;
+};
+
+Deno.serve(async (request) => {
+  const corsResponse = handleCorsPreflightRequest(request);
+  if (corsResponse) {
+    return corsResponse;
+  }
+
+  if (request.method !== "POST") {
+    return methodNotAllowedResponse();
+  }
+
+  try {
+    const body = await readJsonBody<SearchIgdbWorksRequest>(request);
+    const query = body.query?.trim();
+
+    if (!query) {
+      return badRequestResponse("query is required");
+    }
+
+    return jsonResponse(await searchIgdbWorks(query, getDefaultIgdbCallContext()));
+  } catch (error) {
+    return internalServerErrorResponse(error);
+  }
+});

--- a/supabase/migrations/20260418000000_extend_work_and_source_type_enums.sql
+++ b/supabase/migrations/20260418000000_extend_work_and_source_type_enums.sql
@@ -1,0 +1,3 @@
+alter type public.work_type add value if not exists 'game';
+
+alter type public.source_type add value if not exists 'igdb';

--- a/supabase/migrations/20260418000010_add_game_support.sql
+++ b/supabase/migrations/20260418000010_add_game_support.sql
@@ -1,0 +1,95 @@
+create type public.game_platform as enum (
+  'steam',
+  'playstation',
+  'switch',
+  'xbox',
+  'ios',
+  'android'
+);
+
+alter table public.works
+  add column igdb_id bigint,
+  add column release_dates jsonb,
+  add column developer text,
+  add column publisher text,
+  add column franchise text;
+
+alter table public.works
+  drop constraint works_tmdb_fields_check;
+
+alter table public.works
+  add constraint works_source_fields_check check (
+    (
+      source_type = 'manual'
+      and tmdb_media_type is null
+      and tmdb_id is null
+      and igdb_id is null
+    )
+    or (
+      source_type = 'tmdb'
+      and tmdb_media_type is not null
+      and tmdb_id is not null
+      and igdb_id is null
+    )
+    or (
+      source_type = 'igdb'
+      and tmdb_media_type is null
+      and tmdb_id is null
+      and igdb_id is not null
+    )
+  );
+
+alter table public.works
+  drop constraint works_tmdb_media_type_matches_work_type;
+
+alter table public.works
+  add constraint works_tmdb_media_type_matches_work_type check (
+    (
+      work_type = 'movie'
+      and (tmdb_media_type is null or tmdb_media_type = 'movie')
+    )
+    or (
+      work_type in ('series', 'season')
+      and (tmdb_media_type is null or tmdb_media_type = 'tv')
+    )
+    or (
+      work_type = 'game'
+      and tmdb_media_type is null
+    )
+  );
+
+create unique index works_igdb_game_unique_idx
+  on public.works (igdb_id)
+  where source_type = 'igdb';
+
+drop index if exists public.works_manual_title_unique_idx;
+
+create unique index works_manual_title_unique_idx
+  on public.works (created_by, work_type, search_text)
+  where source_type = 'manual' and work_type in ('movie', 'series', 'game');
+
+drop policy if exists "works are readable when shared or owned" on public.works;
+
+create policy "works are readable when shared or owned"
+on public.works
+for select
+to authenticated
+using (
+  source_type in ('tmdb', 'igdb')
+  or created_by = auth.uid()
+);
+
+create table public.twitch_tokens (
+  id smallint primary key default 1,
+  access_token text not null,
+  expires_at timestamptz not null,
+  updated_at timestamptz not null default now(),
+  constraint twitch_tokens_singleton check (id = 1)
+);
+
+alter table public.twitch_tokens enable row level security;
+
+create trigger set_twitch_tokens_updated_at
+before update on public.twitch_tokens
+for each row
+execute function public.set_updated_at();


### PR DESCRIPTION
## Summary

Issue #17 のうち、ゲーム作品連携のバックエンド基盤だけを先行で取り込む PR。
UI 変更を含まないため、本番への可視影響はなし (Edge Function は手動デプロイ)。

- DB migration を 2 本追加し、`work_type` / `source_type` enum を `game` / `igdb` まで拡張、`works` に IGDB メタデータ列、`twitch_tokens` テーブル、関連 CHECK / partial unique index / RLS 拡張を追加
- Twitch OAuth トークンを単一 row でキャッシュし、楽観的 UPDATE で競合を制御する `_shared/igdb-auth.ts` を追加
- IGDB search / details を呼び出す `_shared/igdb.ts` と Edge Function (`search-igdb-works`, `fetch-igdb-work-details`) を追加 (401 で 1 回だけ force refresh)
- TS 側型定義 (`WorkType` / `SourceType` / `GamePlatform` / `GameReleaseDates`) と `getWorkTypeLabel("game")` を追加
- Deno test を 20 ケース追加 (Twitch トークン管理 8 + IGDB ユーティリティ 12)

UI / ルーティング / モーダル変更は別 PR に分離。

## Test plan

- [x] `vp run test:functions` (32 / 32 passed)
- [x] `vp test` (363 / 363 passed)
- [x] `vp check --fix` (pre-commit で実行・通過)
- [ ] Supabase migration の本番適用と Edge Function のデプロイ・smoke は別タイミングで実施

Closes part of #17