### PR TITLE
fix: DnD 隣接要素移動で side 判定が固定される不具合の修正

### DIFF
--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -30,7 +30,7 @@ describe("resolveDragOverItems", () => {
       activeId: "item-3",
       overId: "item-2",
       overRect: makeLogicRect(100, 200),
-      activeCenterY: 120,
+      pointerY: 120,
       isMobileLayout: false,
     });
     // pointer Y=260 > over center=200 → after
@@ -39,7 +39,7 @@ describe("resolveDragOverItems", () => {
       activeId: "item-1",
       overId: "item-2",
       overRect: makeLogicRect(100, 200),
-      activeCenterY: 260,
+      pointerY: 260,
       isMobileLayout: false,
     });
 
@@ -59,7 +59,7 @@ describe("resolveDragOverItems", () => {
       activeId: "item-1",
       overId: "item-2",
       overRect: makeLogicRect(200, 100),
-      activeCenterY: 300,
+      pointerY: 300,
       isMobileLayout: false,
     });
     // item-2 を item-1 の上へ: pointer < over center → before
@@ -68,7 +68,7 @@ describe("resolveDragOverItems", () => {
       activeId: "item-2",
       overId: "item-1",
       overRect: makeLogicRect(100, 100),
-      activeCenterY: 50,
+      pointerY: 50,
       isMobileLayout: false,
     });
 
@@ -80,20 +80,20 @@ describe("resolveDragOverItems", () => {
     {
       name: "pointer が over より上なら before として列またぎ挿入する",
       overId: "item-3",
-      activeCenterY: 120, // < overRect center=200
+      pointerY: 120, // < overRect center=200
     },
     {
       name: "pointer が over 中心と同じなら after として列またぎ挿入する",
       overId: "item-2",
-      activeCenterY: 200, // = overRect center=200 → not < → after
+      pointerY: 200, // = overRect center=200 → not < → after
     },
-  ])("$name", ({ overId, activeCenterY }) => {
+  ])("$name", ({ overId, pointerY }) => {
     const nextItems = resolveDragOverItems({
       items: createWatchingItemsFixture(),
       activeId: "item-1",
       overId,
       overRect: makeLogicRect(),
-      activeCenterY,
+      pointerY,
       isMobileLayout: false,
     });
 
@@ -112,7 +112,7 @@ describe("resolveDragOverItems", () => {
       activeId: "item-1",
       overId: "column:watched",
       overRect: makeLogicRect(),
-      activeCenterY: 0,
+      pointerY: 0,
       isMobileLayout: false,
     });
 
@@ -135,7 +135,7 @@ describe("resolveDragOverItems", () => {
         activeId: "item-1",
         overId: "item-2",
         overRect: makeLogicRect(),
-        activeCenterY: 0,
+        pointerY: 0,
         isMobileLayout: true,
       }),
     ).toEqual(items);
@@ -150,7 +150,7 @@ describe("resolveDragOverItems", () => {
         activeId: "missing",
         overId: "item-2",
         overRect: makeLogicRect(),
-        activeCenterY: 0,
+        pointerY: 0,
         isMobileLayout: false,
       }),
     ).toBe(items);
@@ -160,7 +160,7 @@ describe("resolveDragOverItems", () => {
         activeId: "item-1",
         overId: "item-1",
         overRect: makeLogicRect(),
-        activeCenterY: 0,
+        pointerY: 0,
         isMobileLayout: false,
       }),
     ).toBe(items);

--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -17,29 +17,29 @@ function createWatchingItemsFixture() {
 }
 
 describe("resolveDragOverItems", () => {
-  test("同列内では active item の位置に応じて before/after を切り替える", () => {
+  test("同列内では pointer 位置に応じて before/after を切り替える", () => {
     const items = [
       createBacklogItem({ id: "item-1", sort_order: 1000 }),
       createBacklogItem({ id: "item-2", sort_order: 2000 }),
       createBacklogItem({ id: "item-3", sort_order: 3000 }),
     ];
 
-    // active center (50+50=100) < over center (100+100=200) → before
+    // pointer Y=120 < over center=200 → before
     const beforeItems = resolveDragOverItems({
       items,
       activeId: "item-3",
       overId: "item-2",
       overRect: makeLogicRect(100, 200),
-      activeRect: makeLogicRect(50, 100),
+      activeCenterY: 120,
       isMobileLayout: false,
     });
-    // active center (250+50=300) > over center (100+100=200) → after
+    // pointer Y=260 > over center=200 → after
     const afterItems = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-2",
       overRect: makeLogicRect(100, 200),
-      activeRect: makeLogicRect(250, 100),
+      activeCenterY: 260,
       isMobileLayout: false,
     });
 
@@ -53,22 +53,22 @@ describe("resolveDragOverItems", () => {
       createBacklogItem({ id: "item-2", sort_order: 2000 }),
     ];
 
-    // item-1 を item-2 の下へ: active center > over center → after
+    // item-1 を item-2 の下へ: pointer > over center → after
     const moveDown = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-2",
       overRect: makeLogicRect(200, 100),
-      activeRect: makeLogicRect(300, 100),
+      activeCenterY: 300,
       isMobileLayout: false,
     });
-    // item-2 を item-1 の上へ: active center < over center → before
+    // item-2 を item-1 の上へ: pointer < over center → before
     const moveUp = resolveDragOverItems({
       items,
       activeId: "item-2",
       overId: "item-1",
       overRect: makeLogicRect(100, 100),
-      activeRect: makeLogicRect(0, 100),
+      activeCenterY: 50,
       isMobileLayout: false,
     });
 
@@ -78,22 +78,22 @@ describe("resolveDragOverItems", () => {
 
   test.each([
     {
-      name: "active が over より上なら before として列またぎ挿入する",
+      name: "pointer が over より上なら before として列またぎ挿入する",
       overId: "item-3",
-      activeRect: makeLogicRect(50, 100), // center=100 < overRect center=200
+      activeCenterY: 120, // < overRect center=200
     },
     {
-      name: "active が over と同じ中心なら after として列またぎ挿入する",
+      name: "pointer が over 中心と同じなら after として列またぎ挿入する",
       overId: "item-2",
-      activeRect: makeLogicRect(100, 200), // center=200 = overRect center=200 → not < → after
+      activeCenterY: 200, // = overRect center=200 → not < → after
     },
-  ])("$name", ({ overId, activeRect }) => {
+  ])("$name", ({ overId, activeCenterY }) => {
     const nextItems = resolveDragOverItems({
       items: createWatchingItemsFixture(),
       activeId: "item-1",
       overId,
       overRect: makeLogicRect(),
-      activeRect,
+      activeCenterY,
       isMobileLayout: false,
     });
 
@@ -112,7 +112,7 @@ describe("resolveDragOverItems", () => {
       activeId: "item-1",
       overId: "column:watched",
       overRect: makeLogicRect(),
-      activeRect: makeLogicRect(),
+      activeCenterY: 0,
       isMobileLayout: false,
     });
 
@@ -135,7 +135,7 @@ describe("resolveDragOverItems", () => {
         activeId: "item-1",
         overId: "item-2",
         overRect: makeLogicRect(),
-        activeRect: makeLogicRect(),
+        activeCenterY: 0,
         isMobileLayout: true,
       }),
     ).toEqual(items);
@@ -150,7 +150,7 @@ describe("resolveDragOverItems", () => {
         activeId: "missing",
         overId: "item-2",
         overRect: makeLogicRect(),
-        activeRect: makeLogicRect(),
+        activeCenterY: 0,
         isMobileLayout: false,
       }),
     ).toBe(items);
@@ -160,7 +160,7 @@ describe("resolveDragOverItems", () => {
         activeId: "item-1",
         overId: "item-1",
         overRect: makeLogicRect(),
-        activeRect: makeLogicRect(),
+        activeCenterY: 0,
         isMobileLayout: false,
       }),
     ).toBe(items);

--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -17,63 +17,51 @@ function createWatchingItemsFixture() {
 }
 
 describe("resolveDragOverItems", () => {
-  test("同列内では pointer 位置に応じて before/after を切り替える", () => {
+  test("同列内では active を over の index へ入れ替える", () => {
     const items = [
       createBacklogItem({ id: "item-1", sort_order: 1000 }),
       createBacklogItem({ id: "item-2", sort_order: 2000 }),
       createBacklogItem({ id: "item-3", sort_order: 3000 }),
     ];
 
-    // pointer Y=120 < over center=200 → before
-    const beforeItems = resolveDragOverItems({
+    const moveUp = resolveDragOverItems({
       items,
       activeId: "item-3",
       overId: "item-2",
-      overRect: makeLogicRect(100, 200),
-      pointerY: 120,
+      overRect: makeLogicRect(),
+      pointerY: 0,
       isMobileLayout: false,
     });
-    // pointer Y=260 > over center=200 → after
-    const afterItems = resolveDragOverItems({
+    const moveDown = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-2",
-      overRect: makeLogicRect(100, 200),
-      pointerY: 260,
+      overRect: makeLogicRect(),
+      pointerY: 0,
       isMobileLayout: false,
     });
 
-    expect(beforeItems.map((item) => item.id)).toEqual(["item-1", "item-3", "item-2"]);
-    expect(afterItems.map((item) => item.id)).toEqual(["item-2", "item-1", "item-3"]);
+    expect(moveUp.map((item) => item.id)).toEqual(["item-1", "item-3", "item-2"]);
+    expect(moveDown.map((item) => item.id)).toEqual(["item-2", "item-1", "item-3"]);
   });
 
-  test("隣接要素への移動（1つ上・1つ下）が正しく動作する", () => {
+  test("同列内の隣接入れ替えは pointer が over 中心を超えていなくても成立する", () => {
+    // 回帰: sortable strategy の視覚シフトと閾値がズレて、小さなドラッグで入れ替わらなかった不具合
     const items = [
       createBacklogItem({ id: "item-1", sort_order: 1000 }),
       createBacklogItem({ id: "item-2", sort_order: 2000 }),
     ];
 
-    // item-1 を item-2 の下へ: pointer > over center → after
-    const moveDown = resolveDragOverItems({
+    const next = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-2",
-      overRect: makeLogicRect(200, 100),
-      pointerY: 300,
-      isMobileLayout: false,
-    });
-    // item-2 を item-1 の上へ: pointer < over center → before
-    const moveUp = resolveDragOverItems({
-      items,
-      activeId: "item-2",
-      overId: "item-1",
-      overRect: makeLogicRect(100, 100),
-      pointerY: 50,
+      overRect: makeLogicRect(1000, 100),
+      pointerY: 0,
       isMobileLayout: false,
     });
 
-    expect(moveDown.map((item) => item.id)).toEqual(["item-2", "item-1"]);
-    expect(moveUp.map((item) => item.id)).toEqual(["item-2", "item-1"]);
+    expect(next.map((item) => item.id)).toEqual(["item-2", "item-1"]);
   });
 
   test.each([

--- a/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.test.ts
@@ -1,10 +1,6 @@
 import { resolveDragOverItems, resolveDropPersistence } from "./useBacklogDnd.logic.ts";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
-import {
-  createBacklogItem,
-  createTouchEvent,
-  makeLogicRect,
-} from "./useBacklogDnd.test-helpers.ts";
+import { createBacklogItem, makeLogicRect } from "./useBacklogDnd.test-helpers.ts";
 
 setupTestLifecycle();
 
@@ -21,27 +17,29 @@ function createWatchingItemsFixture() {
 }
 
 describe("resolveDragOverItems", () => {
-  test("同列内では pointer 位置に応じて before/after を切り替える", () => {
+  test("同列内では active item の位置に応じて before/after を切り替える", () => {
     const items = [
       createBacklogItem({ id: "item-1", sort_order: 1000 }),
       createBacklogItem({ id: "item-2", sort_order: 2000 }),
       createBacklogItem({ id: "item-3", sort_order: 3000 }),
     ];
 
+    // active center (50+50=100) < over center (100+100=200) → before
     const beforeItems = resolveDragOverItems({
       items,
       activeId: "item-3",
       overId: "item-2",
-      rect: makeLogicRect(),
-      activatorEvent: { clientY: 120 } as MouseEvent,
+      overRect: makeLogicRect(100, 200),
+      activeRect: makeLogicRect(50, 100),
       isMobileLayout: false,
     });
+    // active center (250+50=300) > over center (100+100=200) → after
     const afterItems = resolveDragOverItems({
       items,
       activeId: "item-1",
       overId: "item-2",
-      rect: makeLogicRect(),
-      activatorEvent: { clientY: 260 } as MouseEvent,
+      overRect: makeLogicRect(100, 200),
+      activeRect: makeLogicRect(250, 100),
       isMobileLayout: false,
     });
 
@@ -49,24 +47,53 @@ describe("resolveDragOverItems", () => {
     expect(afterItems.map((item) => item.id)).toEqual(["item-2", "item-1", "item-3"]);
   });
 
+  test("隣接要素への移動（1つ上・1つ下）が正しく動作する", () => {
+    const items = [
+      createBacklogItem({ id: "item-1", sort_order: 1000 }),
+      createBacklogItem({ id: "item-2", sort_order: 2000 }),
+    ];
+
+    // item-1 を item-2 の下へ: active center > over center → after
+    const moveDown = resolveDragOverItems({
+      items,
+      activeId: "item-1",
+      overId: "item-2",
+      overRect: makeLogicRect(200, 100),
+      activeRect: makeLogicRect(300, 100),
+      isMobileLayout: false,
+    });
+    // item-2 を item-1 の上へ: active center < over center → before
+    const moveUp = resolveDragOverItems({
+      items,
+      activeId: "item-2",
+      overId: "item-1",
+      overRect: makeLogicRect(100, 100),
+      activeRect: makeLogicRect(0, 100),
+      isMobileLayout: false,
+    });
+
+    expect(moveDown.map((item) => item.id)).toEqual(["item-2", "item-1"]);
+    expect(moveUp.map((item) => item.id)).toEqual(["item-2", "item-1"]);
+  });
+
   test.each([
     {
-      name: "touch event でも clientY を読んで列またぎ挿入位置を決める",
+      name: "active が over より上なら before として列またぎ挿入する",
       overId: "item-3",
-      activatorEvent: createTouchEvent(120),
+      activeRect: makeLogicRect(50, 100), // center=100 < overRect center=200
     },
     {
-      name: "touch event に座標が無ければ rect 中央を使って after 扱いにする",
+      name: "active が over と同じ中心なら after として列またぎ挿入する",
       overId: "item-2",
-      activatorEvent: createTouchEvent(),
+      activeRect: makeLogicRect(100, 200), // center=200 = overRect center=200 → not < → after
     },
-  ])("$name", ({ overId, activatorEvent }) => {
+  ])("$name", ({ overId, activeRect }) => {
     const nextItems = resolveDragOverItems({
       items: createWatchingItemsFixture(),
       activeId: "item-1",
       overId,
-      rect: makeLogicRect(),
-      activatorEvent,
+      overRect: makeLogicRect(),
+      activeRect,
       isMobileLayout: false,
     });
 
@@ -84,8 +111,8 @@ describe("resolveDragOverItems", () => {
       items,
       activeId: "item-1",
       overId: "column:watched",
-      rect: makeLogicRect(),
-      activatorEvent: new MouseEvent("mousemove"),
+      overRect: makeLogicRect(),
+      activeRect: makeLogicRect(),
       isMobileLayout: false,
     });
 
@@ -107,8 +134,8 @@ describe("resolveDragOverItems", () => {
         items,
         activeId: "item-1",
         overId: "item-2",
-        rect: makeLogicRect(),
-        activatorEvent: new MouseEvent("mousemove"),
+        overRect: makeLogicRect(),
+        activeRect: makeLogicRect(),
         isMobileLayout: true,
       }),
     ).toEqual(items);
@@ -122,8 +149,8 @@ describe("resolveDragOverItems", () => {
         items,
         activeId: "missing",
         overId: "item-2",
-        rect: makeLogicRect(),
-        activatorEvent: new MouseEvent("mousemove"),
+        overRect: makeLogicRect(),
+        activeRect: makeLogicRect(),
         isMobileLayout: false,
       }),
     ).toBe(items);
@@ -132,8 +159,8 @@ describe("resolveDragOverItems", () => {
         items,
         activeId: "item-1",
         overId: "item-1",
-        rect: makeLogicRect(),
-        activatorEvent: new MouseEvent("mousemove"),
+        overRect: makeLogicRect(),
+        activeRect: makeLogicRect(),
         isMobileLayout: false,
       }),
     ).toBe(items);

--- a/src/features/backlog/hooks/useBacklogDnd.logic.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.ts
@@ -7,7 +7,7 @@ type DragOverResolutionInput = Readonly<{
   activeId: string;
   overId: string;
   overRect: RectLike;
-  activeCenterY: number;
+  pointerY: number;
   isMobileLayout: boolean;
 }>;
 
@@ -27,9 +27,8 @@ function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null 
   return items.find((item) => item.id === id)?.status ?? null;
 }
 
-function resolveDropSide(activeCenterY: number, overRect: RectLike): "before" | "after" {
-  const overCenterY = overRect.top + overRect.height / 2;
-  return activeCenterY < overCenterY ? "before" : "after";
+function resolveDropSide(pointerY: number, overRect: RectLike): "before" | "after" {
+  return pointerY < overRect.top + overRect.height / 2 ? "before" : "after";
 }
 
 function getReorderedColumnItems(
@@ -143,7 +142,7 @@ export function resolveDragOverItems({
   activeId,
   overId,
   overRect,
-  activeCenterY,
+  pointerY,
   isMobileLayout,
 }: DragOverResolutionInput): BacklogItem[] {
   if (activeId === overId) {
@@ -174,7 +173,7 @@ export function resolveDragOverItems({
       overStatus,
       activeId,
       overId,
-      resolveDropSide(activeCenterY, overRect),
+      resolveDropSide(pointerY, overRect),
     );
   }
 
@@ -187,7 +186,7 @@ export function resolveDragOverItems({
     activeId,
     overStatus,
     overId,
-    resolveDropSide(activeCenterY, overRect),
+    resolveDropSide(pointerY, overRect),
   );
 }
 

--- a/src/features/backlog/hooks/useBacklogDnd.logic.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.ts
@@ -31,6 +31,22 @@ function resolveDropSide(pointerY: number, overRect: RectLike): "before" | "afte
   return pointerY < overRect.top + overRect.height / 2 ? "before" : "after";
 }
 
+function arrayMove<T>(array: readonly T[], from: number, to: number): T[] {
+  const result = array.slice();
+  const [item] = result.splice(from, 1);
+  result.splice(to, 0, item);
+  return result;
+}
+
+function reorderSameColumn(items: BacklogItem[], activeId: string, overId: string): BacklogItem[] {
+  const activeIdx = items.findIndex((item) => item.id === activeId);
+  const overIdx = items.findIndex((item) => item.id === overId);
+  if (activeIdx === -1 || overIdx === -1) {
+    return items;
+  }
+  return arrayMove(items, activeIdx, overIdx);
+}
+
 function getReorderedColumnItems(
   columnItems: BacklogItem[],
   activeId: string,
@@ -79,18 +95,6 @@ function moveItemToColumnTop(items: BacklogItem[], activeId: string, status: Bac
   const others = updatedItems.filter((item) => item.status !== status);
 
   return [...others, { ...activeItem, status }, ...columnItems];
-}
-
-function reorderWithinColumn(
-  items: BacklogItem[],
-  status: BacklogStatus,
-  activeId: string,
-  overId: string,
-  side: "before" | "after",
-) {
-  const columnItems = items.filter((item) => item.status === status);
-  const others = items.filter((item) => item.status !== status);
-  return [...others, ...getReorderedColumnItems(columnItems, activeId, overId, side)];
 }
 
 function moveToColumnEdge(items: BacklogItem[], activeId: string, status: BacklogStatus) {
@@ -168,13 +172,7 @@ export function resolveDragOverItems({
       return items;
     }
 
-    return reorderWithinColumn(
-      items,
-      overStatus,
-      activeId,
-      overId,
-      resolveDropSide(pointerY, overRect),
-    );
+    return reorderSameColumn(items, activeId, overId);
   }
 
   if (overId.startsWith("column:")) {

--- a/src/features/backlog/hooks/useBacklogDnd.logic.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.ts
@@ -7,7 +7,7 @@ type DragOverResolutionInput = Readonly<{
   activeId: string;
   overId: string;
   overRect: RectLike;
-  activeRect: RectLike;
+  activeCenterY: number;
   isMobileLayout: boolean;
 }>;
 
@@ -27,8 +27,7 @@ function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null 
   return items.find((item) => item.id === id)?.status ?? null;
 }
 
-function resolveDropSide(activeRect: RectLike, overRect: RectLike): "before" | "after" {
-  const activeCenterY = activeRect.top + activeRect.height / 2;
+function resolveDropSide(activeCenterY: number, overRect: RectLike): "before" | "after" {
   const overCenterY = overRect.top + overRect.height / 2;
   return activeCenterY < overCenterY ? "before" : "after";
 }
@@ -144,7 +143,7 @@ export function resolveDragOverItems({
   activeId,
   overId,
   overRect,
-  activeRect,
+  activeCenterY,
   isMobileLayout,
 }: DragOverResolutionInput): BacklogItem[] {
   if (activeId === overId) {
@@ -175,7 +174,7 @@ export function resolveDragOverItems({
       overStatus,
       activeId,
       overId,
-      resolveDropSide(activeRect, overRect),
+      resolveDropSide(activeCenterY, overRect),
     );
   }
 
@@ -188,7 +187,7 @@ export function resolveDragOverItems({
     activeId,
     overStatus,
     overId,
-    resolveDropSide(activeRect, overRect),
+    resolveDropSide(activeCenterY, overRect),
   );
 }
 

--- a/src/features/backlog/hooks/useBacklogDnd.logic.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.logic.ts
@@ -1,15 +1,13 @@
-import type { DragOverEvent } from "@dnd-kit/core";
 import type { BacklogItem, BacklogStatus } from "../types.ts";
 
 export type RectLike = Pick<DOMRect, "top" | "height">;
-type TouchListKey = "touches" | "changedTouches";
 
 type DragOverResolutionInput = Readonly<{
   items: BacklogItem[];
   activeId: string;
   overId: string;
-  rect: RectLike;
-  activatorEvent: DragOverEvent["activatorEvent"];
+  overRect: RectLike;
+  activeRect: RectLike;
   isMobileLayout: boolean;
 }>;
 
@@ -29,38 +27,10 @@ function findItemStatus(items: BacklogItem[], id: string): BacklogStatus | null 
   return items.find((item) => item.id === id)?.status ?? null;
 }
 
-function getDropSideFromRect(rect: RectLike, clientY: number) {
-  return clientY < rect.top + rect.height / 2 ? "before" : "after";
-}
-
-function getClientYFromPointerEvent(
-  event: MouseEvent | TouchEvent | null | undefined,
-  rect: RectLike,
-  touchListKey: TouchListKey = "touches",
-) {
-  const fallbackY = rect.top + rect.height / 2;
-
-  if (!event) {
-    return fallbackY;
-  }
-
-  if ("touches" in event && event.type.includes("touch")) {
-    const touchList = touchListKey === "changedTouches" ? event.changedTouches : event.touches;
-    return touchList?.[0]?.clientY ?? fallbackY;
-  }
-
-  return "clientY" in event ? (event.clientY ?? fallbackY) : fallbackY;
-}
-
-function resolveDropSide(
-  activatorEvent: DragOverEvent["activatorEvent"],
-  rect: RectLike,
-): "before" | "after" {
-  const clientY = getClientYFromPointerEvent(
-    activatorEvent as MouseEvent | TouchEvent | null | undefined,
-    rect,
-  );
-  return getDropSideFromRect(rect, clientY);
+function resolveDropSide(activeRect: RectLike, overRect: RectLike): "before" | "after" {
+  const activeCenterY = activeRect.top + activeRect.height / 2;
+  const overCenterY = overRect.top + overRect.height / 2;
+  return activeCenterY < overCenterY ? "before" : "after";
 }
 
 function getReorderedColumnItems(
@@ -173,8 +143,8 @@ export function resolveDragOverItems({
   items,
   activeId,
   overId,
-  rect,
-  activatorEvent,
+  overRect,
+  activeRect,
   isMobileLayout,
 }: DragOverResolutionInput): BacklogItem[] {
   if (activeId === overId) {
@@ -205,7 +175,7 @@ export function resolveDragOverItems({
       overStatus,
       activeId,
       overId,
-      resolveDropSide(activatorEvent, rect),
+      resolveDropSide(activeRect, overRect),
     );
   }
 
@@ -218,7 +188,7 @@ export function resolveDragOverItems({
     activeId,
     overStatus,
     overId,
-    resolveDropSide(activatorEvent, rect),
+    resolveDropSide(activeRect, overRect),
   );
 }
 

--- a/src/features/backlog/hooks/useBacklogDnd.test-helpers.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.test-helpers.ts
@@ -53,11 +53,3 @@ export function makeDomRect(top = 100, height = 200): DOMRect {
     toJSON: () => ({}),
   } as DOMRect;
 }
-
-export function createTouchEvent(clientY?: number): TouchEvent {
-  return {
-    type: "touchmove",
-    touches: clientY === undefined ? [] : [{ clientY }],
-    changedTouches: clientY === undefined ? [] : [{ clientY }],
-  } as unknown as TouchEvent;
-}

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -61,14 +61,13 @@ function renderDnd(
   );
 }
 
-function makeActiveRect(top: number, height = 0) {
-  return { top, height, left: 0, right: 0, width: 0, bottom: top + height };
-}
+// initial は origin 固定、delta.y で pointer Y を表現（initial.center + delta.y = 0 + 0 + pointerY = pointerY）
+const ZERO_RECT = { top: 0, height: 0, left: 0, right: 0, width: 0, bottom: 0 };
 
 function dragOver(
   result: ReturnType<typeof renderDnd>["result"],
   overId: string,
-  activeCenterY: number,
+  pointerY: number,
   activeId = "item-1",
 ) {
   act(() => {
@@ -76,9 +75,10 @@ function dragOver(
     result.current.handleDragOver({
       active: {
         id: activeId,
-        rect: { current: { translated: makeActiveRect(activeCenterY) } },
+        rect: { current: { initial: ZERO_RECT } },
       },
       over: { id: overId, rect: makeDomRect(100, 200) },
+      delta: { x: 0, y: pointerY },
     } as unknown as DragOverEvent);
   });
 }
@@ -250,12 +250,14 @@ describe("useBacklogDnd", () => {
     act(() => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
-        active: { id: "item-1", rect: { current: { translated: makeActiveRect(120) } } },
+        active: { id: "item-1", rect: { current: { initial: ZERO_RECT } } },
         over: { id: "item-3", rect: makeDomRect(100, 200) },
+        delta: { x: 0, y: 120 },
       } as unknown as DragOverEvent);
       result.current.handleDragOver({
-        active: { id: "item-1", rect: { current: { translated: makeActiveRect(120) } } },
+        active: { id: "item-1", rect: { current: { initial: ZERO_RECT } } },
         over: { id: "item-2", rect: makeDomRect(100, 200) },
+        delta: { x: 0, y: 120 },
       } as unknown as DragOverEvent);
     });
 

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -61,18 +61,24 @@ function renderDnd(
   );
 }
 
+function makeActiveRect(top: number, height = 0) {
+  return { top, height, left: 0, right: 0, width: 0, bottom: top + height };
+}
+
 function dragOver(
   result: ReturnType<typeof renderDnd>["result"],
   overId: string,
-  clientY: number,
+  activeCenterY: number,
   activeId = "item-1",
 ) {
   act(() => {
     result.current.handleDragStart({ active: { id: activeId } } as DragStartEvent);
     result.current.handleDragOver({
-      active: { id: activeId },
+      active: {
+        id: activeId,
+        rect: { current: { translated: makeActiveRect(activeCenterY) } },
+      },
       over: { id: overId, rect: makeDomRect(100, 200) },
-      activatorEvent: { clientY } as MouseEvent,
     } as unknown as DragOverEvent);
   });
 }
@@ -244,14 +250,12 @@ describe("useBacklogDnd", () => {
     act(() => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
-        active: { id: "item-1" },
+        active: { id: "item-1", rect: { current: { translated: makeActiveRect(120) } } },
         over: { id: "item-3", rect: makeDomRect(100, 200) },
-        activatorEvent: { clientY: 120 } as MouseEvent,
       } as unknown as DragOverEvent);
       result.current.handleDragOver({
-        active: { id: "item-1" },
+        active: { id: "item-1", rect: { current: { translated: makeActiveRect(120) } } },
         over: { id: "item-2", rect: makeDomRect(100, 200) },
-        activatorEvent: { clientY: 120 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 

--- a/src/features/backlog/hooks/useBacklogDnd.test.tsx
+++ b/src/features/backlog/hooks/useBacklogDnd.test.tsx
@@ -61,9 +61,7 @@ function renderDnd(
   );
 }
 
-// initial は origin 固定、delta.y で pointer Y を表現（initial.center + delta.y = 0 + 0 + pointerY = pointerY）
-const ZERO_RECT = { top: 0, height: 0, left: 0, right: 0, width: 0, bottom: 0 };
-
+// activatorEvent.clientY = 0, delta.y = pointerY で実際の pointer Y を表現
 function dragOver(
   result: ReturnType<typeof renderDnd>["result"],
   overId: string,
@@ -73,12 +71,10 @@ function dragOver(
   act(() => {
     result.current.handleDragStart({ active: { id: activeId } } as DragStartEvent);
     result.current.handleDragOver({
-      active: {
-        id: activeId,
-        rect: { current: { initial: ZERO_RECT } },
-      },
+      active: { id: activeId },
       over: { id: overId, rect: makeDomRect(100, 200) },
       delta: { x: 0, y: pointerY },
+      activatorEvent: { clientY: 0 } as MouseEvent,
     } as unknown as DragOverEvent);
   });
 }
@@ -250,14 +246,16 @@ describe("useBacklogDnd", () => {
     act(() => {
       result.current.handleDragStart({ active: { id: "item-1" } } as DragStartEvent);
       result.current.handleDragOver({
-        active: { id: "item-1", rect: { current: { initial: ZERO_RECT } } },
+        active: { id: "item-1" },
         over: { id: "item-3", rect: makeDomRect(100, 200) },
         delta: { x: 0, y: 120 },
+        activatorEvent: { clientY: 0 } as MouseEvent,
       } as unknown as DragOverEvent);
       result.current.handleDragOver({
-        active: { id: "item-1", rect: { current: { initial: ZERO_RECT } } },
+        active: { id: "item-1" },
         over: { id: "item-2", rect: makeDomRect(100, 200) },
         delta: { x: 0, y: 120 },
+        activatorEvent: { clientY: 0 } as MouseEvent,
       } as unknown as DragOverEvent);
     });
 

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -62,7 +62,7 @@ export function useBacklogDnd({
       return;
     }
 
-    const activeRect = active.rect.current.translated;
+    const activeRect = active.rect.current.translated ?? active.rect.current.initial;
     if (!activeRect) {
       return;
     }

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -57,8 +57,13 @@ export function useBacklogDnd({
   };
 
   const handleDragOver = (event: DragOverEvent) => {
-    const { active, over, activatorEvent } = event;
+    const { active, over } = event;
     if (!over) {
+      return;
+    }
+
+    const activeRect = active.rect.current.translated;
+    if (!activeRect) {
       return;
     }
 
@@ -70,8 +75,8 @@ export function useBacklogDnd({
         items: prev,
         activeId,
         overId,
-        rect: over.rect,
-        activatorEvent,
+        overRect: over.rect,
+        activeRect,
         isMobileLayout,
       });
     });

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -15,6 +15,19 @@ import { resolveDragOverItems, resolveDropPersistence } from "./useBacklogDnd.lo
 
 const EMPTY_PENDING_DELETES: ReadonlySet<string> = new Set();
 
+function getActivatorClientY(event: DragOverEvent["activatorEvent"]): number | null {
+  if (!event) return null;
+  if ("touches" in event && event.type.includes("touch")) {
+    const touchEvent = event as TouchEvent;
+    return touchEvent.touches?.[0]?.clientY ?? touchEvent.changedTouches?.[0]?.clientY ?? null;
+  }
+  if ("clientY" in event) {
+    const y = (event as MouseEvent).clientY;
+    return typeof y === "number" ? y : null;
+  }
+  return null;
+}
+
 type Props = Readonly<{
   items: BacklogItem[];
   pendingDeleteIds?: ReadonlySet<string>;
@@ -57,17 +70,17 @@ export function useBacklogDnd({
   };
 
   const handleDragOver = (event: DragOverEvent) => {
-    const { active, over, delta } = event;
+    const { active, over, delta, activatorEvent } = event;
     if (!over) {
       return;
     }
 
-    const initialRect = active.rect.current.initial;
-    if (!initialRect) {
+    const activatorY = getActivatorClientY(activatorEvent);
+    if (activatorY === null) {
       return;
     }
 
-    const activeCenterY = initialRect.top + initialRect.height / 2 + delta.y;
+    const pointerY = activatorY + delta.y;
 
     const activeId = active.id as string;
     const overId = over.id as string;
@@ -78,7 +91,7 @@ export function useBacklogDnd({
         activeId,
         overId,
         overRect: over.rect,
-        activeCenterY,
+        pointerY,
         isMobileLayout,
       });
     });

--- a/src/features/backlog/hooks/useBacklogDnd.ts
+++ b/src/features/backlog/hooks/useBacklogDnd.ts
@@ -57,15 +57,17 @@ export function useBacklogDnd({
   };
 
   const handleDragOver = (event: DragOverEvent) => {
-    const { active, over } = event;
+    const { active, over, delta } = event;
     if (!over) {
       return;
     }
 
-    const activeRect = active.rect.current.translated ?? active.rect.current.initial;
-    if (!activeRect) {
+    const initialRect = active.rect.current.initial;
+    if (!initialRect) {
       return;
     }
+
+    const activeCenterY = initialRect.top + initialRect.height / 2 + delta.y;
 
     const activeId = active.id as string;
     const overId = over.id as string;
@@ -76,7 +78,7 @@ export function useBacklogDnd({
         activeId,
         overId,
         overRect: over.rect,
-        activeRect,
+        activeCenterY,
         isMobileLayout,
       });
     });

--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -12,8 +12,6 @@ export type PrimaryPlatform =
   | "apple_tv_plus"
   | "apple_tv"
   | null;
-export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
-export type GameReleaseDates = Partial<Record<GamePlatform, string>>;
 
 export type WorkSummary = {
   id: string;


### PR DESCRIPTION
## 関連 Issue

Closes #271

## 変更内容

- `resolveDropSide` の side 判定ロジックを修正
  - 変更前: `activatorEvent.clientY`（ドラッグ**開始時**の固定値）と `over.rect` の中線を比較
  - 変更後: `active.rect.current.translated`（ドラッグ中の現在位置）の中心 Y と `over.rect` の中心 Y を比較
- `useBacklogDnd.ts` の `handleDragOver` で `active.rect.current.translated` を取得して渡すよう変更
- テストを rect ベースの比較に更新し、隣接移動の回帰テストを追加
- 未使用になった `createTouchEvent` テストヘルパーを削除

### バグの原因

`activatorEvent` はドラッグ**開始時**のポインターイベントのスナップショットで、ドラッグ中に更新されない。隣接要素にドラッグすると、開始時の clientY が常に over item の中線より上（または下）に固定されるため、side 判定が常に逆方向になり並び替えが発生しなかった。