### PR TITLE
test: TMDB キャッシュ周辺の Deno テスト追加

### DIFF
--- a/supabase/functions/_shared/test-helpers.ts
+++ b/supabase/functions/_shared/test-helpers.ts
@@ -1,3 +1,5 @@
+import { _resetSupabaseAdminClientCacheForTesting } from "./supabase-admin.ts";
+
 export async function withEnv(
   values: Record<string, string | undefined>,
   run: () => Promise<void>,
@@ -24,6 +26,23 @@ export async function withEnv(
       }
     }
   }
+}
+
+export async function withSupabaseAdminEnv(run: () => Promise<void>) {
+  _resetSupabaseAdminClientCacheForTesting();
+  await withEnv(
+    {
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_SERVICE_ROLE_KEY: "role-key",
+    },
+    async () => {
+      try {
+        await run();
+      } finally {
+        _resetSupabaseAdminClientCacheForTesting();
+      }
+    },
+  );
 }
 
 function resolveFetchUrl(input: string | URL | Request): URL {

--- a/supabase/functions/_shared/tmdb/cache_test.ts
+++ b/supabase/functions/_shared/tmdb/cache_test.ts
@@ -1,0 +1,135 @@
+import { assert, assertEquals, assertRejects } from "jsr:@std/assert";
+import {
+  buildExpiresAt,
+  isCacheEntryFresh,
+  normalizeCachedSearchResult,
+  readTmdbMetadataCache,
+  writeTmdbMetadataCache,
+} from "./cache.ts";
+import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
+import { _resetSupabaseAdminClientCacheForTesting } from "../supabase-admin.ts";
+
+function futureIso(offsetMs = 60_000) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+Deno.test("TMDB cache helper は freshness と payload 正規化を判定する", () => {
+  assertEquals(isCacheEntryFresh(null), false);
+  assertEquals(isCacheEntryFresh("not-a-date"), false);
+  assertEquals(isCacheEntryFresh(futureIso()), true);
+
+  const expiresAt = buildExpiresAt(1_500);
+  const expiresAtMs = Date.parse(expiresAt);
+  assert(!Number.isNaN(expiresAtMs));
+  assert(expiresAtMs > Date.now());
+
+  const payload = { tmdbId: 100, tmdbMediaType: "movie" };
+  assertEquals(normalizeCachedSearchResult(payload), payload);
+  assertEquals(normalizeCachedSearchResult(null), null);
+  assertEquals(normalizeCachedSearchResult("invalid"), null);
+});
+
+Deno.test("readTmdbMetadataCache は admin client が無ければ null を返す", async () => {
+  _resetSupabaseAdminClientCacheForTesting();
+  await withEnv({ SUPABASE_URL: undefined, SUPABASE_SERVICE_ROLE_KEY: undefined }, async () => {
+    assertEquals(await readTmdbMetadataCache("cache-key"), null);
+  });
+  _resetSupabaseAdminClientCacheForTesting();
+});
+
+Deno.test("readTmdbMetadataCache は Supabase REST から payload を読み出す", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+        assertEquals(request.method, "GET");
+        assertEquals(url.origin, "http://localhost:54321");
+        assertEquals(url.pathname, "/rest/v1/tmdb_metadata_cache");
+        assertEquals(url.searchParams.get("select"), "payload,expires_at");
+        assertEquals(url.searchParams.get("cache_key"), "eq.cache-key");
+
+        return jsonResponse({
+          payload: { tmdbId: 101, tmdbMediaType: "movie" },
+          expires_at: futureIso(),
+        });
+      },
+      async () => {
+        assertEquals(await readTmdbMetadataCache("cache-key"), {
+          fresh: true,
+          payload: { tmdbId: 101, tmdbMediaType: "movie" },
+        });
+      },
+    );
+  });
+});
+
+Deno.test("readTmdbMetadataCache は空レスポンスで null、エラーで例外を返す", async () => {
+  await withSupabaseAdminEnv(async () => {
+    let calls = 0;
+    await withMockFetch(
+      async (url, init) => {
+        calls += 1;
+        const request = new Request(url, init);
+        assertEquals(request.method, "GET");
+
+        if (calls === 1) {
+          return jsonResponse([]);
+        }
+
+        return jsonResponse({ message: "boom" }, { status: 500 });
+      },
+      async () => {
+        assertEquals(await readTmdbMetadataCache("cache-key"), null);
+        await assertRejects(
+          () => readTmdbMetadataCache("cache-key"),
+          Error,
+          "Failed to read TMDb metadata cache",
+        );
+      },
+    );
+  });
+});
+
+Deno.test("writeTmdbMetadataCache は Supabase REST へ upsert する", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+        assertEquals(request.method, "POST");
+        assertEquals(url.origin, "http://localhost:54321");
+        assertEquals(url.pathname, "/rest/v1/tmdb_metadata_cache");
+
+        const body = JSON.parse(await request.text()) as {
+          cache_key: string;
+          payload: unknown;
+          fetched_at: string;
+          expires_at: string;
+        };
+        assertEquals(body.cache_key, "watch-providers:movie:101:JP");
+        assertEquals(body.payload, { foo: "bar" });
+        assert(!Number.isNaN(Date.parse(body.fetched_at)));
+        assert(Date.parse(body.expires_at) > Date.now());
+
+        return jsonResponse([], { status: 201 });
+      },
+      async () => {
+        await writeTmdbMetadataCache("watch-providers:movie:101:JP", { foo: "bar" });
+      },
+    );
+  });
+});
+
+Deno.test("writeTmdbMetadataCache は Supabase エラーを例外に変換する", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async () => jsonResponse({ message: "write failed" }, { status: 500 }),
+      async () => {
+        await assertRejects(
+          () => writeTmdbMetadataCache("cache-key", { foo: "bar" }),
+          Error,
+          "Failed to write TMDb metadata cache",
+        );
+      },
+    );
+  });
+});

--- a/supabase/functions/_shared/tmdb/cache_test.ts
+++ b/supabase/functions/_shared/tmdb/cache_test.ts
@@ -6,12 +6,9 @@ import {
   readTmdbMetadataCache,
   writeTmdbMetadataCache,
 } from "./cache.ts";
+import { futureIso } from "./test-helpers.ts";
 import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
 import { _resetSupabaseAdminClientCacheForTesting } from "../supabase-admin.ts";
-
-function futureIso(offsetMs = 60_000) {
-  return new Date(Date.now() + offsetMs).toISOString();
-}
 
 Deno.test("TMDB cache helper は freshness と payload 正規化を判定する", () => {
   assertEquals(isCacheEntryFresh(null), false);

--- a/supabase/functions/_shared/tmdb/similar_test.ts
+++ b/supabase/functions/_shared/tmdb/similar_test.ts
@@ -2,17 +2,173 @@ import { assertEquals } from "jsr:@std/assert";
 import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
 import { fetchTmdbSimilar } from "./similar.ts";
 import { createMovieResult } from "./test-fixtures.ts";
+import {
+  futureIso,
+  pastIso,
+  respondWithEmptyMetadataCache,
+  withSupabaseTmdbEnv,
+} from "./test-helpers.ts";
 
-function futureIso(offsetMs = 60_000) {
-  return new Date(Date.now() + offsetMs).toISOString();
+type SimilarRefreshState = {
+  deleteCalls: number;
+  inserts: unknown[];
+};
+
+async function handleSimilarCacheRefreshRequest(
+  url: URL,
+  request: Request,
+  state: SimilarRefreshState,
+): Promise<Response | null> {
+  if (url.pathname !== "/rest/v1/work_recommendation_cache") {
+    return null;
+  }
+
+  if (request.method === "GET") {
+    return jsonResponse([
+      {
+        source_tmdb_media_type: "movie",
+        source_tmdb_id: 41,
+        payload: createMovieResult({ tmdbId: 50, title: "Stale Similar" }),
+        rank: 0,
+        expires_at: pastIso(),
+      },
+    ]);
+  }
+
+  if (request.method === "DELETE") {
+    state.deleteCalls += 1;
+    return jsonResponse([]);
+  }
+
+  if (request.method === "POST") {
+    state.inserts.push(JSON.parse(await request.text()));
+    return jsonResponse([], { status: 201 });
+  }
+
+  return null;
 }
 
-function pastIso(offsetMs = 60_000) {
-  return new Date(Date.now() - offsetMs).toISOString();
+function handleSimilarPageFetch(url: URL): Response | null {
+  if (url.hostname !== "api.themoviedb.org" || url.pathname !== "/3/movie/41/similar") {
+    return null;
+  }
+
+  return jsonResponse({
+    results: [
+      {
+        id: 51,
+        media_type: "movie",
+        title: "Similar A",
+        original_title: "Similar A Original",
+        overview: "A",
+        release_date: "2024-01-01",
+      },
+      {
+        id: 51,
+        media_type: "movie",
+        title: "Similar A",
+        original_title: "Similar A Original",
+        overview: "A",
+        release_date: "2024-01-01",
+      },
+      {
+        id: 52,
+        media_type: "movie",
+        title: "Similar B",
+        original_title: "Similar B Original",
+        overview: "B",
+        release_date: "2024-02-01",
+      },
+    ],
+  });
 }
 
-async function withSupabaseTmdbEnv(run: () => Promise<void>) {
-  await withEnv({ TMDB_API_KEY: "tmdb-test-key" }, () => withSupabaseAdminEnv(run));
+function handleSimilarEnrichmentFetch(url: URL): Response | null {
+  if (url.hostname !== "api.themoviedb.org") {
+    return null;
+  }
+
+  if (url.pathname.endsWith("/watch/providers")) {
+    return jsonResponse({ results: { JP: { flatrate: [] } } });
+  }
+
+  if (url.pathname.endsWith("/release_dates")) {
+    return jsonResponse({ results: [] });
+  }
+
+  if (url.pathname.endsWith("/external_ids")) {
+    return jsonResponse({ imdb_id: null });
+  }
+
+  return null;
+}
+
+async function handleSimilarRefreshFetch(
+  url: URL,
+  init: RequestInit | undefined,
+  state: SimilarRefreshState,
+): Promise<Response> {
+  const request = new Request(url, init);
+  const response =
+    (await handleSimilarCacheRefreshRequest(url, request, state)) ??
+    respondWithEmptyMetadataCache(url, request) ??
+    handleSimilarPageFetch(url) ??
+    handleSimilarEnrichmentFetch(url);
+
+  if (response) {
+    return response;
+  }
+
+  throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+}
+
+function handleStaleSimilarCacheRead(
+  url: URL,
+  request: Request,
+  staleResult: ReturnType<typeof createMovieResult>,
+): Response | null {
+  if (url.pathname !== "/rest/v1/work_recommendation_cache" || request.method !== "GET") {
+    return null;
+  }
+
+  return jsonResponse([
+    {
+      source_tmdb_media_type: "movie",
+      source_tmdb_id: 41,
+      payload: staleResult,
+      rank: 0,
+      expires_at: pastIso(),
+    },
+  ]);
+}
+
+function handleSimilarFailureRequest(url: URL, request: Request): Response | null {
+  if (url.hostname === "api.themoviedb.org" && url.pathname === "/3/movie/41/similar") {
+    return jsonResponse({ results: [] });
+  }
+
+  if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "DELETE") {
+    return jsonResponse({ message: "delete failed" }, { status: 500 });
+  }
+
+  return null;
+}
+
+async function handleSimilarFailureFetch(
+  url: URL,
+  init: RequestInit | undefined,
+  staleResult: ReturnType<typeof createMovieResult>,
+): Promise<Response> {
+  const request = new Request(url, init);
+  const response =
+    handleStaleSimilarCacheRead(url, request, staleResult) ??
+    handleSimilarFailureRequest(url, request);
+
+  if (response) {
+    return response;
+  }
+
+  throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
 }
 
 Deno.test("fetchTmdbSimilar は source と recommendation の重複を除外する", async () => {
@@ -193,88 +349,13 @@ Deno.test("fetchTmdbSimilar は fresh cache があれば source ごとにそれ�
 
 Deno.test("fetchTmdbSimilar は stale cache を refresh して recommendation cache を更新する", async () => {
   await withSupabaseTmdbEnv(async () => {
-    let deleteCalls = 0;
-    const inserts: unknown[] = [];
+    const state: SimilarRefreshState = {
+      deleteCalls: 0,
+      inserts: [],
+    };
 
     await withMockFetch(
-      async (url, init) => {
-        const request = new Request(url, init);
-
-        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "GET") {
-          return jsonResponse([
-            {
-              source_tmdb_media_type: "movie",
-              source_tmdb_id: 41,
-              payload: createMovieResult({ tmdbId: 50, title: "Stale Similar" }),
-              rank: 0,
-              expires_at: pastIso(),
-            },
-          ]);
-        }
-
-        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "DELETE") {
-          deleteCalls += 1;
-          return jsonResponse([]);
-        }
-
-        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "POST") {
-          inserts.push(JSON.parse(await request.text()));
-          return jsonResponse([], { status: 201 });
-        }
-
-        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "GET") {
-          return jsonResponse([]);
-        }
-
-        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "POST") {
-          return jsonResponse([], { status: 201 });
-        }
-
-        if (url.hostname === "api.themoviedb.org" && url.pathname === "/3/movie/41/similar") {
-          return jsonResponse({
-            results: [
-              {
-                id: 51,
-                media_type: "movie",
-                title: "Similar A",
-                original_title: "Similar A Original",
-                overview: "A",
-                release_date: "2024-01-01",
-              },
-              {
-                id: 51,
-                media_type: "movie",
-                title: "Similar A",
-                original_title: "Similar A Original",
-                overview: "A",
-                release_date: "2024-01-01",
-              },
-              {
-                id: 52,
-                media_type: "movie",
-                title: "Similar B",
-                original_title: "Similar B Original",
-                overview: "B",
-                release_date: "2024-02-01",
-              },
-            ],
-          });
-        }
-
-        if (url.hostname === "api.themoviedb.org" && url.pathname.endsWith("/watch/providers")) {
-          return jsonResponse({ results: { JP: { flatrate: [] } } });
-        }
-
-        if (url.hostname === "api.themoviedb.org" && url.pathname.endsWith("/release_dates")) {
-          return jsonResponse({ results: [] });
-        }
-
-        if (url.hostname === "api.themoviedb.org" && url.pathname.endsWith("/external_ids")) {
-          return jsonResponse({ imdb_id: null });
-        }
-
-        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
-      },
+      (url, init) => handleSimilarRefreshFetch(url, init, state),
       async () => {
         assertEquals(await fetchTmdbSimilar([{ tmdbId: 41, tmdbMediaType: "movie" }]), [
           createMovieResult({
@@ -295,10 +376,10 @@ Deno.test("fetchTmdbSimilar は stale cache を refresh して recommendation ca
           }),
         ]);
 
-        assertEquals(deleteCalls, 1);
-        assertEquals(inserts.length, 1);
+        assertEquals(state.deleteCalls, 1);
+        assertEquals(state.inserts.length, 1);
         assertEquals(
-          (inserts[0] as Array<{ rank: number }>).map((row) => row.rank),
+          (state.inserts[0] as Array<{ rank: number }>).map((row) => row.rank),
           [0, 1],
         );
       },
@@ -311,31 +392,7 @@ Deno.test("fetchTmdbSimilar は refresh 失敗時に stale cache を返す", asy
     const staleResult = createMovieResult({ tmdbId: 60, title: "Stale Similar" });
 
     await withMockFetch(
-      async (url, init) => {
-        const request = new Request(url, init);
-
-        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "GET") {
-          return jsonResponse([
-            {
-              source_tmdb_media_type: "movie",
-              source_tmdb_id: 41,
-              payload: staleResult,
-              rank: 0,
-              expires_at: pastIso(),
-            },
-          ]);
-        }
-
-        if (url.hostname === "api.themoviedb.org" && url.pathname === "/3/movie/41/similar") {
-          return jsonResponse({ results: [] });
-        }
-
-        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "DELETE") {
-          return jsonResponse({ message: "delete failed" }, { status: 500 });
-        }
-
-        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
-      },
+      (url, init) => handleSimilarFailureFetch(url, init, staleResult),
       async () => {
         assertEquals(await fetchTmdbSimilar([{ tmdbId: 41, tmdbMediaType: "movie" }]), [
           staleResult,

--- a/supabase/functions/_shared/tmdb/similar_test.ts
+++ b/supabase/functions/_shared/tmdb/similar_test.ts
@@ -1,7 +1,19 @@
 import { assertEquals } from "jsr:@std/assert";
-import { jsonResponse, withEnv, withMockFetch } from "../test-helpers.ts";
+import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
 import { fetchTmdbSimilar } from "./similar.ts";
 import { createMovieResult } from "./test-fixtures.ts";
+
+function futureIso(offsetMs = 60_000) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function pastIso(offsetMs = 60_000) {
+  return new Date(Date.now() - offsetMs).toISOString();
+}
+
+async function withSupabaseTmdbEnv(run: () => Promise<void>) {
+  await withEnv({ TMDB_API_KEY: "tmdb-test-key" }, () => withSupabaseAdminEnv(run));
+}
 
 Deno.test("fetchTmdbSimilar は source と recommendation の重複を除外する", async () => {
   await withEnv(
@@ -119,4 +131,216 @@ Deno.test("fetchTmdbSimilar は source と recommendation の重複を除外す�
       );
     },
   );
+});
+
+Deno.test("fetchTmdbSimilar は fresh cache があれば source ごとにそれを返す", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+        assertEquals(request.method, "GET");
+        assertEquals(url.pathname, "/rest/v1/work_recommendation_cache");
+        assertEquals(url.searchParams.get("recommendation_source"), "eq.similar");
+        assertEquals(url.searchParams.get("source_tmdb_id"), "in.(41,42)");
+        assertEquals(url.searchParams.get("order"), "rank.asc");
+
+        return jsonResponse([
+          {
+            source_tmdb_media_type: "movie",
+            source_tmdb_id: 41,
+            payload: createMovieResult({ tmdbId: 51, title: "Cached A" }),
+            rank: 0,
+            expires_at: futureIso(),
+          },
+          {
+            source_tmdb_media_type: "movie",
+            source_tmdb_id: 41,
+            payload: null,
+            rank: 1,
+            expires_at: futureIso(),
+          },
+          {
+            source_tmdb_media_type: "movie",
+            source_tmdb_id: 42,
+            payload: createMovieResult({ tmdbId: 52, title: "Cached B" }),
+            rank: 0,
+            expires_at: futureIso(),
+          },
+          {
+            source_tmdb_media_type: "tv",
+            source_tmdb_id: 99,
+            payload: createMovieResult({ tmdbId: 999, title: "Ignored" }),
+            rank: 0,
+            expires_at: futureIso(),
+          },
+        ]);
+      },
+      async () => {
+        assertEquals(
+          await fetchTmdbSimilar([
+            { tmdbId: 41, tmdbMediaType: "movie" },
+            { tmdbId: 42, tmdbMediaType: "movie" },
+          ]),
+          [
+            createMovieResult({ tmdbId: 51, title: "Cached A" }),
+            createMovieResult({ tmdbId: 52, title: "Cached B" }),
+          ],
+        );
+      },
+    );
+  });
+});
+
+Deno.test("fetchTmdbSimilar は stale cache を refresh して recommendation cache を更新する", async () => {
+  await withSupabaseTmdbEnv(async () => {
+    let deleteCalls = 0;
+    const inserts: unknown[] = [];
+
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+
+        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "GET") {
+          return jsonResponse([
+            {
+              source_tmdb_media_type: "movie",
+              source_tmdb_id: 41,
+              payload: createMovieResult({ tmdbId: 50, title: "Stale Similar" }),
+              rank: 0,
+              expires_at: pastIso(),
+            },
+          ]);
+        }
+
+        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "DELETE") {
+          deleteCalls += 1;
+          return jsonResponse([]);
+        }
+
+        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "POST") {
+          inserts.push(JSON.parse(await request.text()));
+          return jsonResponse([], { status: 201 });
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "GET") {
+          return jsonResponse([]);
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "POST") {
+          return jsonResponse([], { status: 201 });
+        }
+
+        if (url.hostname === "api.themoviedb.org" && url.pathname === "/3/movie/41/similar") {
+          return jsonResponse({
+            results: [
+              {
+                id: 51,
+                media_type: "movie",
+                title: "Similar A",
+                original_title: "Similar A Original",
+                overview: "A",
+                release_date: "2024-01-01",
+              },
+              {
+                id: 51,
+                media_type: "movie",
+                title: "Similar A",
+                original_title: "Similar A Original",
+                overview: "A",
+                release_date: "2024-01-01",
+              },
+              {
+                id: 52,
+                media_type: "movie",
+                title: "Similar B",
+                original_title: "Similar B Original",
+                overview: "B",
+                release_date: "2024-02-01",
+              },
+            ],
+          });
+        }
+
+        if (url.hostname === "api.themoviedb.org" && url.pathname.endsWith("/watch/providers")) {
+          return jsonResponse({ results: { JP: { flatrate: [] } } });
+        }
+
+        if (url.hostname === "api.themoviedb.org" && url.pathname.endsWith("/release_dates")) {
+          return jsonResponse({ results: [] });
+        }
+
+        if (url.hostname === "api.themoviedb.org" && url.pathname.endsWith("/external_ids")) {
+          return jsonResponse({ imdb_id: null });
+        }
+
+        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+      },
+      async () => {
+        assertEquals(await fetchTmdbSimilar([{ tmdbId: 41, tmdbMediaType: "movie" }]), [
+          createMovieResult({
+            tmdbId: 51,
+            title: "Similar A",
+            originalTitle: "Similar A Original",
+            overview: "A",
+            releaseDate: "2024-01-01",
+            hasJapaneseRelease: false,
+          }),
+          createMovieResult({
+            tmdbId: 52,
+            title: "Similar B",
+            originalTitle: "Similar B Original",
+            overview: "B",
+            releaseDate: "2024-02-01",
+            hasJapaneseRelease: false,
+          }),
+        ]);
+
+        assertEquals(deleteCalls, 1);
+        assertEquals(inserts.length, 1);
+        assertEquals(
+          (inserts[0] as Array<{ rank: number }>).map((row) => row.rank),
+          [0, 1],
+        );
+      },
+    );
+  });
+});
+
+Deno.test("fetchTmdbSimilar は refresh 失敗時に stale cache を返す", async () => {
+  await withSupabaseTmdbEnv(async () => {
+    const staleResult = createMovieResult({ tmdbId: 60, title: "Stale Similar" });
+
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+
+        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "GET") {
+          return jsonResponse([
+            {
+              source_tmdb_media_type: "movie",
+              source_tmdb_id: 41,
+              payload: staleResult,
+              rank: 0,
+              expires_at: pastIso(),
+            },
+          ]);
+        }
+
+        if (url.hostname === "api.themoviedb.org" && url.pathname === "/3/movie/41/similar") {
+          return jsonResponse({ results: [] });
+        }
+
+        if (url.pathname === "/rest/v1/work_recommendation_cache" && request.method === "DELETE") {
+          return jsonResponse({ message: "delete failed" }, { status: 500 });
+        }
+
+        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+      },
+      async () => {
+        assertEquals(await fetchTmdbSimilar([{ tmdbId: 41, tmdbMediaType: "movie" }]), [
+          staleResult,
+        ]);
+      },
+    );
+  });
 });

--- a/supabase/functions/_shared/tmdb/test-helpers.ts
+++ b/supabase/functions/_shared/tmdb/test-helpers.ts
@@ -1,0 +1,38 @@
+import { jsonResponse, withEnv, withSupabaseAdminEnv } from "../test-helpers.ts";
+
+export function futureIso(offsetMs = 60_000) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+export function pastIso(offsetMs = 60_000) {
+  return new Date(Date.now() - offsetMs).toISOString();
+}
+
+export async function withSupabaseTmdbEnv(
+  run: () => Promise<void>,
+  options: { omdbApiKey?: string | undefined } = {},
+) {
+  await withEnv(
+    {
+      TMDB_API_KEY: "tmdb-test-key",
+      OMDB_API_KEY: options.omdbApiKey,
+    },
+    () => withSupabaseAdminEnv(run),
+  );
+}
+
+export function respondWithEmptyMetadataCache(url: URL, request: Request): Response | null {
+  if (url.pathname !== "/rest/v1/tmdb_metadata_cache") {
+    return null;
+  }
+
+  if (request.method === "GET") {
+    return jsonResponse([]);
+  }
+
+  if (request.method === "POST") {
+    return jsonResponse([], { status: 201 });
+  }
+
+  return null;
+}

--- a/supabase/functions/_shared/tmdb/trending_test.ts
+++ b/supabase/functions/_shared/tmdb/trending_test.ts
@@ -1,22 +1,16 @@
 import { assertEquals } from "jsr:@std/assert";
 import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
 import { createMovieResult, createSeriesResult } from "./test-fixtures.ts";
+import {
+  futureIso,
+  pastIso,
+  respondWithEmptyMetadataCache,
+  withSupabaseTmdbEnv,
+} from "./test-helpers.ts";
 import { fetchTmdbTrending } from "./trending.ts";
 
 function isTmdbRequest(url: URL, pathname: string): boolean {
   return url.hostname === "api.themoviedb.org" && url.pathname === pathname;
-}
-
-function futureIso(offsetMs = 60_000) {
-  return new Date(Date.now() + offsetMs).toISOString();
-}
-
-function pastIso(offsetMs = 60_000) {
-  return new Date(Date.now() - offsetMs).toISOString();
-}
-
-async function withSupabaseTmdbEnv(run: () => Promise<void>) {
-  await withEnv({ TMDB_API_KEY: "tmdb-test-key" }, () => withSupabaseAdminEnv(run));
 }
 
 function handleTrendingFetch(url: URL): Response {
@@ -117,6 +111,191 @@ function handleTrendingFetch(url: URL): Response {
   throw new Error(`Unhandled fetch: ${url.toString()}`);
 }
 
+type TrendingRefreshState = {
+  deleteCalls: number;
+  inserts: unknown[];
+};
+
+async function handleTrendingCacheRefreshRequest(
+  url: URL,
+  request: Request,
+  state: TrendingRefreshState,
+): Promise<Response | null> {
+  if (url.pathname !== "/rest/v1/tmdb_trending_cache") {
+    return null;
+  }
+
+  if (request.method === "GET") {
+    return jsonResponse([
+      {
+        rank: 0,
+        payload: createMovieResult({ tmdbId: 999, title: "Stale" }),
+        expires_at: pastIso(),
+      },
+    ]);
+  }
+
+  if (request.method === "DELETE") {
+    state.deleteCalls += 1;
+    return jsonResponse([]);
+  }
+
+  if (request.method === "POST") {
+    state.inserts.push(JSON.parse(await request.text()));
+    return jsonResponse([], { status: 201 });
+  }
+
+  return null;
+}
+
+function handleTrendingPageFetch(url: URL): Response | null {
+  if (!isTmdbRequest(url, "/3/trending/all/week")) {
+    return null;
+  }
+
+  const page = url.searchParams.get("page");
+  if (page === "1") {
+    return jsonResponse({
+      results: [
+        {
+          id: 31,
+          media_type: "movie",
+          title: "Movie One",
+          original_title: "Movie One Original",
+          overview: "movie overview",
+          poster_path: "/movie-one.jpg",
+          release_date: "2024-01-01",
+        },
+      ],
+    });
+  }
+
+  if (page === "2") {
+    return jsonResponse({
+      results: [
+        {
+          id: 32,
+          media_type: "tv",
+          name: "Show Two",
+          original_name: "Show Two Original",
+          overview: "series overview",
+          poster_path: "/show-two.jpg",
+          first_air_date: "2024-02-01",
+        },
+      ],
+    });
+  }
+
+  return jsonResponse({ results: [] });
+}
+
+function handleTrendingMovieFetch(url: URL): Response | null {
+  if (isTmdbRequest(url, "/3/movie/31/watch/providers")) {
+    return jsonResponse({
+      results: {
+        JP: {
+          flatrate: [{ provider_id: 97, provider_name: "U-NEXT", logo_path: "/u.png" }],
+        },
+      },
+    });
+  }
+
+  if (isTmdbRequest(url, "/3/movie/31/release_dates")) {
+    return jsonResponse({
+      results: [
+        {
+          iso_3166_1: "JP",
+          release_dates: [{ release_date: "2024-01-10" }],
+        },
+      ],
+    });
+  }
+
+  if (isTmdbRequest(url, "/3/movie/31/external_ids")) {
+    return jsonResponse({ imdb_id: null });
+  }
+
+  return null;
+}
+
+function handleTrendingSeriesFetch(url: URL): Response | null {
+  if (isTmdbRequest(url, "/3/tv/32/watch/providers")) {
+    return jsonResponse({
+      results: {
+        JP: {
+          flatrate: [{ provider_id: 337, provider_name: "Disney+", logo_path: "/d.png" }],
+        },
+      },
+    });
+  }
+
+  if (isTmdbRequest(url, "/3/tv/32/external_ids")) {
+    return jsonResponse({ imdb_id: null });
+  }
+
+  return null;
+}
+
+function handleTrendingRefreshTmdbFetch(url: URL): Response | null {
+  return (
+    handleTrendingPageFetch(url) ?? handleTrendingMovieFetch(url) ?? handleTrendingSeriesFetch(url)
+  );
+}
+
+async function handleTrendingRefreshFetch(
+  url: URL,
+  init: RequestInit | undefined,
+  state: TrendingRefreshState,
+): Promise<Response> {
+  const request = new Request(url, init);
+  const response =
+    (await handleTrendingCacheRefreshRequest(url, request, state)) ??
+    respondWithEmptyMetadataCache(url, request) ??
+    handleTrendingRefreshTmdbFetch(url);
+
+  if (response) {
+    return response;
+  }
+
+  throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+}
+
+function handleStaleTrendingCacheRead(
+  url: URL,
+  request: Request,
+  staleResult: ReturnType<typeof createMovieResult>,
+): Response | null {
+  if (url.pathname !== "/rest/v1/tmdb_trending_cache" || request.method !== "GET") {
+    return null;
+  }
+
+  return jsonResponse([
+    {
+      rank: 0,
+      payload: staleResult,
+      expires_at: pastIso(),
+    },
+  ]);
+}
+
+async function handleTrendingFailureFetch(
+  url: URL,
+  init: RequestInit | undefined,
+  staleResult: ReturnType<typeof createMovieResult>,
+): Promise<Response> {
+  const request = new Request(url, init);
+  const cacheResponse = handleStaleTrendingCacheRead(url, request, staleResult);
+  if (cacheResponse) {
+    return cacheResponse;
+  }
+
+  if (isTmdbRequest(url, "/3/trending/all/week")) {
+    throw new Error("tmdb down");
+  }
+
+  throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+}
+
 Deno.test("fetchTmdbTrending は 3 ページを集約して重複を除外する", async () => {
   await withEnv(
     {
@@ -201,119 +380,13 @@ Deno.test("fetchTmdbTrending は fresh cache があればそれを返す", async
 
 Deno.test("fetchTmdbTrending は stale cache を refresh して trending cache を更新する", async () => {
   await withSupabaseTmdbEnv(async () => {
-    let trendingDeleteCalls = 0;
-    const trendingInserts: unknown[] = [];
+    const state: TrendingRefreshState = {
+      deleteCalls: 0,
+      inserts: [],
+    };
 
     await withMockFetch(
-      async (url, init) => {
-        const request = new Request(url, init);
-
-        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "GET") {
-          return jsonResponse([
-            {
-              rank: 0,
-              payload: createMovieResult({ tmdbId: 999, title: "Stale" }),
-              expires_at: pastIso(),
-            },
-          ]);
-        }
-
-        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "DELETE") {
-          trendingDeleteCalls += 1;
-          return jsonResponse([]);
-        }
-
-        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "POST") {
-          trendingInserts.push(JSON.parse(await request.text()));
-          return jsonResponse([], { status: 201 });
-        }
-
-        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "GET") {
-          return jsonResponse([]);
-        }
-
-        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "POST") {
-          return jsonResponse([], { status: 201 });
-        }
-
-        if (isTmdbRequest(url, "/3/trending/all/week")) {
-          const page = url.searchParams.get("page");
-          if (page === "1") {
-            return jsonResponse({
-              results: [
-                {
-                  id: 31,
-                  media_type: "movie",
-                  title: "Movie One",
-                  original_title: "Movie One Original",
-                  overview: "movie overview",
-                  poster_path: "/movie-one.jpg",
-                  release_date: "2024-01-01",
-                },
-              ],
-            });
-          }
-
-          if (page === "2") {
-            return jsonResponse({
-              results: [
-                {
-                  id: 32,
-                  media_type: "tv",
-                  name: "Show Two",
-                  original_name: "Show Two Original",
-                  overview: "series overview",
-                  poster_path: "/show-two.jpg",
-                  first_air_date: "2024-02-01",
-                },
-              ],
-            });
-          }
-
-          return jsonResponse({ results: [] });
-        }
-
-        if (isTmdbRequest(url, "/3/movie/31/watch/providers")) {
-          return jsonResponse({
-            results: {
-              JP: {
-                flatrate: [{ provider_id: 97, provider_name: "U-NEXT", logo_path: "/u.png" }],
-              },
-            },
-          });
-        }
-
-        if (isTmdbRequest(url, "/3/movie/31/release_dates")) {
-          return jsonResponse({
-            results: [
-              {
-                iso_3166_1: "JP",
-                release_dates: [{ release_date: "2024-01-10" }],
-              },
-            ],
-          });
-        }
-
-        if (isTmdbRequest(url, "/3/movie/31/external_ids")) {
-          return jsonResponse({ imdb_id: null });
-        }
-
-        if (isTmdbRequest(url, "/3/tv/32/watch/providers")) {
-          return jsonResponse({
-            results: {
-              JP: {
-                flatrate: [{ provider_id: 337, provider_name: "Disney+", logo_path: "/d.png" }],
-              },
-            },
-          });
-        }
-
-        if (isTmdbRequest(url, "/3/tv/32/external_ids")) {
-          return jsonResponse({ imdb_id: null });
-        }
-
-        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
-      },
+      (url, init) => handleTrendingRefreshFetch(url, init, state),
       async () => {
         assertEquals(await fetchTmdbTrending(), [
           createMovieResult({
@@ -337,10 +410,10 @@ Deno.test("fetchTmdbTrending は stale cache を refresh して trending cache �
           }),
         ]);
 
-        assertEquals(trendingDeleteCalls, 1);
-        assertEquals(trendingInserts.length, 1);
+        assertEquals(state.deleteCalls, 1);
+        assertEquals(state.inserts.length, 1);
         assertEquals(
-          (trendingInserts[0] as Array<{ rank: number }>).map((row) => row.rank),
+          (state.inserts[0] as Array<{ rank: number }>).map((row) => row.rank),
           [0, 1],
         );
       },
@@ -353,25 +426,7 @@ Deno.test("fetchTmdbTrending は refresh 失敗時に stale cache を返す", as
     const staleResults = [createMovieResult({ tmdbId: 301, title: "Stale Movie" })];
 
     await withMockFetch(
-      async (url, init) => {
-        const request = new Request(url, init);
-
-        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "GET") {
-          return jsonResponse([
-            {
-              rank: 0,
-              payload: staleResults[0],
-              expires_at: pastIso(),
-            },
-          ]);
-        }
-
-        if (isTmdbRequest(url, "/3/trending/all/week")) {
-          throw new Error("tmdb down");
-        }
-
-        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
-      },
+      (url, init) => handleTrendingFailureFetch(url, init, staleResults[0]),
       async () => {
         assertEquals(await fetchTmdbTrending(), staleResults);
       },

--- a/supabase/functions/_shared/tmdb/trending_test.ts
+++ b/supabase/functions/_shared/tmdb/trending_test.ts
@@ -1,9 +1,22 @@
 import { assertEquals } from "jsr:@std/assert";
-import { jsonResponse, withEnv, withMockFetch } from "../test-helpers.ts";
+import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
+import { createMovieResult, createSeriesResult } from "./test-fixtures.ts";
 import { fetchTmdbTrending } from "./trending.ts";
 
 function isTmdbRequest(url: URL, pathname: string): boolean {
   return url.hostname === "api.themoviedb.org" && url.pathname === pathname;
+}
+
+function futureIso(offsetMs = 60_000) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function pastIso(offsetMs = 60_000) {
+  return new Date(Date.now() - offsetMs).toISOString();
+}
+
+async function withSupabaseTmdbEnv(run: () => Promise<void>) {
+  await withEnv({ TMDB_API_KEY: "tmdb-test-key" }, () => withSupabaseAdminEnv(run));
 }
 
 function handleTrendingFetch(url: URL): Response {
@@ -150,4 +163,218 @@ Deno.test("fetchTmdbTrending は 3 ページを集約して重複を除外する
       );
     },
   );
+});
+
+Deno.test("fetchTmdbTrending は fresh cache があればそれを返す", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+        assertEquals(request.method, "GET");
+        assertEquals(url.pathname, "/rest/v1/tmdb_trending_cache");
+        assertEquals(url.searchParams.get("cache_window"), "eq.week");
+        assertEquals(url.searchParams.get("order"), "rank.asc");
+
+        return jsonResponse([
+          { rank: 0, payload: null, expires_at: futureIso() },
+          {
+            rank: 1,
+            payload: createMovieResult({ tmdbId: 201, title: "Cached Movie" }),
+            expires_at: futureIso(),
+          },
+          {
+            rank: 2,
+            payload: createSeriesResult({ tmdbId: 202, title: "Cached Show" }),
+            expires_at: futureIso(),
+          },
+        ]);
+      },
+      async () => {
+        assertEquals(await fetchTmdbTrending(), [
+          createMovieResult({ tmdbId: 201, title: "Cached Movie" }),
+          createSeriesResult({ tmdbId: 202, title: "Cached Show" }),
+        ]);
+      },
+    );
+  });
+});
+
+Deno.test("fetchTmdbTrending は stale cache を refresh して trending cache を更新する", async () => {
+  await withSupabaseTmdbEnv(async () => {
+    let trendingDeleteCalls = 0;
+    const trendingInserts: unknown[] = [];
+
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+
+        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "GET") {
+          return jsonResponse([
+            {
+              rank: 0,
+              payload: createMovieResult({ tmdbId: 999, title: "Stale" }),
+              expires_at: pastIso(),
+            },
+          ]);
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "DELETE") {
+          trendingDeleteCalls += 1;
+          return jsonResponse([]);
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "POST") {
+          trendingInserts.push(JSON.parse(await request.text()));
+          return jsonResponse([], { status: 201 });
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "GET") {
+          return jsonResponse([]);
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "POST") {
+          return jsonResponse([], { status: 201 });
+        }
+
+        if (isTmdbRequest(url, "/3/trending/all/week")) {
+          const page = url.searchParams.get("page");
+          if (page === "1") {
+            return jsonResponse({
+              results: [
+                {
+                  id: 31,
+                  media_type: "movie",
+                  title: "Movie One",
+                  original_title: "Movie One Original",
+                  overview: "movie overview",
+                  poster_path: "/movie-one.jpg",
+                  release_date: "2024-01-01",
+                },
+              ],
+            });
+          }
+
+          if (page === "2") {
+            return jsonResponse({
+              results: [
+                {
+                  id: 32,
+                  media_type: "tv",
+                  name: "Show Two",
+                  original_name: "Show Two Original",
+                  overview: "series overview",
+                  poster_path: "/show-two.jpg",
+                  first_air_date: "2024-02-01",
+                },
+              ],
+            });
+          }
+
+          return jsonResponse({ results: [] });
+        }
+
+        if (isTmdbRequest(url, "/3/movie/31/watch/providers")) {
+          return jsonResponse({
+            results: {
+              JP: {
+                flatrate: [{ provider_id: 97, provider_name: "U-NEXT", logo_path: "/u.png" }],
+              },
+            },
+          });
+        }
+
+        if (isTmdbRequest(url, "/3/movie/31/release_dates")) {
+          return jsonResponse({
+            results: [
+              {
+                iso_3166_1: "JP",
+                release_dates: [{ release_date: "2024-01-10" }],
+              },
+            ],
+          });
+        }
+
+        if (isTmdbRequest(url, "/3/movie/31/external_ids")) {
+          return jsonResponse({ imdb_id: null });
+        }
+
+        if (isTmdbRequest(url, "/3/tv/32/watch/providers")) {
+          return jsonResponse({
+            results: {
+              JP: {
+                flatrate: [{ provider_id: 337, provider_name: "Disney+", logo_path: "/d.png" }],
+              },
+            },
+          });
+        }
+
+        if (isTmdbRequest(url, "/3/tv/32/external_ids")) {
+          return jsonResponse({ imdb_id: null });
+        }
+
+        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+      },
+      async () => {
+        assertEquals(await fetchTmdbTrending(), [
+          createMovieResult({
+            tmdbId: 31,
+            title: "Movie One",
+            originalTitle: "Movie One Original",
+            overview: "movie overview",
+            posterPath: "/movie-one.jpg",
+            releaseDate: "2024-01-01",
+            jpWatchPlatforms: [{ key: "u_next", logoPath: "/u.png" }],
+            hasJapaneseRelease: true,
+          }),
+          createSeriesResult({
+            tmdbId: 32,
+            title: "Show Two",
+            originalTitle: "Show Two Original",
+            overview: "series overview",
+            posterPath: "/show-two.jpg",
+            releaseDate: "2024-02-01",
+            jpWatchPlatforms: [{ key: "disney_plus", logoPath: "/d.png" }],
+          }),
+        ]);
+
+        assertEquals(trendingDeleteCalls, 1);
+        assertEquals(trendingInserts.length, 1);
+        assertEquals(
+          (trendingInserts[0] as Array<{ rank: number }>).map((row) => row.rank),
+          [0, 1],
+        );
+      },
+    );
+  });
+});
+
+Deno.test("fetchTmdbTrending は refresh 失敗時に stale cache を返す", async () => {
+  await withSupabaseTmdbEnv(async () => {
+    const staleResults = [createMovieResult({ tmdbId: 301, title: "Stale Movie" })];
+
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+
+        if (url.pathname === "/rest/v1/tmdb_trending_cache" && request.method === "GET") {
+          return jsonResponse([
+            {
+              rank: 0,
+              payload: staleResults[0],
+              expires_at: pastIso(),
+            },
+          ]);
+        }
+
+        if (isTmdbRequest(url, "/3/trending/all/week")) {
+          throw new Error("tmdb down");
+        }
+
+        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+      },
+      async () => {
+        assertEquals(await fetchTmdbTrending(), staleResults);
+      },
+    );
+  });
 });

--- a/supabase/functions/_shared/tmdb/watch-providers_test.ts
+++ b/supabase/functions/_shared/tmdb/watch-providers_test.ts
@@ -1,0 +1,174 @@
+import { assertEquals } from "jsr:@std/assert";
+import { checkJapaneseReleaseCached, fetchWatchProvidersJP } from "./watch-providers.ts";
+import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
+
+function futureIso(offsetMs = 60_000) {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function pastIso(offsetMs = 60_000) {
+  return new Date(Date.now() - offsetMs).toISOString();
+}
+
+async function withSupabaseTmdbEnv(run: () => Promise<void>) {
+  await withEnv({ TMDB_API_KEY: "tmdb-test-key" }, () => withSupabaseAdminEnv(run));
+}
+
+Deno.test("fetchWatchProvidersJP は fresh cache を正規化して返す", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+        assertEquals(request.method, "GET");
+        assertEquals(url.pathname, "/rest/v1/tmdb_metadata_cache");
+        assertEquals(url.searchParams.get("cache_key"), "eq.watch-providers:movie:101:JP");
+
+        return jsonResponse({
+          payload: [
+            null,
+            { key: "netflix", logoPath: "/netflix.png" },
+            { key: "prime_video", logoPath: null },
+            { logoPath: "/missing.png" },
+          ],
+          expires_at: futureIso(),
+        });
+      },
+      async () => {
+        assertEquals(await fetchWatchProvidersJP(101, "movie"), [
+          { key: "netflix", logoPath: "/netflix.png" },
+          { key: "prime_video", logoPath: null },
+        ]);
+      },
+    );
+  });
+});
+
+Deno.test("fetchWatchProvidersJP は stale cache から TMDB を引き直して metadata cache を更新する", async () => {
+  await withSupabaseTmdbEnv(async () => {
+    const writes: Array<{ cache_key: string; payload: unknown }> = [];
+
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "GET") {
+          return jsonResponse({
+            payload: [{ key: "u_next", logoPath: "/old.png" }],
+            expires_at: pastIso(),
+          });
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "POST") {
+          writes.push(
+            JSON.parse(await request.text()) as {
+              cache_key: string;
+              payload: unknown;
+            },
+          );
+          return jsonResponse([], { status: 201 });
+        }
+
+        if (
+          url.hostname === "api.themoviedb.org" &&
+          url.pathname === "/3/movie/101/watch/providers"
+        ) {
+          return jsonResponse({
+            results: {
+              JP: {
+                flatrate: [
+                  { provider_id: 97, provider_name: "U-NEXT", logo_path: "/u-next.png" },
+                  { provider_id: 97, provider_name: "U-NEXT", logo_path: "/u-next-dup.png" },
+                  { provider_id: 337, provider_name: "Disney+", logo_path: null },
+                  { provider_id: 999, provider_name: "Unknown", logo_path: "/ignore.png" },
+                ],
+              },
+            },
+          });
+        }
+
+        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+      },
+      async () => {
+        assertEquals(await fetchWatchProvidersJP(101, "movie"), [
+          { key: "u_next", logoPath: "/u-next.png" },
+          { key: "disney_plus", logoPath: null },
+        ]);
+        assertEquals(
+          writes.map(({ cache_key, payload }) => ({ cache_key, payload })),
+          [
+            {
+              cache_key: "watch-providers:movie:101:JP",
+              payload: [
+                { key: "u_next", logoPath: "/u-next.png" },
+                { key: "disney_plus", logoPath: null },
+              ],
+            },
+          ],
+        );
+      },
+    );
+  });
+});
+
+Deno.test("checkJapaneseReleaseCached は fresh cache の boolean を返す", async () => {
+  await withSupabaseAdminEnv(async () => {
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+        assertEquals(request.method, "GET");
+        assertEquals(url.pathname, "/rest/v1/tmdb_metadata_cache");
+        assertEquals(url.searchParams.get("cache_key"), "eq.jp-release:movie:31");
+
+        return jsonResponse({
+          payload: false,
+          expires_at: futureIso(),
+        });
+      },
+      async () => {
+        assertEquals(await checkJapaneseReleaseCached(31), false);
+      },
+    );
+  });
+});
+
+Deno.test("checkJapaneseReleaseCached は release_dates 取得失敗時に true を返して書き戻す", async () => {
+  await withSupabaseTmdbEnv(async () => {
+    const writes: Array<{ cache_key: string; payload: unknown }> = [];
+
+    await withMockFetch(
+      async (url, init) => {
+        const request = new Request(url, init);
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "GET") {
+          return jsonResponse({
+            payload: "invalid",
+            expires_at: pastIso(),
+          });
+        }
+
+        if (url.pathname === "/rest/v1/tmdb_metadata_cache" && request.method === "POST") {
+          writes.push(
+            JSON.parse(await request.text()) as {
+              cache_key: string;
+              payload: unknown;
+            },
+          );
+          return jsonResponse([], { status: 201 });
+        }
+
+        if (url.hostname === "api.themoviedb.org" && url.pathname === "/3/movie/31/release_dates") {
+          throw new Error("tmdb down");
+        }
+
+        throw new Error(`Unhandled fetch: ${request.method} ${url.toString()}`);
+      },
+      async () => {
+        assertEquals(await checkJapaneseReleaseCached(31), true);
+        assertEquals(
+          writes.map(({ cache_key, payload }) => ({ cache_key, payload })),
+          [{ cache_key: "jp-release:movie:31", payload: true }],
+        );
+      },
+    );
+  });
+});

--- a/supabase/functions/_shared/tmdb/watch-providers_test.ts
+++ b/supabase/functions/_shared/tmdb/watch-providers_test.ts
@@ -1,18 +1,7 @@
 import { assertEquals } from "jsr:@std/assert";
 import { checkJapaneseReleaseCached, fetchWatchProvidersJP } from "./watch-providers.ts";
-import { jsonResponse, withEnv, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
-
-function futureIso(offsetMs = 60_000) {
-  return new Date(Date.now() + offsetMs).toISOString();
-}
-
-function pastIso(offsetMs = 60_000) {
-  return new Date(Date.now() - offsetMs).toISOString();
-}
-
-async function withSupabaseTmdbEnv(run: () => Promise<void>) {
-  await withEnv({ TMDB_API_KEY: "tmdb-test-key" }, () => withSupabaseAdminEnv(run));
-}
+import { futureIso, pastIso, withSupabaseTmdbEnv } from "./test-helpers.ts";
+import { jsonResponse, withMockFetch, withSupabaseAdminEnv } from "../test-helpers.ts";
 
 Deno.test("fetchWatchProvidersJP は fresh cache を正規化して返す", async () => {
   await withSupabaseAdminEnv(async () => {


### PR DESCRIPTION
## 関連 Issue

Refs #295

## 変更内容

- `supabase/functions/_shared/tmdb/cache.ts` に pure helper と Supabase REST read/write 成功・失敗の Deno テストを追加
- `supabase/functions/_shared/tmdb/watch-providers.ts` に fresh cache 利用と stale refresh の Deno テストを追加
- `supabase/functions/_shared/tmdb/trending.ts` / `supabase/functions/_shared/tmdb/similar.ts` に fresh cache、refresh write、stale fallback の Deno テストを追加
- Supabase admin client を使う Deno テスト向けに `withSupabaseAdminEnv` を `supabase/functions/_shared/test-helpers.ts` へ追加

## 検証

- `vp run test:functions`
- `vp exec deno test --allow-env --no-check --no-lock --node-modules-dir=none --coverage=/tmp/mirukan-deno-cov-295 supabase/functions/`
- `vp run build:analyze`

## カバレッジ

- `supabase/functions/_shared/tmdb/cache.ts`: lines 27.3% -> 100.0%
- `supabase/functions/_shared/tmdb/watch-providers.ts`: lines 71.3% -> 94.3%
- `supabase/functions/_shared/tmdb/trending.ts`: lines 50.4% -> 87.6%
- `supabase/functions/_shared/tmdb/similar.ts`: lines 54.0% -> 90.8%
