### PR TITLE
test: Edge Functions 共有モジュールのテスト追加

### DIFF
--- a/src/features/backlog/types.ts
+++ b/src/features/backlog/types.ts
@@ -12,9 +12,6 @@ export type PrimaryPlatform =
   | "apple_tv_plus"
   | "apple_tv"
   | null;
-export type GamePlatform = "steam" | "playstation" | "switch" | "xbox" | "ios" | "android";
-export type GameReleaseDates = Partial<Record<GamePlatform, string>>;
-
 export type WorkSummary = {
   id: string;
   title: string;

--- a/supabase/functions/_shared/gemini_test.ts
+++ b/supabase/functions/_shared/gemini_test.ts
@@ -1,0 +1,293 @@
+import { assertEquals } from "jsr:@std/assert";
+import { suggestDisplayTitle, translateSearchQuery } from "./gemini.ts";
+
+async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, Deno.env.get(key));
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
+    }
+  }
+}
+
+async function withMockFetch(
+  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
+  run: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url =
+      input instanceof Request ? new URL(input.url) : input instanceof URL ? input : new URL(input);
+    return await handler(url, init);
+  }) as typeof fetch;
+
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function geminiResponse(text: string) {
+  return new Response(
+    JSON.stringify({
+      candidates: [{ content: { parts: [{ text }] } }],
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+// supabase env を未設定にすることで readGeminiCache / writeGeminiCache を no-op にする
+
+Deno.test("translateSearchQuery は日本語を含まない入力で null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      assertEquals(await translateSearchQuery("pure english title"), null);
+      assertEquals(await translateSearchQuery("   "), null);
+    },
+  );
+});
+
+Deno.test("translateSearchQuery は Gemini の JSON 結果を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        (url) => {
+          assertEquals(url.hostname, "generativelanguage.googleapis.com");
+          return geminiResponse(JSON.stringify({ query: "Spirited Away" }));
+        },
+        async () => {
+          assertEquals(await translateSearchQuery("千と千尋の神隠し"), "Spirited Away");
+        },
+      );
+    },
+  );
+});
+
+Deno.test("translateSearchQuery は余計な前後テキスト付き JSON も抽出する", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => geminiResponse('Here is the translation:\n{"query": "Your Name"}\nThank you.'),
+        async () => {
+          assertEquals(await translateSearchQuery("君の名は"), "Your Name");
+        },
+      );
+    },
+  );
+});
+
+Deno.test("translateSearchQuery は query が入力と同一なら null にする", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => geminiResponse(JSON.stringify({ query: "ワンピース" })),
+        async () => {
+          assertEquals(await translateSearchQuery("ワンピース"), null);
+        },
+      );
+    },
+  );
+});
+
+Deno.test("translateSearchQuery は Gemini 失敗時に null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => new Response("boom", { status: 500 }),
+        async () => {
+          assertEquals(await translateSearchQuery("進撃の巨人"), null);
+        },
+      );
+    },
+  );
+});
+
+Deno.test("translateSearchQuery は GEMINI_API_KEY 未設定で null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: undefined,
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      assertEquals(await translateSearchQuery("鬼滅の刃"), null);
+    },
+  );
+});
+
+Deno.test("translateSearchQuery はパース不能レスポンスで null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => geminiResponse("no json here"),
+        async () => {
+          assertEquals(await translateSearchQuery("呪術廻戦"), null);
+        },
+      );
+    },
+  );
+});
+
+Deno.test("suggestDisplayTitle は空 title で null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      assertEquals(
+        await suggestDisplayTitle({ title: "   ", originalTitle: null, workType: "movie" }),
+        null,
+      );
+    },
+  );
+});
+
+Deno.test("suggestDisplayTitle は Gemini の title 候補を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => geminiResponse(JSON.stringify({ title: "君の名は。" })),
+        async () => {
+          assertEquals(
+            await suggestDisplayTitle({
+              title: "Your Name",
+              originalTitle: "君の名は。",
+              workType: "movie",
+            }),
+            "君の名は。",
+          );
+        },
+      );
+    },
+  );
+});
+
+Deno.test("suggestDisplayTitle は候補が現タイトルと同じなら null にする", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => geminiResponse(JSON.stringify({ title: "Your Name" })),
+        async () => {
+          assertEquals(
+            await suggestDisplayTitle({
+              title: "Your Name",
+              originalTitle: null,
+              workType: "movie",
+            }),
+            null,
+          );
+        },
+      );
+    },
+  );
+});
+
+Deno.test("suggestDisplayTitle は Gemini 失敗時に null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => new Response("fail", { status: 502 }),
+        async () => {
+          assertEquals(
+            await suggestDisplayTitle({
+              title: "Attack on Titan",
+              originalTitle: "進撃の巨人",
+              workType: "series",
+            }),
+            null,
+          );
+        },
+      );
+    },
+  );
+});
+
+Deno.test("suggestDisplayTitle は title フィールド欠落で null を返す", async () => {
+  await withEnv(
+    {
+      GEMINI_API_KEY: "test-key",
+      SUPABASE_URL: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+    },
+    async () => {
+      await withMockFetch(
+        () => geminiResponse(JSON.stringify({ other: "value" })),
+        async () => {
+          assertEquals(
+            await suggestDisplayTitle({
+              title: "Demon Slayer",
+              originalTitle: null,
+              workType: "series",
+            }),
+            null,
+          );
+        },
+      );
+    },
+  );
+});

--- a/supabase/functions/_shared/gemini_test.ts
+++ b/supabase/functions/_shared/gemini_test.ts
@@ -1,49 +1,6 @@
 import { assertEquals } from "jsr:@std/assert";
 import { suggestDisplayTitle, translateSearchQuery } from "./gemini.ts";
-
-async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
-  const previous = new Map<string, string | undefined>();
-
-  for (const [key, value] of Object.entries(values)) {
-    previous.set(key, Deno.env.get(key));
-    if (value === undefined) {
-      Deno.env.delete(key);
-    } else {
-      Deno.env.set(key, value);
-    }
-  }
-
-  try {
-    await run();
-  } finally {
-    for (const [key, value] of previous.entries()) {
-      if (value === undefined) {
-        Deno.env.delete(key);
-      } else {
-        Deno.env.set(key, value);
-      }
-    }
-  }
-}
-
-async function withMockFetch(
-  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
-  run: () => Promise<void>,
-) {
-  const originalFetch = globalThis.fetch;
-
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url =
-      input instanceof Request ? new URL(input.url) : input instanceof URL ? input : new URL(input);
-    return await handler(url, init);
-  }) as typeof fetch;
-
-  try {
-    await run();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
+import { withEnv, withMockFetch } from "./test-helpers.ts";
 
 function geminiResponse(text: string) {
   return new Response(
@@ -55,239 +12,159 @@ function geminiResponse(text: string) {
 }
 
 // supabase env を未設定にすることで readGeminiCache / writeGeminiCache を no-op にする
+const CACHE_OFF_ENV = {
+  SUPABASE_URL: undefined,
+  SUPABASE_SERVICE_ROLE_KEY: undefined,
+} as const;
 
 Deno.test("translateSearchQuery は日本語を含まない入力で null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      assertEquals(await translateSearchQuery("pure english title"), null);
-      assertEquals(await translateSearchQuery("   "), null);
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    assertEquals(await translateSearchQuery("pure english title"), null);
+    assertEquals(await translateSearchQuery("   "), null);
+  });
 });
 
 Deno.test("translateSearchQuery は Gemini の JSON 結果を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        (url) => {
-          assertEquals(url.hostname, "generativelanguage.googleapis.com");
-          return geminiResponse(JSON.stringify({ query: "Spirited Away" }));
-        },
-        async () => {
-          assertEquals(await translateSearchQuery("千と千尋の神隠し"), "Spirited Away");
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      (url) => {
+        assertEquals(url.hostname, "generativelanguage.googleapis.com");
+        return geminiResponse(JSON.stringify({ query: "Spirited Away" }));
+      },
+      async () => {
+        assertEquals(await translateSearchQuery("千と千尋の神隠し"), "Spirited Away");
+      },
+    );
+  });
 });
 
 Deno.test("translateSearchQuery は余計な前後テキスト付き JSON も抽出する", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => geminiResponse('Here is the translation:\n{"query": "Your Name"}\nThank you.'),
-        async () => {
-          assertEquals(await translateSearchQuery("君の名は"), "Your Name");
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => geminiResponse('Here is the translation:\n{"query": "Your Name"}\nThank you.'),
+      async () => {
+        assertEquals(await translateSearchQuery("君の名は"), "Your Name");
+      },
+    );
+  });
 });
 
 Deno.test("translateSearchQuery は query が入力と同一なら null にする", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => geminiResponse(JSON.stringify({ query: "ワンピース" })),
-        async () => {
-          assertEquals(await translateSearchQuery("ワンピース"), null);
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => geminiResponse(JSON.stringify({ query: "ワンピース" })),
+      async () => {
+        assertEquals(await translateSearchQuery("ワンピース"), null);
+      },
+    );
+  });
 });
 
 Deno.test("translateSearchQuery は Gemini 失敗時に null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => new Response("boom", { status: 500 }),
-        async () => {
-          assertEquals(await translateSearchQuery("進撃の巨人"), null);
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => new Response("boom", { status: 500 }),
+      async () => {
+        assertEquals(await translateSearchQuery("進撃の巨人"), null);
+      },
+    );
+  });
 });
 
 Deno.test("translateSearchQuery は GEMINI_API_KEY 未設定で null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: undefined,
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      assertEquals(await translateSearchQuery("鬼滅の刃"), null);
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: undefined, ...CACHE_OFF_ENV }, async () => {
+    assertEquals(await translateSearchQuery("鬼滅の刃"), null);
+  });
 });
 
 Deno.test("translateSearchQuery はパース不能レスポンスで null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => geminiResponse("no json here"),
-        async () => {
-          assertEquals(await translateSearchQuery("呪術廻戦"), null);
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => geminiResponse("no json here"),
+      async () => {
+        assertEquals(await translateSearchQuery("呪術廻戦"), null);
+      },
+    );
+  });
 });
 
 Deno.test("suggestDisplayTitle は空 title で null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      assertEquals(
-        await suggestDisplayTitle({ title: "   ", originalTitle: null, workType: "movie" }),
-        null,
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    assertEquals(
+      await suggestDisplayTitle({ title: "   ", originalTitle: null, workType: "movie" }),
+      null,
+    );
+  });
 });
 
 Deno.test("suggestDisplayTitle は Gemini の title 候補を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => geminiResponse(JSON.stringify({ title: "君の名は。" })),
-        async () => {
-          assertEquals(
-            await suggestDisplayTitle({
-              title: "Your Name",
-              originalTitle: "君の名は。",
-              workType: "movie",
-            }),
-            "君の名は。",
-          );
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => geminiResponse(JSON.stringify({ title: "君の名は。" })),
+      async () => {
+        assertEquals(
+          await suggestDisplayTitle({
+            title: "Your Name",
+            originalTitle: "君の名は。",
+            workType: "movie",
+          }),
+          "君の名は。",
+        );
+      },
+    );
+  });
 });
 
 Deno.test("suggestDisplayTitle は候補が現タイトルと同じなら null にする", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => geminiResponse(JSON.stringify({ title: "Your Name" })),
-        async () => {
-          assertEquals(
-            await suggestDisplayTitle({
-              title: "Your Name",
-              originalTitle: null,
-              workType: "movie",
-            }),
-            null,
-          );
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => geminiResponse(JSON.stringify({ title: "Your Name" })),
+      async () => {
+        assertEquals(
+          await suggestDisplayTitle({
+            title: "Your Name",
+            originalTitle: null,
+            workType: "movie",
+          }),
+          null,
+        );
+      },
+    );
+  });
 });
 
 Deno.test("suggestDisplayTitle は Gemini 失敗時に null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => new Response("fail", { status: 502 }),
-        async () => {
-          assertEquals(
-            await suggestDisplayTitle({
-              title: "Attack on Titan",
-              originalTitle: "進撃の巨人",
-              workType: "series",
-            }),
-            null,
-          );
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => new Response("fail", { status: 502 }),
+      async () => {
+        assertEquals(
+          await suggestDisplayTitle({
+            title: "Attack on Titan",
+            originalTitle: "進撃の巨人",
+            workType: "series",
+          }),
+          null,
+        );
+      },
+    );
+  });
 });
 
 Deno.test("suggestDisplayTitle は title フィールド欠落で null を返す", async () => {
-  await withEnv(
-    {
-      GEMINI_API_KEY: "test-key",
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
-    },
-    async () => {
-      await withMockFetch(
-        () => geminiResponse(JSON.stringify({ other: "value" })),
-        async () => {
-          assertEquals(
-            await suggestDisplayTitle({
-              title: "Demon Slayer",
-              originalTitle: null,
-              workType: "series",
-            }),
-            null,
-          );
-        },
-      );
-    },
-  );
+  await withEnv({ GEMINI_API_KEY: "test-key", ...CACHE_OFF_ENV }, async () => {
+    await withMockFetch(
+      () => geminiResponse(JSON.stringify({ other: "value" })),
+      async () => {
+        assertEquals(
+          await suggestDisplayTitle({
+            title: "Demon Slayer",
+            originalTitle: null,
+            workType: "series",
+          }),
+          null,
+        );
+      },
+    );
+  });
 });

--- a/supabase/functions/_shared/igdb_test.ts
+++ b/supabase/functions/_shared/igdb_test.ts
@@ -12,13 +12,7 @@ import {
   selectInvolvedCompany,
   unixSecondsToIsoDate,
 } from "./igdb.ts";
-
-function jsonResponse(payload: unknown, init: ResponseInit = {}) {
-  return new Response(JSON.stringify(payload), {
-    status: init.status ?? 200,
-    headers: { "Content-Type": "application/json", ...init.headers },
-  });
-}
+import { jsonResponse } from "./test-helpers.ts";
 
 function createContext(
   fetchImpl: typeof fetch,

--- a/supabase/functions/_shared/omdb_test.ts
+++ b/supabase/functions/_shared/omdb_test.ts
@@ -1,56 +1,6 @@
 import { assertEquals, assertRejects, assertThrows } from "jsr:@std/assert";
 import { extractRatings, fetchOmdbDetails, isDefinitiveOmdbMiss } from "./omdb.ts";
-
-async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
-  const previous = new Map<string, string | undefined>();
-
-  for (const [key, value] of Object.entries(values)) {
-    previous.set(key, Deno.env.get(key));
-    if (value === undefined) {
-      Deno.env.delete(key);
-    } else {
-      Deno.env.set(key, value);
-    }
-  }
-
-  try {
-    await run();
-  } finally {
-    for (const [key, value] of previous.entries()) {
-      if (value === undefined) {
-        Deno.env.delete(key);
-      } else {
-        Deno.env.set(key, value);
-      }
-    }
-  }
-}
-
-async function withMockFetch(
-  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
-  run: () => Promise<void>,
-) {
-  const originalFetch = globalThis.fetch;
-
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url =
-      input instanceof Request ? new URL(input.url) : input instanceof URL ? input : new URL(input);
-    return await handler(url, init);
-  }) as typeof fetch;
-
-  try {
-    await run();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
-
-function jsonResponse(payload: unknown, init: ResponseInit = {}) {
-  return new Response(JSON.stringify(payload), {
-    status: init.status ?? 200,
-    headers: { "Content-Type": "application/json", ...init.headers },
-  });
-}
+import { jsonResponse, withEnv, withMockFetch } from "./test-helpers.ts";
 
 Deno.test("isDefinitiveOmdbMiss は未発見系エラーだけを true にする", () => {
   assertEquals(isDefinitiveOmdbMiss("Movie not found!"), true);

--- a/supabase/functions/_shared/omdb_test.ts
+++ b/supabase/functions/_shared/omdb_test.ts
@@ -1,8 +1,61 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
-import { extractRatings, isDefinitiveOmdbMiss } from "./omdb.ts";
+import { assertEquals, assertRejects, assertThrows } from "jsr:@std/assert";
+import { extractRatings, fetchOmdbDetails, isDefinitiveOmdbMiss } from "./omdb.ts";
+
+async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, Deno.env.get(key));
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
+    }
+  }
+}
+
+async function withMockFetch(
+  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
+  run: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url =
+      input instanceof Request ? new URL(input.url) : input instanceof URL ? input : new URL(input);
+    return await handler(url, init);
+  }) as typeof fetch;
+
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+}
 
 Deno.test("isDefinitiveOmdbMiss は未発見系エラーだけを true にする", () => {
   assertEquals(isDefinitiveOmdbMiss("Movie not found!"), true);
+  assertEquals(isDefinitiveOmdbMiss("Series not found!"), true);
+  assertEquals(isDefinitiveOmdbMiss("Episode not found!"), true);
   assertEquals(isDefinitiveOmdbMiss("Incorrect IMDb ID."), true);
   assertEquals(isDefinitiveOmdbMiss("Invalid API key!"), false);
   assertEquals(isDefinitiveOmdbMiss("Request limit reached!"), false);
@@ -33,4 +86,115 @@ Deno.test("extractRatings は一時障害を例外として返す", () => {
     Error,
     "Request limit reached!",
   );
+});
+
+Deno.test("extractRatings は Error が未指定の失敗レスポンスでも例外を投げる", () => {
+  assertThrows(
+    () => extractRatings({ Response: "False" }),
+    Error,
+    "OMDb returned an error response",
+  );
+});
+
+Deno.test("extractRatings は各 Source の評価値をパースする", () => {
+  assertEquals(
+    extractRatings({
+      Response: "True",
+      Ratings: [
+        { Source: "Rotten Tomatoes", Value: "87%" },
+        { Source: "Internet Movie Database", Value: "8.4/10" },
+        { Source: "Metacritic", Value: "73/100" },
+      ],
+      imdbVotes: "1,234,567",
+    }),
+    {
+      rottenTomatoesScore: 87,
+      imdbRating: 8.4,
+      imdbVotes: 1234567,
+      metacriticScore: 73,
+    },
+  );
+});
+
+Deno.test("extractRatings は範囲外や未知フォーマットの値を null にする", () => {
+  assertEquals(
+    extractRatings({
+      Response: "True",
+      Ratings: [
+        { Source: "Rotten Tomatoes", Value: "120%" },
+        { Source: "Internet Movie Database", Value: "12/10" },
+        { Source: "Metacritic", Value: "abc/100" },
+        { Source: "Unknown Source", Value: "ignored" },
+      ],
+      imdbVotes: "not-a-number",
+    }),
+    {
+      rottenTomatoesScore: null,
+      imdbRating: null,
+      imdbVotes: null,
+      metacriticScore: null,
+    },
+  );
+});
+
+Deno.test("extractRatings は imdbRating が無いとき imdbVotes を無視する", () => {
+  assertEquals(
+    extractRatings({
+      Response: "True",
+      Ratings: [{ Source: "Rotten Tomatoes", Value: "50%" }],
+      imdbVotes: "10,000",
+    }),
+    {
+      rottenTomatoesScore: 50,
+      imdbRating: null,
+      imdbVotes: null,
+      metacriticScore: null,
+    },
+  );
+});
+
+Deno.test("extractRatings は Ratings が未指定でも空結果を返す", () => {
+  assertEquals(extractRatings({ Response: "True" }), {
+    rottenTomatoesScore: null,
+    imdbRating: null,
+    imdbVotes: null,
+    metacriticScore: null,
+  });
+});
+
+Deno.test("fetchOmdbDetails は OMDb レスポンスを評価値に変換する", async () => {
+  await withEnv({ OMDB_API_KEY: "test-key" }, async () => {
+    await withMockFetch(
+      (url) => {
+        assertEquals(url.hostname, "www.omdbapi.com");
+        assertEquals(url.searchParams.get("i"), "tt0133093");
+        assertEquals(url.searchParams.get("apikey"), "test-key");
+        return jsonResponse({
+          Response: "True",
+          Ratings: [{ Source: "Rotten Tomatoes", Value: "88%" }],
+        });
+      },
+      async () => {
+        const result = await fetchOmdbDetails("tt0133093");
+        assertEquals(result.rottenTomatoesScore, 88);
+      },
+    );
+  });
+});
+
+Deno.test("fetchOmdbDetails は OMDB_API_KEY 未設定で例外を投げる", async () => {
+  await withEnv({ OMDB_API_KEY: undefined }, async () => {
+    await assertRejects(() => fetchOmdbDetails("tt0000001"), Error, "OMDB_API_KEY");
+  });
+});
+
+Deno.test("fetchOmdbDetails は非 2xx レスポンスで例外を投げる", async () => {
+  await withEnv({ OMDB_API_KEY: "test-key" }, async () => {
+    await withMockFetch(
+      () => new Response("oops", { status: 503 }),
+      async () => {
+        await assertRejects(() => fetchOmdbDetails("tt0000001"), Error, "status 503");
+      },
+    );
+  });
 });

--- a/supabase/functions/_shared/supabase-admin.ts
+++ b/supabase/functions/_shared/supabase-admin.ts
@@ -32,3 +32,8 @@ export function getSupabaseAdminClient(): SupabaseAdminClient | null {
 
   return cachedClient;
 }
+
+// テスト用: モジュールスコープのクライアントキャッシュをリセットする
+export function _resetSupabaseAdminClientCacheForTesting() {
+  cachedClient = null;
+}

--- a/supabase/functions/_shared/supabase-admin_test.ts
+++ b/supabase/functions/_shared/supabase-admin_test.ts
@@ -1,0 +1,66 @@
+import { assert, assertEquals, assertStrictEquals } from "jsr:@std/assert";
+import {
+  _resetSupabaseAdminClientCacheForTesting,
+  getSupabaseAdminClient,
+} from "./supabase-admin.ts";
+
+async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, Deno.env.get(key));
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
+    }
+  }
+}
+
+Deno.test("getSupabaseAdminClient は SUPABASE_URL が無ければ null を返す", async () => {
+  _resetSupabaseAdminClientCacheForTesting();
+  await withEnv({ SUPABASE_URL: undefined, SUPABASE_SERVICE_ROLE_KEY: "role-key" }, async () => {
+    assertEquals(getSupabaseAdminClient(), null);
+  });
+  _resetSupabaseAdminClientCacheForTesting();
+});
+
+Deno.test("getSupabaseAdminClient は SERVICE_ROLE_KEY が無ければ null を返す", async () => {
+  _resetSupabaseAdminClientCacheForTesting();
+  await withEnv(
+    { SUPABASE_URL: "http://localhost:54321", SUPABASE_SERVICE_ROLE_KEY: undefined },
+    async () => {
+      assertEquals(getSupabaseAdminClient(), null);
+    },
+  );
+  _resetSupabaseAdminClientCacheForTesting();
+});
+
+Deno.test("getSupabaseAdminClient は環境変数が揃えばクライアントを生成してキャッシュする", async () => {
+  _resetSupabaseAdminClientCacheForTesting();
+  await withEnv(
+    {
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_SERVICE_ROLE_KEY: "role-key",
+    },
+    async () => {
+      const first = getSupabaseAdminClient();
+      assert(first !== null);
+      const second = getSupabaseAdminClient();
+      assertStrictEquals(second, first);
+    },
+  );
+  _resetSupabaseAdminClientCacheForTesting();
+});

--- a/supabase/functions/_shared/supabase-admin_test.ts
+++ b/supabase/functions/_shared/supabase-admin_test.ts
@@ -3,31 +3,7 @@ import {
   _resetSupabaseAdminClientCacheForTesting,
   getSupabaseAdminClient,
 } from "./supabase-admin.ts";
-
-async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
-  const previous = new Map<string, string | undefined>();
-
-  for (const [key, value] of Object.entries(values)) {
-    previous.set(key, Deno.env.get(key));
-    if (value === undefined) {
-      Deno.env.delete(key);
-    } else {
-      Deno.env.set(key, value);
-    }
-  }
-
-  try {
-    await run();
-  } finally {
-    for (const [key, value] of previous.entries()) {
-      if (value === undefined) {
-        Deno.env.delete(key);
-      } else {
-        Deno.env.set(key, value);
-      }
-    }
-  }
-}
+import { withEnv } from "./test-helpers.ts";
 
 Deno.test("getSupabaseAdminClient は SUPABASE_URL が無ければ null を返す", async () => {
   _resetSupabaseAdminClientCacheForTesting();

--- a/supabase/functions/_shared/test-helpers.ts
+++ b/supabase/functions/_shared/test-helpers.ts
@@ -1,0 +1,64 @@
+export async function withEnv(
+  values: Record<string, string | undefined>,
+  run: () => Promise<void>,
+) {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, Deno.env.get(key));
+    if (value === undefined) {
+      Deno.env.delete(key);
+    } else {
+      Deno.env.set(key, value);
+    }
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        Deno.env.delete(key);
+      } else {
+        Deno.env.set(key, value);
+      }
+    }
+  }
+}
+
+function resolveFetchUrl(input: string | URL | Request): URL {
+  if (input instanceof Request) {
+    return new URL(input.url);
+  }
+
+  if (input instanceof URL) {
+    return input;
+  }
+
+  return new URL(input);
+}
+
+export async function withMockFetch(
+  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
+  run: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = resolveFetchUrl(input);
+    return await handler(url, init);
+  }) as typeof fetch;
+
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+export function jsonResponse(payload: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(payload), {
+    status: init.status ?? 200,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+}

--- a/supabase/functions/_shared/tmdb_test.ts
+++ b/supabase/functions/_shared/tmdb_test.ts
@@ -9,71 +9,7 @@ import {
   type TmdbSearchResult,
   type TmdbSeasonSelectionTarget,
 } from "./tmdb.ts";
-
-function jsonResponse(payload: unknown, init: ResponseInit = {}) {
-  return new Response(JSON.stringify(payload), {
-    status: init.status ?? 200,
-    headers: {
-      "Content-Type": "application/json",
-      ...init.headers,
-    },
-  });
-}
-
-async function withEnv(values: Record<string, string | undefined>, run: () => Promise<void>) {
-  const previous = new Map<string, string | undefined>();
-
-  for (const [key, value] of Object.entries(values)) {
-    previous.set(key, Deno.env.get(key));
-    if (value === undefined) {
-      Deno.env.delete(key);
-    } else {
-      Deno.env.set(key, value);
-    }
-  }
-
-  try {
-    await run();
-  } finally {
-    for (const [key, value] of previous.entries()) {
-      if (value === undefined) {
-        Deno.env.delete(key);
-      } else {
-        Deno.env.set(key, value);
-      }
-    }
-  }
-}
-
-async function withMockFetch(
-  handler: (url: URL, init?: RequestInit) => Response | Promise<Response>,
-  run: () => Promise<void>,
-) {
-  const originalFetch = globalThis.fetch;
-
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url = resolveFetchUrl(input);
-    return await handler(url, init);
-  }) as typeof fetch;
-
-  try {
-    await run();
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-}
-
-function resolveFetchUrl(input: string | URL | Request): URL {
-  if (input instanceof Request) {
-    return new URL(input.url);
-  }
-
-  if (input instanceof URL) {
-    return input;
-  }
-
-  return new URL(input);
-}
+import { jsonResponse, withEnv, withMockFetch } from "./test-helpers.ts";
 
 function isTmdbRequest(url: URL, pathname: string): boolean {
   return url.hostname === "api.themoviedb.org" && url.pathname === pathname;


### PR DESCRIPTION
## 関連 Issue

Refs #269

## 変更内容

- `supabase/functions/_shared/omdb_test.ts` に `fetchOmdbDetails` の成功 / API key 未設定 / 非 2xx 分岐と、`extractRatings` のフォーマット別パース・範囲外値・`imdbRating` 欠落時の `imdbVotes` 無視などのエッジケースを追加
- `supabase/functions/_shared/gemini_test.ts` を新規追加し、`translateSearchQuery` / `suggestDisplayTitle` の日本語判定・JSON 抽出・同一値サニタイズ・Gemini 失敗時 null・API key 未設定時 null を網羅
- `supabase/functions/_shared/supabase-admin_test.ts` を新規追加し、環境変数の欠落分岐とキャッシュ再利用を検証
- `supabase/functions/_shared/supabase-admin.ts` にテスト専用のキャッシュリセット export (`_resetSupabaseAdminClientCacheForTesting`) を追加。モジュールスコープの cached client が他テストに漏れないようにするため

## 検証

- `vp run test:functions` → 55 passed / 0 failed