### PR TITLE
refactor: 重複率が高いファイルの共通化

### DIFF
--- a/src/features/backlog/components/LoginPage.test.tsx
+++ b/src/features/backlog/components/LoginPage.test.tsx
@@ -14,6 +14,25 @@ vi.mock("../../../lib/auth-repository.ts", () => authRepositoryMock);
 
 setupTestLifecycle();
 
+async function submitLogin(
+  user: ReturnType<typeof userEvent.setup>,
+  email = "akari@example.com",
+  password = "password123",
+) {
+  await user.type(screen.getByLabelText("メールアドレス"), email);
+  await user.type(screen.getByLabelText("パスワード"), password);
+  await user.click(screen.getByText("ログイン", { selector: "button[type='submit']" }));
+}
+
+async function submitPasswordReset(
+  user: ReturnType<typeof userEvent.setup>,
+  email = "akari@example.com",
+) {
+  await user.click(screen.getByRole("button", { name: "パスワードを忘れた場合" }));
+  await user.type(screen.getByLabelText("メールアドレス"), email);
+  await user.click(screen.getByRole("button", { name: "リセットメールを送信" }));
+}
+
 describe("LoginPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -103,10 +122,7 @@ describe("LoginPage", () => {
 
     render(<LoginPage />);
 
-    await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
-    await user.type(screen.getByLabelText("パスワード"), "password123");
-
-    await user.click(screen.getByText("ログイン", { selector: "button[type='submit']" }));
+    await submitLogin(user);
 
     expect(screen.getByRole("button", { name: "ログインしています..." })).toBeDisabled();
     expect(screen.getByLabelText("メールアドレス")).toBeDisabled();
@@ -129,10 +145,7 @@ describe("LoginPage", () => {
 
     render(<LoginPage />);
 
-    await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
-    await user.type(screen.getByLabelText("パスワード"), "password123");
-
-    await user.click(screen.getByText("ログイン", { selector: "button[type='submit']" }));
+    await submitLogin(user);
 
     expect(
       await screen.findByText("メールアドレスまたはパスワードが正しくありません。"),
@@ -150,9 +163,7 @@ describe("LoginPage", () => {
 
     render(<LoginPage />);
 
-    await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
-    await user.type(screen.getByLabelText("パスワード"), "password123");
-    await user.click(screen.getByText("ログイン", { selector: "button[type='submit']" }));
+    await submitLogin(user);
 
     expect(
       await screen.findByText(
@@ -235,9 +246,7 @@ describe("LoginPage", () => {
 
     render(<LoginPage showDevLoginHint={false} />);
 
-    await user.click(screen.getByRole("button", { name: "パスワードを忘れた場合" }));
-    await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
-    await user.click(screen.getByRole("button", { name: "リセットメールを送信" }));
+    await submitPasswordReset(user);
 
     expect(authRepositoryMock.resetPasswordForEmail).toHaveBeenCalledWith("akari@example.com", {
       redirectTo: globalThis.location.origin,
@@ -256,9 +265,7 @@ describe("LoginPage", () => {
 
     render(<LoginPage showDevLoginHint={false} />);
 
-    await user.click(screen.getByRole("button", { name: "パスワードを忘れた場合" }));
-    await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
-    await user.click(screen.getByRole("button", { name: "リセットメールを送信" }));
+    await submitPasswordReset(user);
     await screen.findByText("リセットメールを送信しました");
 
     await user.click(screen.getByRole("button", { name: "ログインへ戻る" }));
@@ -294,9 +301,7 @@ describe("LoginPage", () => {
 
     render(<LoginPage showDevLoginHint={false} />);
 
-    await user.click(screen.getByRole("button", { name: "パスワードを忘れた場合" }));
-    await user.type(screen.getByLabelText("メールアドレス"), "akari@example.com");
-    await user.click(screen.getByRole("button", { name: "リセットメールを送信" }));
+    await submitPasswordReset(user);
 
     expect(
       await screen.findByText(

--- a/supabase/functions/_shared/tmdb/test-fixtures.ts
+++ b/supabase/functions/_shared/tmdb/test-fixtures.ts
@@ -1,12 +1,18 @@
 import type { TmdbSearchResult } from "./types.ts";
 
-export function createMovieResult(
+type ResultKind = {
+  tmdbMediaType: TmdbSearchResult["tmdbMediaType"];
+  workType: TmdbSearchResult["workType"];
+};
+
+function createResult(
+  kind: ResultKind,
   overrides: Partial<TmdbSearchResult> & { tmdbId: number; title: string },
 ): TmdbSearchResult {
   return {
     tmdbId: overrides.tmdbId,
-    tmdbMediaType: "movie",
-    workType: "movie",
+    tmdbMediaType: kind.tmdbMediaType,
+    workType: kind.workType,
     title: overrides.title,
     originalTitle: overrides.originalTitle ?? `${overrides.title} Original`,
     overview: overrides.overview ?? "overview",
@@ -18,20 +24,14 @@ export function createMovieResult(
   };
 }
 
+export function createMovieResult(
+  overrides: Partial<TmdbSearchResult> & { tmdbId: number; title: string },
+): TmdbSearchResult {
+  return createResult({ tmdbMediaType: "movie", workType: "movie" }, overrides);
+}
+
 export function createSeriesResult(
   overrides: Partial<TmdbSearchResult> & { tmdbId: number; title: string },
 ): TmdbSearchResult {
-  return {
-    tmdbId: overrides.tmdbId,
-    tmdbMediaType: "tv",
-    workType: "series",
-    title: overrides.title,
-    originalTitle: overrides.originalTitle ?? `${overrides.title} Original`,
-    overview: overrides.overview ?? "overview",
-    posterPath: overrides.posterPath ?? null,
-    releaseDate: overrides.releaseDate ?? "2024-01-01",
-    jpWatchPlatforms: overrides.jpWatchPlatforms ?? [],
-    hasJapaneseRelease: overrides.hasJapaneseRelease ?? true,
-    rottenTomatoesScore: overrides.rottenTomatoesScore ?? null,
-  };
+  return createResult({ tmdbMediaType: "tv", workType: "series" }, overrides);
 }


### PR DESCRIPTION
## 関連 Issue

Refs #295

## 変更内容

- `supabase/functions/_shared/tmdb/test-fixtures.ts`（重複率 84.2%）: `createMovieResult` / `createSeriesResult` の object 生成ロジックを内部ヘルパー `createResult` に共通化。公開 API 不変
- `src/features/backlog/components/LoginPage.test.tsx`（重複率 8.0%）: ログイン送信・パスワードリセット送信の反復パターンを `submitLogin` / `submitPasswordReset` ヘルパーに切り出し

## 見送った項目

- `src/features/backlog/hooks/useBoardPageController.test.tsx`（13.0%）/ `src/features/backlog/components/BoardPage.test.tsx`（7.6%）: 重複は各ファイルの `vi.mock` 宣言だが、ホイストの制約と参照パス差異により安全な共通化が難しいためスキップ
- `supabase/seed.sql`（5.0%）: 構造的な INSERT データで、共通化するとかえって可読性が下がるためスキップ

## 検証

- `vp run test:functions`（deno test 55 件 pass）
- `vp test src/features/backlog/components/LoginPage.test.tsx`（23 件 pass）