### PR TITLE
refactor: SonarCloud すぐ直す指摘の解消

### DIFF
--- a/supabase/functions/_shared/igdb.ts
+++ b/supabase/functions/_shared/igdb.ts
@@ -132,7 +132,7 @@ const DETAILS_FIELDS = [
 ].join(",");
 
 function escapeIgdbString(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return value.replaceAll("\\", String.raw`\\`).replaceAll('"', '\\"');
 }
 
 export function buildIgdbSearchBody(query: string, limit = 20): string {

--- a/supabase/functions/_shared/igdb_test.ts
+++ b/supabase/functions/_shared/igdb_test.ts
@@ -14,6 +14,12 @@ import {
 } from "./igdb.ts";
 import { jsonResponse } from "./test-helpers.ts";
 
+function fetchInputUrl(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
 function createContext(
   fetchImpl: typeof fetch,
   options: { tokenSequence?: string[] } = {},
@@ -63,7 +69,7 @@ Deno.test("unixSecondsToIsoDate は秒を YYYY-MM-DD に変換する", () => {
 Deno.test("buildIgdbSearchBody はクエリをエスケープしてカテゴリで絞る", () => {
   assertEquals(
     buildIgdbSearchBody('Zelda "BOTW"'),
-    `fields id,name,summary,cover.image_id,first_release_date,platforms.slug; search "Zelda \\"BOTW\\""; where category = (0,8,9,10,11); limit 20;`,
+    String.raw`fields id,name,summary,cover.image_id,first_release_date,platforms.slug; search "Zelda \"BOTW\""; where category = (0,8,9,10,11); limit 20;`,
   );
 });
 
@@ -105,9 +111,7 @@ Deno.test("callIgdbEndpoint は 401 で 1 度だけ force refresh して再試�
   let calls = 0;
   const fetchImpl = (async (input: string | URL | Request) => {
     calls += 1;
-    const url =
-      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    assertEquals(url, "https://api.igdb.com/v4/games");
+    assertEquals(fetchInputUrl(input), "https://api.igdb.com/v4/games");
     if (calls === 1) {
       return new Response("Unauthorized", { status: 401 });
     }
@@ -138,9 +142,7 @@ Deno.test("callIgdbEndpoint は連続 401 で例外を投げる", async () => {
 
 Deno.test("searchIgdbWorks は IGDB レスポンスを IgdbSearchResult[] に変換する", async () => {
   const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url =
-      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    assertEquals(url, "https://api.igdb.com/v4/games");
+    assertEquals(fetchInputUrl(input), "https://api.igdb.com/v4/games");
     assertEquals(init?.method, "POST");
     return jsonResponse([
       {

--- a/supabase/functions/_shared/tmdb/test-helpers.ts
+++ b/supabase/functions/_shared/tmdb/test-helpers.ts
@@ -10,7 +10,7 @@ export function pastIso(offsetMs = 60_000) {
 
 export async function withSupabaseTmdbEnv(
   run: () => Promise<void>,
-  options: { omdbApiKey?: string | undefined } = {},
+  options: { omdbApiKey?: string } = {},
 ) {
   await withEnv(
     {


### PR DESCRIPTION
## 関連 Issue

Refs #307

## 変更内容

quality report snapshot (#307) の「すぐ直す」5 件に対応。バグ・脆弱性は 0 件のため未対応。「構造改善が必要」項目は別 PR 候補として今回は対象外。振る舞いは変えていない。

- `supabase/functions/_shared/tmdb/test-helpers.ts`: `omdbApiKey?: string | undefined` の `| undefined` を削除（`?` と重複）
- `supabase/functions/_shared/igdb_test.ts`: `buildIgdbSearchBody` の期待値テンプレートを `String.raw` 化してエスケープを削減
- `supabase/functions/_shared/igdb_test.ts`: `fetch` 入力を URL 文字列に揃える処理をネスト三項から `fetchInputUrl` ヘルパーに抽出（2 箇所で共有）
- `supabase/functions/_shared/igdb.ts`: `escapeIgdbString` の `"\\\\"` を `String.raw` 化

## 検証

- `vp run test:functions` → 71/71 passed
- `vp run knip` → 警告なし
- pre-commit (`vp check --fix`) 通過

## 見送った項目

- 「構造改善が必要」: 長大ファイル / 複雑度 / 重複率は単発の修正で安全に触れにくく、別 Issue で個別対応する方が PR を膨らませずに済むため今回は対象外