### PR TITLE
test: Issue #290 の低カバレッジ箇所のテスト追加

### DIFF
--- a/src/features/backlog/components/KanbanColumn.test.tsx
+++ b/src/features/backlog/components/KanbanColumn.test.tsx
@@ -1,13 +1,18 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
 import { createWorkSummary } from "../../../test/backlog-fixtures.ts";
 import type { BacklogItem } from "../types.ts";
 import { KanbanColumn } from "./KanbanColumn.tsx";
 
+const dndState = vi.hoisted(() => ({
+  isOver: false,
+}));
+
 vi.mock("@dnd-kit/core", () => ({
   useDroppable: () => ({
     setNodeRef: vi.fn(),
-    isOver: false,
+    isOver: dndState.isOver,
   }),
 }));
 
@@ -17,7 +22,24 @@ vi.mock("@dnd-kit/sortable", () => ({
 }));
 
 vi.mock("./BacklogCard.tsx", () => ({
-  BacklogCard: ({ item }: { item: BacklogItem }) => <div>{item.works?.title}</div>,
+  BacklogCard: ({
+    item,
+    showModeBadge,
+    onOpenDetail,
+  }: {
+    item: BacklogItem;
+    showModeBadge: boolean;
+    onOpenDetail: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid={`card-${item.id}`}
+      data-show-mode-badge={String(showModeBadge)}
+      onClick={onOpenDetail}
+    >
+      {item.works?.title}
+    </button>
+  ),
 }));
 
 setupTestLifecycle();
@@ -35,6 +57,10 @@ function createItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
 }
 
 describe("KanbanColumn", () => {
+  beforeEach(() => {
+    dndState.isOver = false;
+  });
+
   test("ストック列では絞り込みカードを表示する", () => {
     render(
       <KanbanColumn
@@ -51,6 +77,7 @@ describe("KanbanColumn", () => {
     );
 
     expect(screen.getByRole("group", { name: "おすすめの絞り込み" })).toBeInTheDocument();
+    expect(screen.getByTestId("card-item-1")).toHaveAttribute("data-show-mode-badge", "true");
   });
 
   test("ストック列以外では絞り込みカードを表示しない", () => {
@@ -88,5 +115,90 @@ describe("KanbanColumn", () => {
     );
 
     expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  test("空の列にドラッグオーバーすると dropzone の強調と空状態メッセージを出す", () => {
+    dndState.isOver = true;
+
+    render(
+      <KanbanColumn
+        status="want_to_watch"
+        items={[]}
+        activeViewingMode={null}
+        isMobileLayout={false}
+        onOpenAddModal={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onDeleteItem={vi.fn()}
+        onMarkAsWatched={vi.fn()}
+      />,
+    );
+
+    const dropzone = document.querySelector('[data-dropzone-status="want_to_watch"]');
+    expect(dropzone).toHaveStyle({
+      minHeight: "120px",
+      outline: "2px dashed rgba(191, 90, 54, 0.45)",
+    });
+  });
+
+  test("視聴済みが 20 件を超えると過去分を折りたたみ、展開で表示する", async () => {
+    const user = userEvent.setup();
+    const watchedItems = Array.from({ length: 21 }, (_, index) =>
+      createItem({
+        id: `item-${index + 1}`,
+        status: "watched",
+        works: createWorkSummary({ title: `作品${index + 1}` }),
+      }),
+    );
+
+    render(
+      <KanbanColumn
+        status="watched"
+        items={watchedItems}
+        activeViewingMode={null}
+        isMobileLayout={false}
+        onOpenAddModal={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onDeleteItem={vi.fn()}
+        onMarkAsWatched={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("作品20")).toBeInTheDocument();
+    expect(screen.queryByText("作品21")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "過去の視聴済み（1件）" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "過去の視聴済み（1件）" }));
+
+    expect(screen.getByText("作品21")).toBeInTheDocument();
+    expect(screen.getByTestId("card-item-21")).toHaveAttribute("data-show-mode-badge", "false");
+  });
+
+  test("カード押下で詳細を開く", async () => {
+    const user = userEvent.setup();
+    const onOpenDetail = vi.fn();
+
+    render(
+      <KanbanColumn
+        status="watched"
+        items={[
+          createItem({ id: "item-1", status: "watched" }),
+          createItem({
+            id: "item-2",
+            status: "watched",
+            works: createWorkSummary({ title: "作品2" }),
+          }),
+        ]}
+        activeViewingMode={null}
+        isMobileLayout={false}
+        onOpenAddModal={vi.fn()}
+        onOpenDetail={onOpenDetail}
+        onDeleteItem={vi.fn()}
+        onMarkAsWatched={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTestId("card-item-1"));
+
+    expect(onOpenDetail).toHaveBeenCalledWith("item-1");
   });
 });

--- a/src/features/backlog/components/MobileKanbanBoard.test.tsx
+++ b/src/features/backlog/components/MobileKanbanBoard.test.tsx
@@ -1,0 +1,173 @@
+import type React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { setupTestLifecycle } from "../../../test/test-lifecycle.ts";
+import type { BacklogStatus } from "../types.ts";
+import type { KanbanColumnProps } from "./kanban-board-shared.ts";
+import { MobileKanbanBoard } from "./MobileKanbanBoard.tsx";
+
+vi.mock("./KanbanColumn.tsx", () => ({
+  KanbanColumn: ({ status, extra }: { status: string; extra?: React.ReactNode }) => (
+    <div>
+      <div>{`column:${status}`}</div>
+      {extra}
+    </div>
+  ),
+}));
+
+setupTestLifecycle();
+
+function createColumnProps(status: BacklogStatus): KanbanColumnProps {
+  return {
+    status,
+    items: [],
+    activeViewingMode: null,
+    isMobileLayout: true,
+    onOpenAddModal: vi.fn(),
+    onOpenDetail: vi.fn(),
+    onDeleteItem: vi.fn(),
+    onMarkAsWatched: vi.fn(),
+  };
+}
+
+function renderBoard(overrides: Partial<React.ComponentProps<typeof MobileKanbanBoard>> = {}) {
+  const onTabChange = vi.fn();
+  const getColumnProps = vi.fn((status: BacklogStatus) => createColumnProps(status));
+  const columnRef = vi.fn();
+
+  const result = render(
+    <MobileKanbanBoard
+      selectedTabStatus="stacked"
+      isMobileDragging={false}
+      onTabChange={onTabChange}
+      getColumnProps={getColumnProps}
+      columnRef={columnRef}
+      {...overrides}
+    />,
+  );
+
+  return { onTabChange, getColumnProps, columnRef, ...result };
+}
+
+describe("MobileKanbanBoard", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test("選択中タブを scrollIntoView し、対応する column を描画する", () => {
+    const { getColumnProps, columnRef } = renderBoard();
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+    expect(screen.getByText("column:stacked")).toBeInTheDocument();
+    expect(getColumnProps).toHaveBeenCalledWith("stacked");
+    expect(columnRef).toHaveBeenCalledWith("stacked", expect.any(HTMLElement));
+  });
+
+  test("タブ押下で対象 status に切り替える", async () => {
+    const user = userEvent.setup();
+    const { onTabChange } = renderBoard();
+
+    await user.click(screen.getByRole("tab", { name: "視聴中" }));
+
+    expect(onTabChange).toHaveBeenCalledWith("watching");
+  });
+
+  test("左スワイプで次のタブへ移動する", () => {
+    const { onTabChange } = renderBoard();
+    const content = document.querySelector(".board-tab-content");
+    if (!content) throw new Error("tab content not found");
+
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 120, clientY: 20 }],
+    });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 20, clientY: 24 }],
+    });
+
+    expect(onTabChange).toHaveBeenCalledWith("want_to_watch");
+  });
+
+  test("右スワイプで前のタブへ移動する", () => {
+    const { onTabChange } = renderBoard({ selectedTabStatus: "watching" });
+    const content = document.querySelector(".board-tab-content");
+    if (!content) throw new Error("tab content not found");
+
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 20, clientY: 24 }],
+    });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 120, clientY: 20 }],
+    });
+
+    expect(onTabChange).toHaveBeenCalledWith("want_to_watch");
+  });
+
+  test("短すぎるスワイプではタブを切り替えない", () => {
+    const { onTabChange } = renderBoard();
+    const content = document.querySelector(".board-tab-content");
+    if (!content) throw new Error("tab content not found");
+
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 120, clientY: 20 }],
+    });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 80, clientY: 24 }],
+    });
+
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  test("縦方向の移動が大きい場合はタブを切り替えない", () => {
+    const { onTabChange } = renderBoard();
+    const content = document.querySelector(".board-tab-content");
+    if (!content) throw new Error("tab content not found");
+
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 120, clientY: 20 }],
+    });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 20, clientY: 160 }],
+    });
+
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  test("ドラッグ中はスワイプしてもタブを切り替えない", () => {
+    const { onTabChange } = renderBoard({ isMobileDragging: true });
+    const content = document.querySelector(".board-tab-content");
+    if (!content) throw new Error("tab content not found");
+
+    fireEvent.touchStart(content, {
+      touches: [{ clientX: 120, clientY: 20 }],
+    });
+    fireEvent.touchEnd(content, {
+      changedTouches: [{ clientX: 20, clientY: 24 }],
+    });
+
+    expect(onTabChange).not.toHaveBeenCalled();
+  });
+
+  test("スクロール中は class を付け、1秒後に外す", () => {
+    vi.useFakeTimers();
+    renderBoard();
+    const content = document.querySelector(".board-tab-content");
+    if (!content) throw new Error("tab content not found");
+
+    fireEvent.scroll(content);
+    expect(content).toHaveClass("is-scrolling");
+
+    vi.advanceTimersByTime(1000);
+
+    expect(content).not.toHaveClass("is-scrolling");
+  });
+});

--- a/src/features/backlog/hooks/useBacklogActions.test.tsx
+++ b/src/features/backlog/hooks/useBacklogActions.test.tsx
@@ -86,7 +86,7 @@ function HookHarness({
   results?: TmdbSearchResult[];
   feedback?: ReturnType<typeof createToastFeedback>;
 }>) {
-  const { handleDeleteItem, handleAddTmdbWorksToStacked } = useBacklogActions({
+  const { handleDeleteItem, handleMarkAsWatched, handleAddTmdbWorksToStacked } = useBacklogActions({
     items,
     localItems: localItems ?? items,
     setLocalItems,
@@ -102,6 +102,9 @@ function HookHarness({
     <>
       <button type="button" onClick={() => void handleDeleteItem("item-1")}>
         削除
+      </button>
+      <button type="button" onClick={() => void handleMarkAsWatched("item-1")}>
+        視聴済みにする
       </button>
       <button type="button" onClick={() => void handleAddTmdbWorksToStacked(results)}>
         追加
@@ -166,6 +169,77 @@ describe("useBacklogActions", () => {
     expect(loadItems).not.toHaveBeenCalled();
   });
 
+  test("undo 時の updater は pendingDeleteIds を外し、元の位置に復元する", async () => {
+    const feedback = createToastFeedback(true);
+    let pendingDeleteIds = new Set<string>();
+    let localItems = [
+      createItem(),
+      createItem({ id: "item-2", works: createWorkSummary({ title: "作品2" }) }),
+    ];
+    const setPendingDeleteIds = vi.fn((updater: React.SetStateAction<ReadonlySet<string>>) => {
+      pendingDeleteIds =
+        typeof updater === "function"
+          ? new Set(
+              (updater as (prev: ReadonlySet<string>) => ReadonlySet<string>)(pendingDeleteIds),
+            )
+          : new Set(updater);
+    });
+    const setLocalItems = vi.fn((updater: React.SetStateAction<BacklogItem[]>) => {
+      localItems = typeof updater === "function" ? updater(localItems) : updater;
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        feedback={feedback}
+        localItems={localItems}
+        setLocalItems={setLocalItems}
+        setPendingDeleteIds={setPendingDeleteIds}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(setLocalItems).toHaveBeenCalledTimes(2));
+    expect(pendingDeleteIds.has("item-1")).toBe(false);
+    expect(localItems.map((item) => item.id)).toEqual(["item-1", "item-2"]);
+  });
+
+  test("undo 復元時にすでに item があれば重複して挿入しない", async () => {
+    const feedback = createToastFeedback(true);
+    const item = createItem();
+    let localItems = [item];
+    let updateCount = 0;
+    const setLocalItems = vi.fn((updater: React.SetStateAction<BacklogItem[]>) => {
+      if (typeof updater !== "function") {
+        localItems = updater;
+        return;
+      }
+
+      updateCount += 1;
+      if (updateCount === 1) {
+        localItems = updater(localItems);
+        return;
+      }
+
+      const nextItems = updater([item]);
+      expect(nextItems).toEqual([item]);
+      localItems = nextItems;
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness feedback={feedback} localItems={localItems} setLocalItems={setLocalItems} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(setLocalItems).toHaveBeenCalledTimes(2));
+    expect(localItems).toEqual([item]);
+  });
+
   test("delete 失敗時は alert を出して reload する", async () => {
     const feedback = createToastFeedback(false);
     const loadItems = vi.fn().mockResolvedValue(undefined);
@@ -187,10 +261,120 @@ describe("useBacklogActions", () => {
     expect(loadItems).toHaveBeenCalled();
   });
 
+  test("delete 完了後の updater は pendingDeleteIds から対象を外す", async () => {
+    const feedback = createToastFeedback(false);
+    let pendingDeleteIds = new Set<string>();
+    const setPendingDeleteIds = vi.fn((updater: React.SetStateAction<ReadonlySet<string>>) => {
+      pendingDeleteIds =
+        typeof updater === "function"
+          ? new Set(
+              (updater as (prev: ReadonlySet<string>) => ReadonlySet<string>)(pendingDeleteIds),
+            )
+          : new Set(updater);
+    });
+
+    const user = userEvent.setup();
+
+    render(<HookHarness feedback={feedback} setPendingDeleteIds={setPendingDeleteIds} />);
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    await waitFor(() => expect(repositoryMocks.deleteBacklogItem).toHaveBeenCalledWith("item-1"));
+    expect(pendingDeleteIds.has("item-1")).toBe(false);
+  });
+
+  test("localItems に対象がなければ delete を何もしない", async () => {
+    const feedback = createToastFeedback(false);
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    const setLocalItems = vi.fn();
+    const setPendingDeleteIds = vi.fn();
+    const onItemDeleted = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[createItem()]}
+        localItems={[createItem({ id: "item-2" })]}
+        feedback={feedback}
+        loadItems={loadItems}
+        setLocalItems={setLocalItems}
+        setPendingDeleteIds={setPendingDeleteIds}
+        onItemDeleted={onItemDeleted}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "削除" }));
+
+    expect(feedback.toast).not.toHaveBeenCalled();
+    expect(setLocalItems).not.toHaveBeenCalled();
+    expect(setPendingDeleteIds).not.toHaveBeenCalled();
+    expect(onItemDeleted).not.toHaveBeenCalled();
+    expect(loadItems).not.toHaveBeenCalled();
+  });
+
+  test("mark as watched 成功時は watched の先頭 sort_order で更新して reload する", async () => {
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[
+          createItem({ id: "item-1", status: "stacked", sort_order: 5000 }),
+          createItem({ id: "item-2", status: "watched", sort_order: 3000 }),
+          createItem({ id: "item-3", status: "watched", sort_order: 1000 }),
+        ]}
+        loadItems={loadItems}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "視聴済みにする" }));
+
+    await waitFor(() =>
+      expect(repositoryMocks.updateBacklogItem).toHaveBeenCalledWith("item-1", {
+        status: "watched",
+        sort_order: 0,
+      }),
+    );
+    expect(loadItems).toHaveBeenCalled();
+  });
+
+  test("mark as watched 失敗時は alert を表示して reload しない", async () => {
+    const feedback = createToastFeedback();
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    repositoryMocks.updateBacklogItem.mockResolvedValueOnce({
+      error: "update failed",
+    });
+
+    const user = userEvent.setup();
+
+    render(<HookHarness feedback={feedback} loadItems={loadItems} />);
+
+    await user.click(screen.getByRole("button", { name: "視聴済みにする" }));
+
+    await waitFor(() =>
+      expect(feedback.alert).toHaveBeenCalledWith("変更に失敗しました: update failed"),
+    );
+    expect(loadItems).not.toHaveBeenCalled();
+  });
+
+  test("追加対象が空なら何もしない", async () => {
+    const feedback = createToastFeedback();
+    const user = userEvent.setup();
+
+    render(<HookHarness results={[]} feedback={feedback} />);
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(repositoryMocks.upsertTmdbWork).not.toHaveBeenCalled();
+    expect(repositoryMocks.upsertBacklogItemsToStatus).not.toHaveBeenCalled();
+    expect(feedback.alert).not.toHaveBeenCalled();
+  });
+
   test("複数追加で一部失敗したら成功分は反映しつつ失敗作品を通知する", async () => {
     const feedback = createToastFeedback();
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onWorksAdded = vi.fn();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     repositoryMocks.upsertTmdbWork
       .mockResolvedValueOnce({ data: { id: "work-1" }, error: null })
       .mockResolvedValueOnce({ data: null, error: { message: "tmdb failed" } });
@@ -221,12 +405,14 @@ describe("useBacklogActions", () => {
     expect(loadItems).toHaveBeenCalled();
     expect(onWorksAdded).toHaveBeenCalled();
     expect(feedback.alert).toHaveBeenCalledWith("一部の作品を追加できませんでした: 作品2");
+    consoleErrorSpy.mockRestore();
   });
 
   test("複数追加がすべて失敗したら詳細を通知して追加処理を中断する", async () => {
     const feedback = createToastFeedback();
     const loadItems = vi.fn().mockResolvedValue(undefined);
     const onWorksAdded = vi.fn();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     repositoryMocks.upsertTmdbWork
       .mockResolvedValueOnce({ data: null, error: { message: "tmdb failed" } })
       .mockResolvedValueOnce({ data: null, error: { message: "tmdb failed" } });
@@ -250,11 +436,13 @@ describe("useBacklogActions", () => {
     expect(repositoryMocks.upsertBacklogItemsToStatus).not.toHaveBeenCalled();
     expect(loadItems).not.toHaveBeenCalled();
     expect(onWorksAdded).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
   });
 
   test("確認ダイアログの件数は追加成功した作品数を使う", async () => {
     const feedback = createToastFeedback();
     const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     repositoryMocks.upsertTmdbWork
       .mockResolvedValueOnce({ data: { id: "work-1" }, error: null })
       .mockResolvedValueOnce({ data: null, error: { message: "tmdb failed" } });
@@ -275,5 +463,112 @@ describe("useBacklogActions", () => {
 
     await waitFor(() => expect(feedback.confirm).toHaveBeenCalledTimes(1));
     expect(feedback.confirm).toHaveBeenCalledWith(expect.stringContaining("1件の作品"));
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("確認ダイアログでキャンセルしたら追加を中断する", async () => {
+    const feedback = createToastFeedback();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    feedback.confirm.mockResolvedValue(false);
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[
+          createItem({
+            id: "item-9",
+            status: "watching",
+            works: createWorkSummary({ id: "work-1", title: "作品1" }),
+          }),
+        ]}
+        results={[createSearchResult()]}
+        feedback={feedback}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() => expect(feedback.confirm).toHaveBeenCalledTimes(1));
+    expect(repositoryMocks.upsertBacklogItemsToStatus).not.toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("選択作品がすでに stacked のみなら専用メッセージを表示する", async () => {
+    const feedback = createToastFeedback();
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[
+          createItem({
+            id: "item-9",
+            status: "stacked",
+            works: createWorkSummary({ id: "work-1", title: "作品1" }),
+          }),
+        ]}
+        results={[createSearchResult()]}
+        feedback={feedback}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() =>
+      expect(feedback.alert).toHaveBeenCalledWith("選択した作品はすでにストックにあります"),
+    );
+    expect(repositoryMocks.upsertBacklogItemsToStatus).not.toHaveBeenCalled();
+  });
+
+  test("追加自体は成功したが失敗作品がない場合は alert を出さない", async () => {
+    const feedback = createToastFeedback();
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    const onWorksAdded = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[]}
+        results={[createSearchResult()]}
+        feedback={feedback}
+        loadItems={loadItems}
+        onWorksAdded={onWorksAdded}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() => expect(repositoryMocks.upsertBacklogItemsToStatus).toHaveBeenCalled());
+    expect(loadItems).toHaveBeenCalled();
+    expect(onWorksAdded).toHaveBeenCalled();
+    expect(feedback.alert).not.toHaveBeenCalled();
+  });
+
+  test("backlog item 追加に失敗したら alert を表示して reload しない", async () => {
+    const feedback = createToastFeedback();
+    const loadItems = vi.fn().mockResolvedValue(undefined);
+    const onWorksAdded = vi.fn();
+    repositoryMocks.upsertBacklogItemsToStatus.mockResolvedValueOnce({
+      error: "insert failed",
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <HookHarness
+        items={[]}
+        results={[createSearchResult()]}
+        feedback={feedback}
+        loadItems={loadItems}
+        onWorksAdded={onWorksAdded}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() =>
+      expect(feedback.alert).toHaveBeenCalledWith("追加に失敗しました: insert failed"),
+    );
+    expect(loadItems).not.toHaveBeenCalled();
+    expect(onWorksAdded).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,55 @@
+function setEnv(name: "VITE_SUPABASE_URL" | "VITE_SUPABASE_PUBLISHABLE_KEY", value?: string) {
+  const env = import.meta.env as Record<string, string | undefined>;
+  if (value === undefined) {
+    delete env[name];
+    return;
+  }
+
+  env[name] = value;
+}
+
+async function importEnvModule() {
+  vi.resetModules();
+  return import("./env.ts");
+}
+
+describe("env", () => {
+  const originalSupabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const originalSupabasePublishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+
+  afterEach(() => {
+    setEnv("VITE_SUPABASE_URL", originalSupabaseUrl);
+    setEnv("VITE_SUPABASE_PUBLISHABLE_KEY", originalSupabasePublishableKey);
+    vi.resetModules();
+  });
+
+  test("設定済みの環境変数をそのまま公開する", async () => {
+    setEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+    setEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "publishable-key");
+
+    const { env } = await importEnvModule();
+
+    expect(env).toEqual({
+      supabaseUrl: "https://example.supabase.co",
+      supabasePublishableKey: "publishable-key",
+    });
+  });
+
+  test("VITE_SUPABASE_URL が欠けていると import 時に失敗する", async () => {
+    setEnv("VITE_SUPABASE_URL");
+    setEnv("VITE_SUPABASE_PUBLISHABLE_KEY", "publishable-key");
+
+    await expect(importEnvModule()).rejects.toThrow(
+      "Missing environment variable: VITE_SUPABASE_URL",
+    );
+  });
+
+  test("VITE_SUPABASE_PUBLISHABLE_KEY が欠けていると import 時に失敗する", async () => {
+    setEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+    setEnv("VITE_SUPABASE_PUBLISHABLE_KEY");
+
+    await expect(importEnvModule()).rejects.toThrow(
+      "Missing environment variable: VITE_SUPABASE_PUBLISHABLE_KEY",
+    );
+  });
+});


### PR DESCRIPTION
## 関連 Issue

Refs #290

## 変更内容

- `src/features/backlog/hooks/useBacklogActions.ts` の delete / undo / mark as watched / 追加失敗系の未テスト分岐を補強
- `src/features/backlog/components/KanbanColumn.tsx` の空状態 dropzone、視聴済み折りたたみ、詳細オープンを検証
- `src/features/backlog/components/MobileKanbanBoard.tsx` のタブ切り替え、スワイプ、スクロール状態、`columnRef` を新規テスト化
- `src/lib/env.ts` の正常系と必須環境変数欠落時の失敗を新規テスト化
- `src/features/backlog/hooks/useAddFlow.ts` は今回の PR では対象外

## カバレッジ変化

- `useBacklogActions.ts`: lines 67.6% / branches 60.0% / functions 42.9% -> lines 100% / branches 94.28% / functions 100%
- `KanbanColumn.tsx`: lines 73.3% / branches 54.2% / functions 42.9% -> lines 93.33% / branches 100% / functions 85.71%
- `MobileKanbanBoard.tsx`: lines 75.6% / branches 41.7% / functions 83.3% -> lines 100% / branches 83.33% / functions 100%
- `env.ts`: lines 75.0% / branches 50.0% / functions 100% -> lines 100% / branches 100% / functions 100%

## 検証

- `vp test src/lib/env.test.ts src/features/backlog/hooks/useBacklogActions.test.tsx src/features/backlog/components/KanbanColumn.test.tsx src/features/backlog/components/MobileKanbanBoard.test.tsx`
- `vp exec vitest --coverage`
