### PR TITLE
Vercel ビルド時の deno build script warning を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
     "allowBuilds": {
+      "deno": true,
       "msw": true
     },
     "overrides": {


### PR DESCRIPTION
## 関連 Issue

- なし

## 変更内容

- `package.json` の `pnpm.allowBuilds` に `deno: true` を追加
- Vercel / pnpm 10 の install 時に出ていた `Ignored build scripts: deno` warning を解消
- `vp install` を実行し、`deno postinstall` が許可されて warning が出ないことを確認
