### PR TITLE
refactor: SonarCloud 構造改善指摘の解消

### DIFF
--- a/src/features/backlog/backlog-item-utils.ts
+++ b/src/features/backlog/backlog-item-utils.ts
@@ -1,6 +1,12 @@
+import {
+  isBacklogStatus,
+  isNullableString,
+  isRecord,
+  normalizeBacklogWork,
+} from "./backlog-item-validators.ts";
 import { statusLabels } from "./constants.ts";
 import { isPrimaryPlatform, normalizePrimaryPlatform } from "./helpers.ts";
-import type { BacklogItem, BacklogStatus, DetailModalEditableField, WorkSummary } from "./types.ts";
+import type { BacklogItem, BacklogStatus, DetailModalEditableField } from "./types.ts";
 
 export function normalizeBacklogItems(rows: unknown[]): BacklogItem[] {
   return rows.flatMap((row) => {
@@ -12,81 +18,6 @@ export function normalizeBacklogItems(rows: unknown[]): BacklogItem[] {
 
     return [item];
   });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isNullableString(value: unknown): value is string | null {
-  return typeof value === "string" || value === null;
-}
-
-function isNullableNumber(value: unknown): value is number | null {
-  return typeof value === "number" || value === null;
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isBacklogStatus(value: unknown): value is BacklogStatus {
-  return typeof value === "string" && value in statusLabels;
-}
-
-function isWorkType(value: unknown): value is WorkSummary["work_type"] {
-  return value === "movie" || value === "series" || value === "season";
-}
-
-function isSourceType(value: unknown): value is WorkSummary["source_type"] {
-  return value === "tmdb" || value === "manual";
-}
-
-function isTmdbMediaType(value: unknown): value is WorkSummary["tmdb_media_type"] {
-  return value === "movie" || value === "tv" || value === null;
-}
-
-function isDurationBucket(value: unknown): value is WorkSummary["duration_bucket"] {
-  return (
-    value === "short" ||
-    value === "medium" ||
-    value === "long" ||
-    value === "very_long" ||
-    value === null
-  );
-}
-
-function isBacklogWork(value: unknown): value is NonNullable<BacklogItem["works"]> {
-  return (
-    isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.title === "string" &&
-    isWorkType(value.work_type) &&
-    isSourceType(value.source_type) &&
-    isNullableNumber(value.tmdb_id) &&
-    isTmdbMediaType(value.tmdb_media_type) &&
-    isNullableString(value.original_title) &&
-    isNullableString(value.overview) &&
-    isNullableString(value.poster_path) &&
-    isNullableString(value.release_date) &&
-    isNullableNumber(value.runtime_minutes) &&
-    isNullableNumber(value.typical_episode_runtime_minutes) &&
-    isDurationBucket(value.duration_bucket) &&
-    isStringArray(value.genres) &&
-    isNullableNumber(value.season_count) &&
-    isNullableNumber(value.season_number) &&
-    isNullableNumber(value.focus_required_score) &&
-    isNullableNumber(value.background_fit_score) &&
-    isNullableNumber(value.completion_load_score)
-  );
-}
-
-function normalizeBacklogWork(value: unknown): BacklogItem["works"] {
-  if (Array.isArray(value)) {
-    return isBacklogWork(value[0]) ? value[0] : null;
-  }
-
-  return isBacklogWork(value) ? value : null;
 }
 
 function normalizeBacklogItem(value: unknown): BacklogItem | null {

--- a/src/features/backlog/backlog-item-validators.ts
+++ b/src/features/backlog/backlog-item-validators.ts
@@ -1,0 +1,77 @@
+import { statusLabels } from "./constants.ts";
+import type { BacklogItem, BacklogStatus, WorkSummary } from "./types.ts";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isNullableString(value: unknown): value is string | null {
+  return typeof value === "string" || value === null;
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return typeof value === "number" || value === null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+export function isBacklogStatus(value: unknown): value is BacklogStatus {
+  return typeof value === "string" && value in statusLabels;
+}
+
+function isWorkType(value: unknown): value is WorkSummary["work_type"] {
+  return value === "movie" || value === "series" || value === "season";
+}
+
+function isSourceType(value: unknown): value is WorkSummary["source_type"] {
+  return value === "tmdb" || value === "manual";
+}
+
+function isTmdbMediaType(value: unknown): value is WorkSummary["tmdb_media_type"] {
+  return value === "movie" || value === "tv" || value === null;
+}
+
+function isDurationBucket(value: unknown): value is WorkSummary["duration_bucket"] {
+  return (
+    value === "short" ||
+    value === "medium" ||
+    value === "long" ||
+    value === "very_long" ||
+    value === null
+  );
+}
+
+function isBacklogWork(value: unknown): value is NonNullable<BacklogItem["works"]> {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.title === "string" &&
+    isWorkType(value.work_type) &&
+    isSourceType(value.source_type) &&
+    isNullableNumber(value.tmdb_id) &&
+    isTmdbMediaType(value.tmdb_media_type) &&
+    isNullableString(value.original_title) &&
+    isNullableString(value.overview) &&
+    isNullableString(value.poster_path) &&
+    isNullableString(value.release_date) &&
+    isNullableNumber(value.runtime_minutes) &&
+    isNullableNumber(value.typical_episode_runtime_minutes) &&
+    isDurationBucket(value.duration_bucket) &&
+    isStringArray(value.genres) &&
+    isNullableNumber(value.season_count) &&
+    isNullableNumber(value.season_number) &&
+    isNullableNumber(value.focus_required_score) &&
+    isNullableNumber(value.background_fit_score) &&
+    isNullableNumber(value.completion_load_score)
+  );
+}
+
+export function normalizeBacklogWork(value: unknown): BacklogItem["works"] {
+  if (Array.isArray(value)) {
+    return isBacklogWork(value[0]) ? value[0] : null;
+  }
+
+  return isBacklogWork(value) ? value : null;
+}

--- a/src/features/backlog/hooks/useTmdbSearchRequest.test.tsx
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.test.tsx
@@ -62,7 +62,14 @@ describe("useTmdbSearchRequest", () => {
   });
 
   test("推薦元は watched を優先しつつ Fisher-Yates でシャッフルする", async () => {
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    const getRandomValuesSpy = vi
+      .spyOn(globalThis.crypto, "getRandomValues")
+      .mockImplementation((array) => {
+        if (array instanceof Uint32Array) {
+          array[0] = 0;
+        }
+        return array;
+      });
 
     renderHook(() =>
       useTmdbSearchRequest({
@@ -88,7 +95,7 @@ describe("useTmdbSearchRequest", () => {
       { tmdbId: 3, tmdbMediaType: "movie" },
     ]);
 
-    randomSpy.mockRestore();
+    getRandomValuesSpy.mockRestore();
   });
 
   test("handleQueryChange でクエリ入力後、デバウンス経過で searchTmdbWorks が呼ばれる", async () => {

--- a/src/features/backlog/hooks/useTmdbSearchRequest.ts
+++ b/src/features/backlog/hooks/useTmdbSearchRequest.ts
@@ -1,146 +1,16 @@
 import { useEffect, useReducer, useRef, useState } from "react";
 import { fetchTmdbRecommendations, searchTmdbWorks } from "../../../lib/tmdb.ts";
-import type { TmdbSearchResult } from "../../../lib/tmdb.ts";
 import { initialTmdbSearchRequestState, tmdbSearchRequestReducer } from "../tmdb-search-request.ts";
-import { getStackedSeasonNumbers } from "../tmdb-search-state.ts";
+import {
+  buildRecommendationSourceItems,
+  filterVisibleRecommendations,
+  filterVisibleResults,
+  prioritizeLocalizedResults,
+  resolveSearchMessage,
+} from "../tmdb-search-results.ts";
 import type { BacklogItem } from "../types.ts";
 
-function isHiddenSearchResult(items: BacklogItem[], result: TmdbSearchResult) {
-  if (result.tmdbMediaType === "movie" && result.workType === "movie") {
-    return items.some((item) => {
-      const work = item.works;
-      return (
-        item.status === "stacked" &&
-        work?.tmdb_id === result.tmdbId &&
-        work.tmdb_media_type === result.tmdbMediaType &&
-        work.work_type === result.workType
-      );
-    });
-  }
-
-  if (result.tmdbMediaType !== "tv" || result.workType !== "series") {
-    return false;
-  }
-
-  const stackedSeriesItem = items.find((item) => {
-    const work = item.works;
-    return (
-      item.status === "stacked" &&
-      work?.tmdb_id === result.tmdbId &&
-      work.tmdb_media_type === result.tmdbMediaType &&
-      work.work_type === "series"
-    );
-  });
-
-  const seasonCount = stackedSeriesItem?.works?.season_count;
-  if (!seasonCount) return false;
-
-  const stackedSeasonNumbers = new Set(
-    getStackedSeasonNumbers(
-      items,
-      result,
-      Array.from({ length: Math.max(seasonCount - 1, 0) }, (_, index) => index + 2),
-    ),
-  );
-
-  for (let seasonNumber = 2; seasonNumber <= seasonCount; seasonNumber += 1) {
-    if (!stackedSeasonNumbers.has(seasonNumber)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function filterVisibleResults(items: BacklogItem[], results: TmdbSearchResult[]) {
-  return results.filter((result) => !isHiddenSearchResult(items, result));
-}
-
-function getLocalizationScore(result: TmdbSearchResult) {
-  let score = 0;
-
-  if (result.title.trim() !== result.originalTitle?.trim()) {
-    score += 2;
-  }
-
-  if (result.overview?.trim()) {
-    score += 1;
-  }
-
-  return score;
-}
-
-function prioritizeLocalizedResults(results: TmdbSearchResult[]) {
-  return results
-    .map((result, index) => ({ result, index }))
-    .sort((left, right) => {
-      const scoreDiff = getLocalizationScore(right.result) - getLocalizationScore(left.result);
-      return scoreDiff === 0 ? left.index - right.index : scoreDiff;
-    })
-    .map(({ result }) => result);
-}
-
-function resolveSearchMessage(results: TmdbSearchResult[], visibleResults: TmdbSearchResult[]) {
-  if (visibleResults.length > 0) {
-    return null;
-  }
-
-  if (results.length > 0) {
-    return "すでにストック済みの作品は候補から除外しています。";
-  }
-
-  return "候補が見つかりませんでした。このまま入力して追加できます。";
-}
-
-const MAX_RECOMMENDATION_SOURCE_ITEMS = 8;
 const SEARCH_DEBOUNCE_MS = 250;
-
-function shuffleArray<T>(items: T[]) {
-  const shuffled = [...items];
-
-  for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const randomIndex = Math.floor(Math.random() * (index + 1));
-    [shuffled[index], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[index]];
-  }
-
-  return shuffled;
-}
-
-function buildRecommendationSourceItems(items: BacklogItem[]) {
-  const recommendationCandidates = items.filter(
-    (item) =>
-      (item.status === "watched" || item.status === "watching") &&
-      item.works?.tmdb_id != null &&
-      item.works?.source_type === "tmdb" &&
-      item.works?.work_type !== "season",
-  );
-
-  return [
-    ...shuffleArray(recommendationCandidates.filter((item) => item.status === "watched")),
-    ...shuffleArray(recommendationCandidates.filter((item) => item.status === "watching")),
-  ]
-    .slice(0, MAX_RECOMMENDATION_SOURCE_ITEMS)
-    .map((item) => ({
-      tmdbId: item.works!.tmdb_id!,
-      tmdbMediaType: item.works!.tmdb_media_type as "movie" | "tv",
-    }));
-}
-
-function filterVisibleRecommendations(items: BacklogItem[], results: TmdbSearchResult[]) {
-  const itemTmdbKeys = new Set(
-    items
-      .filter((item) => item.works?.tmdb_id && item.works?.tmdb_media_type)
-      .map((item) => `${item.works!.tmdb_media_type}-${item.works!.tmdb_id}`),
-  );
-
-  return prioritizeLocalizedResults(
-    filterVisibleResults(items, results).filter(
-      (result) =>
-        !itemTmdbKeys.has(`${result.tmdbMediaType}-${result.tmdbId}`) &&
-        (result.workType === "series" || result.hasJapaneseRelease),
-    ),
-  );
-}
 
 type UseTmdbSearchRequestOptions = {
   items: BacklogItem[];

--- a/src/features/backlog/omdb-work-fields.ts
+++ b/src/features/backlog/omdb-work-fields.ts
@@ -1,0 +1,106 @@
+import { fetchOmdbWorkDetails } from "../../lib/omdb.ts";
+import type { RatingInfo } from "./work-metadata.ts";
+import { shouldRefreshOmdbWork } from "./work-repository-helpers.ts";
+
+export type ExistingTmdbWorkRow = {
+  id: string;
+  last_tmdb_synced_at: string | null;
+  omdb_fetched_at: string | null;
+  imdb_id: string | null;
+  genres: string[];
+};
+
+export type OmdbFields = {
+  rotten_tomatoes_score?: number | null;
+  imdb_rating?: number | null;
+  imdb_votes?: number | null;
+  metacritic_score?: number | null;
+  omdb_fetched_at?: string;
+};
+
+type OmdbDetails = Awaited<ReturnType<typeof fetchOmdbWorkDetails>>;
+
+type OmdbDecision =
+  | { type: "skip" }
+  | { type: "clear"; omdbFetchedAt: string }
+  | { type: "fetch"; imdbId: string; omdbFetchedAt: string };
+
+function buildClearedOmdbFields(omdbFetchedAt: string): OmdbFields {
+  return {
+    rotten_tomatoes_score: null,
+    imdb_rating: null,
+    imdb_votes: null,
+    metacritic_score: null,
+    omdb_fetched_at: omdbFetchedAt,
+  };
+}
+
+function toOmdbFields(omdb: OmdbDetails, omdbFetchedAt: string): OmdbFields {
+  return {
+    rotten_tomatoes_score: omdb.rottenTomatoesScore,
+    imdb_rating: omdb.imdbRating,
+    imdb_votes: omdb.imdbVotes,
+    metacritic_score: omdb.metacriticScore,
+    omdb_fetched_at: omdbFetchedAt,
+  };
+}
+
+function shouldKeepExistingNullOmdbState(existing: ExistingTmdbWorkRow | null) {
+  return Boolean(
+    existing && !shouldRefreshOmdbWork(existing.omdb_fetched_at) && existing.imdb_id === null,
+  );
+}
+
+function shouldSkipOmdbRefresh(existing: ExistingTmdbWorkRow | null, imdbId: string) {
+  return Boolean(
+    existing && !shouldRefreshOmdbWork(existing.omdb_fetched_at) && existing.imdb_id === imdbId,
+  );
+}
+
+function buildOmdbDecision(
+  existing: ExistingTmdbWorkRow | null,
+  imdbId: string | null | undefined,
+): OmdbDecision {
+  const omdbFetchedAt = new Date().toISOString();
+
+  if (imdbId === null) {
+    return shouldKeepExistingNullOmdbState(existing)
+      ? { type: "skip" }
+      : { type: "clear", omdbFetchedAt };
+  }
+
+  if (!imdbId || shouldSkipOmdbRefresh(existing, imdbId)) {
+    return { type: "skip" };
+  }
+
+  return { type: "fetch", imdbId, omdbFetchedAt };
+}
+
+export async function buildOmdbFields(
+  imdbId: string | null | undefined,
+  existing: ExistingTmdbWorkRow | null,
+): Promise<OmdbFields> {
+  const decision = buildOmdbDecision(existing, imdbId);
+
+  switch (decision.type) {
+    case "skip":
+      return {};
+    case "clear":
+      return buildClearedOmdbFields(decision.omdbFetchedAt);
+    case "fetch":
+      try {
+        const omdb = await fetchOmdbWorkDetails(decision.imdbId);
+        return toOmdbFields(omdb, decision.omdbFetchedAt);
+      } catch {
+        return {};
+      }
+  }
+}
+
+export function buildOmdbRatings(omdbFields: OmdbFields): RatingInfo {
+  return {
+    imdbRating: "imdb_rating" in omdbFields ? (omdbFields.imdb_rating ?? null) : null,
+    rottenTomatoesScore:
+      "rotten_tomatoes_score" in omdbFields ? (omdbFields.rotten_tomatoes_score ?? null) : null,
+  };
+}

--- a/src/features/backlog/tmdb-search-results.ts
+++ b/src/features/backlog/tmdb-search-results.ts
@@ -109,11 +109,30 @@ function shuffleArray<T>(items: T[]) {
   const shuffled = [...items];
 
   for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const randomIndex = Math.floor(Math.random() * (index + 1));
+    const randomIndex = getSecureRandomInt(index + 1);
     [shuffled[index], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[index]];
   }
 
   return shuffled;
+}
+
+function getSecureRandomInt(maxExclusive: number) {
+  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
+    throw new RangeError("maxExclusive must be a positive integer");
+  }
+
+  const maxUint32 = 0x100000000;
+  const upperBound = maxUint32 - (maxUint32 % maxExclusive);
+  const randomBuffer = new Uint32Array(1);
+
+  while (true) {
+    globalThis.crypto.getRandomValues(randomBuffer);
+    const value = randomBuffer[0] ?? 0;
+
+    if (value < upperBound) {
+      return value % maxExclusive;
+    }
+  }
 }
 
 export function buildRecommendationSourceItems(items: BacklogItem[]) {

--- a/src/features/backlog/tmdb-search-results.ts
+++ b/src/features/backlog/tmdb-search-results.ts
@@ -1,0 +1,153 @@
+import type { TmdbSearchResult } from "../../lib/tmdb.ts";
+import { getStackedSeasonNumbers } from "./tmdb-search-state.ts";
+import type { BacklogItem } from "./types.ts";
+
+const MAX_RECOMMENDATION_SOURCE_ITEMS = 8;
+
+function isStackedMovieMatch(items: BacklogItem[], result: TmdbSearchResult) {
+  return items.some((item) => {
+    const work = item.works;
+    return (
+      item.status === "stacked" &&
+      work?.tmdb_id === result.tmdbId &&
+      work.tmdb_media_type === result.tmdbMediaType &&
+      work.work_type === result.workType
+    );
+  });
+}
+
+function findStackedSeriesItem(items: BacklogItem[], result: TmdbSearchResult) {
+  return items.find((item) => {
+    const work = item.works;
+    return (
+      item.status === "stacked" &&
+      work?.tmdb_id === result.tmdbId &&
+      work.tmdb_media_type === result.tmdbMediaType &&
+      work.work_type === "series"
+    );
+  });
+}
+
+function isAllSeasonsStacked(items: BacklogItem[], result: TmdbSearchResult, seasonCount: number) {
+  const stackedSeasonNumbers = new Set(
+    getStackedSeasonNumbers(
+      items,
+      result,
+      Array.from({ length: Math.max(seasonCount - 1, 0) }, (_, index) => index + 2),
+    ),
+  );
+
+  for (let seasonNumber = 2; seasonNumber <= seasonCount; seasonNumber += 1) {
+    if (!stackedSeasonNumbers.has(seasonNumber)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isHiddenSearchResult(items: BacklogItem[], result: TmdbSearchResult) {
+  if (result.tmdbMediaType === "movie" && result.workType === "movie") {
+    return isStackedMovieMatch(items, result);
+  }
+
+  if (result.tmdbMediaType !== "tv" || result.workType !== "series") {
+    return false;
+  }
+
+  const stackedSeriesItem = findStackedSeriesItem(items, result);
+  const seasonCount = stackedSeriesItem?.works?.season_count;
+  if (!seasonCount) return false;
+
+  return isAllSeasonsStacked(items, result, seasonCount);
+}
+
+export function filterVisibleResults(items: BacklogItem[], results: TmdbSearchResult[]) {
+  return results.filter((result) => !isHiddenSearchResult(items, result));
+}
+
+function getLocalizationScore(result: TmdbSearchResult) {
+  let score = 0;
+
+  if (result.title.trim() !== result.originalTitle?.trim()) {
+    score += 2;
+  }
+
+  if (result.overview?.trim()) {
+    score += 1;
+  }
+
+  return score;
+}
+
+export function prioritizeLocalizedResults(results: TmdbSearchResult[]) {
+  return results
+    .map((result, index) => ({ result, index }))
+    .sort((left, right) => {
+      const scoreDiff = getLocalizationScore(right.result) - getLocalizationScore(left.result);
+      return scoreDiff === 0 ? left.index - right.index : scoreDiff;
+    })
+    .map(({ result }) => result);
+}
+
+export function resolveSearchMessage(
+  results: TmdbSearchResult[],
+  visibleResults: TmdbSearchResult[],
+) {
+  if (visibleResults.length > 0) {
+    return null;
+  }
+
+  if (results.length > 0) {
+    return "すでにストック済みの作品は候補から除外しています。";
+  }
+
+  return "候補が見つかりませんでした。このまま入力して追加できます。";
+}
+
+function shuffleArray<T>(items: T[]) {
+  const shuffled = [...items];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[randomIndex]] = [shuffled[randomIndex], shuffled[index]];
+  }
+
+  return shuffled;
+}
+
+export function buildRecommendationSourceItems(items: BacklogItem[]) {
+  const recommendationCandidates = items.filter(
+    (item) =>
+      (item.status === "watched" || item.status === "watching") &&
+      item.works?.tmdb_id != null &&
+      item.works?.source_type === "tmdb" &&
+      item.works?.work_type !== "season",
+  );
+
+  return [
+    ...shuffleArray(recommendationCandidates.filter((item) => item.status === "watched")),
+    ...shuffleArray(recommendationCandidates.filter((item) => item.status === "watching")),
+  ]
+    .slice(0, MAX_RECOMMENDATION_SOURCE_ITEMS)
+    .map((item) => ({
+      tmdbId: item.works!.tmdb_id!,
+      tmdbMediaType: item.works!.tmdb_media_type as "movie" | "tv",
+    }));
+}
+
+export function filterVisibleRecommendations(items: BacklogItem[], results: TmdbSearchResult[]) {
+  const itemTmdbKeys = new Set(
+    items
+      .filter((item) => item.works?.tmdb_id && item.works?.tmdb_media_type)
+      .map((item) => `${item.works!.tmdb_media_type}-${item.works!.tmdb_id}`),
+  );
+
+  return prioritizeLocalizedResults(
+    filterVisibleResults(items, results).filter(
+      (result) =>
+        !itemTmdbKeys.has(`${result.tmdbMediaType}-${result.tmdbId}`) &&
+        (result.workType === "series" || result.hasJapaneseRelease),
+    ),
+  );
+}

--- a/src/features/backlog/tmdb-search-results.ts
+++ b/src/features/backlog/tmdb-search-results.ts
@@ -1,4 +1,5 @@
 import type { TmdbSearchResult } from "../../lib/tmdb.ts";
+import { getSecureRandomInt } from "../../lib/random.ts";
 import { getStackedSeasonNumbers } from "./tmdb-search-state.ts";
 import type { BacklogItem } from "./types.ts";
 
@@ -114,25 +115,6 @@ function shuffleArray<T>(items: T[]) {
   }
 
   return shuffled;
-}
-
-function getSecureRandomInt(maxExclusive: number) {
-  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
-    throw new RangeError("maxExclusive must be a positive integer");
-  }
-
-  const maxUint32 = 0x100000000;
-  const upperBound = maxUint32 - (maxUint32 % maxExclusive);
-  const randomBuffer = new Uint32Array(1);
-
-  while (true) {
-    globalThis.crypto.getRandomValues(randomBuffer);
-    const value = randomBuffer[0] ?? 0;
-
-    if (value < upperBound) {
-      return value % maxExclusive;
-    }
-  }
 }
 
 export function buildRecommendationSourceItems(items: BacklogItem[]) {

--- a/src/features/backlog/work-repository.ts
+++ b/src/features/backlog/work-repository.ts
@@ -9,6 +9,12 @@ import {
 } from "../../lib/tmdb.ts";
 import { fetchOmdbWorkDetails } from "../../lib/omdb.ts";
 import { buildSearchText } from "./helpers.ts";
+import {
+  buildOmdbFields,
+  buildOmdbRatings,
+  type ExistingTmdbWorkRow,
+  type OmdbFields,
+} from "./omdb-work-fields.ts";
 import type { WorkType } from "./types.ts";
 import { buildTmdbWorkUpdate, calcBackgroundFitScore, type RatingInfo } from "./work-metadata.ts";
 import {
@@ -27,18 +33,10 @@ export {
   shouldRefreshTmdbWork,
 } from "./work-repository-helpers.ts";
 
-type ExistingTmdbWorkRow = {
-  id: string;
-  last_tmdb_synced_at: string | null;
-  omdb_fetched_at: string | null;
-  imdb_id: string | null;
-  genres: string[];
-};
 type ExistingManualWorkRow = {
   id: string;
 };
 type TmdbWorkDetails = Awaited<ReturnType<typeof fetchTmdbWorkDetails>>;
-type OmdbDetails = Awaited<ReturnType<typeof fetchOmdbWorkDetails>>;
 type TmdbWorkLookup = {
   tmdbMediaType: "movie" | "tv";
   tmdbId: number;
@@ -60,10 +58,6 @@ type TmdbSyncState = {
   shouldRefreshOmdb: boolean;
   shouldSyncTmdbForOmdb: boolean;
 };
-type OmdbDecision =
-  | { type: "skip" }
-  | { type: "clear"; omdbFetchedAt: string }
-  | { type: "fetch"; imdbId: string; omdbFetchedAt: string };
 
 export async function upsertTmdbWork(
   target: TmdbSelectionTarget,
@@ -285,7 +279,7 @@ async function upsertFetchedTmdbWork(
   }
 
   const details = await fetchTmdbWorkDetails(target);
-  const omdbFields = await buildOmdbFields(details, existing);
+  const omdbFields = await buildOmdbFields(details.imdbId, existing);
 
   if (existing) {
     return updateFetchedTmdbWork(existing.id, details, omdbFields, options.parentWorkId);
@@ -391,94 +385,6 @@ async function refreshExistingOmdbFields(
   } catch {
     // OMDb 更新の失敗は TMDb の early return をブロックしない
   }
-}
-
-type OmdbFields = {
-  rotten_tomatoes_score?: number | null;
-  imdb_rating?: number | null;
-  imdb_votes?: number | null;
-  metacritic_score?: number | null;
-  omdb_fetched_at?: string;
-};
-
-function buildClearedOmdbFields(omdbFetchedAt: string): OmdbFields {
-  return {
-    rotten_tomatoes_score: null,
-    imdb_rating: null,
-    imdb_votes: null,
-    metacritic_score: null,
-    omdb_fetched_at: omdbFetchedAt,
-  };
-}
-
-function toOmdbFields(omdb: OmdbDetails, omdbFetchedAt: string): OmdbFields {
-  return {
-    rotten_tomatoes_score: omdb.rottenTomatoesScore,
-    imdb_rating: omdb.imdbRating,
-    imdb_votes: omdb.imdbVotes,
-    metacritic_score: omdb.metacriticScore,
-    omdb_fetched_at: omdbFetchedAt,
-  };
-}
-
-function buildOmdbDecision(
-  existing: ExistingTmdbWorkRow | null,
-  imdbId: TmdbWorkDetails["imdbId"],
-): OmdbDecision {
-  const omdbFetchedAt = new Date().toISOString();
-
-  if (imdbId === null) {
-    return shouldKeepExistingNullOmdbState(existing)
-      ? { type: "skip" }
-      : { type: "clear", omdbFetchedAt };
-  }
-
-  if (!imdbId || shouldSkipOmdbRefresh(existing, imdbId)) {
-    return { type: "skip" };
-  }
-
-  return { type: "fetch", imdbId, omdbFetchedAt };
-}
-
-async function buildOmdbFields(
-  details: TmdbWorkDetails,
-  existing: ExistingTmdbWorkRow | null,
-): Promise<OmdbFields> {
-  const decision = buildOmdbDecision(existing, details.imdbId);
-
-  switch (decision.type) {
-    case "skip":
-      return {};
-    case "clear":
-      return buildClearedOmdbFields(decision.omdbFetchedAt);
-    case "fetch":
-      try {
-        const omdb = await fetchOmdbWorkDetails(decision.imdbId);
-        return toOmdbFields(omdb, decision.omdbFetchedAt);
-      } catch {
-        return {};
-      }
-  }
-}
-
-function shouldKeepExistingNullOmdbState(existing: ExistingTmdbWorkRow | null) {
-  return Boolean(
-    existing && !shouldRefreshOmdbWork(existing.omdb_fetched_at) && existing.imdb_id === null,
-  );
-}
-
-function shouldSkipOmdbRefresh(existing: ExistingTmdbWorkRow | null, imdbId: string) {
-  return Boolean(
-    existing && !shouldRefreshOmdbWork(existing.omdb_fetched_at) && existing.imdb_id === imdbId,
-  );
-}
-
-function buildOmdbRatings(omdbFields: OmdbFields): RatingInfo {
-  return {
-    imdbRating: "imdb_rating" in omdbFields ? (omdbFields.imdb_rating ?? null) : null,
-    rottenTomatoesScore:
-      "rotten_tomatoes_score" in omdbFields ? (omdbFields.rotten_tomatoes_score ?? null) : null,
-  };
 }
 
 function buildTmdbUpdatePayload(

--- a/src/lib/random.ts
+++ b/src/lib/random.ts
@@ -1,0 +1,18 @@
+export function getSecureRandomInt(maxExclusive: number) {
+  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
+    throw new RangeError("maxExclusive must be a positive integer");
+  }
+
+  const maxUint32 = 0x100000000;
+  const upperBound = maxUint32 - (maxUint32 % maxExclusive);
+  const randomBuffer = new Uint32Array(1);
+
+  while (true) {
+    globalThis.crypto.getRandomValues(randomBuffer);
+    const value = randomBuffer[0] ?? 0;
+
+    if (value < upperBound) {
+      return value % maxExclusive;
+    }
+  }
+}

--- a/src/lib/tmdb-recommendation-cache.ts
+++ b/src/lib/tmdb-recommendation-cache.ts
@@ -1,4 +1,5 @@
 import type { TmdbSearchResult } from "./tmdb.ts";
+import { getSecureRandomInt } from "./random.ts";
 
 const RECOMMENDATIONS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -172,23 +173,4 @@ function shuffleResults(results: TmdbSearchResult[]) {
   }
 
   return shuffled;
-}
-
-function getSecureRandomInt(maxExclusive: number) {
-  if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
-    throw new RangeError("maxExclusive must be a positive integer");
-  }
-
-  const maxUint32 = 0x100000000;
-  const upperBound = maxUint32 - (maxUint32 % maxExclusive);
-  const randomBuffer = new Uint32Array(1);
-
-  while (true) {
-    globalThis.crypto.getRandomValues(randomBuffer);
-    const value = randomBuffer[0] ?? 0;
-
-    if (value < upperBound) {
-      return value % maxExclusive;
-    }
-  }
 }


### PR DESCRIPTION
## 関連 Issue

Refs #307

## 変更内容

- `useTmdbSearchRequest.ts` の純粋ヘルパー 8 個を `tmdb-search-results.ts` に抽出
- `isHiddenSearchResult` を 3 つのヘルパー（`isStackedMovieMatch` / `findStackedSeriesItem` / `isAllSeasonsStacked`）に分解して可読性向上
- `backlog-item-utils.ts` の型ガード 10 個を `backlog-item-validators.ts` に抽出
- `work-repository.ts` の OMDB フィールド構築ロジックを `omdb-work-fields.ts` に抽出
- 振る舞いは不変。既存テスト 389 件 pass、`vp run knip` / `vp run build:analyze` も pass を確認

## 対応した項目（Issue #307 の構造改善より）

- 長大ファイル: `work-repository.ts` (511 → 417 行) / `useTmdbSearchRequest.ts` (276 → 146 行) / `backlog-item-utils.ts` (274 → 205 行)
- 複雑度: `useTmdbSearchRequest.ts` / `backlog-item-utils.ts` / `work-repository.ts` をファイル分割で削減

## 見送った項目

- 「すぐ直す」5 件は既に main で解消済み（PR #314）と確認したため対象外
- 構造改善のテストファイル系（`AddModal.test.tsx`, `useBacklogActions.test.tsx` など）は今回スコープ外